### PR TITLE
Support separate deployment by specifying -p pro1 in docker compose up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,3 @@ volumes:
 networks:
   claude-relay-network:
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
   # 🚀 Claude Relay Service
   claude-relay:
     build: .
-    container_name: claude-relay-service
     restart: unless-stopped
     ports:
       - "${PORT:-3000}:3000"
@@ -83,7 +82,6 @@ services:
   # 📊 Redis Database
   redis:
     image: redis:7-alpine
-    container_name: claude-relay-redis
     restart: unless-stopped
     ports:
       - "${REDIS_PORT:-6379}:6379"
@@ -101,7 +99,6 @@ services:
   # 📈 Redis Monitoring (Optional)
   redis-commander:
     image: rediscommander/redis-commander:latest
-    container_name: claude-relay-redis-web
     restart: unless-stopped
     ports:
       - "${REDIS_WEB_PORT:-8081}:8081"
@@ -117,7 +114,6 @@ services:
   # 📊 Application Monitoring (Optional)
   prometheus:
     image: prom/prometheus:latest
-    container_name: claude-relay-prometheus
     restart: unless-stopped
     ports:
       - "${PROMETHEUS_PORT:-9090}:9090"
@@ -138,7 +134,6 @@ services:
   # 📈 Grafana Dashboard (Optional)
   grafana:
     image: grafana/grafana:latest
-    container_name: claude-relay-grafana
     restart: unless-stopped
     ports:
       - "${GRAFANA_PORT:-3001}:3000"


### PR DESCRIPTION
Now you can use docker compose -p proj2 up -d to deploy another service