### PR TITLE
feat: add pre-built Docker image reference

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
   # 🚀 Claude Relay Service
   claude-relay:
     build: .
+    image: weishaw/claude-relay-service:latest
     restart: unless-stopped
     ports:
       - "${PORT:-3000}:3000"


### PR DESCRIPTION
Add image reference to weishaw/claude-relay-service:latest in docker-compose.yml to enable using pre-built images instead of always building from source.

🤖 Generated with [Claude Code](https://claude.ai/code)