### PR TITLE
feat: add Setup Token OAuth flow for simplified Claude account setup

### DIFF
--- a/web/admin-spa/src/stores/accounts.js
+++ b/web/admin-spa/src/stores/accounts.js
@@ -398,6 +398,42 @@ export const useAccountsStore = defineStore('accounts', () => {
     }
   }
 
+  // 生成Claude Setup Token URL
+  const generateClaudeSetupTokenUrl = async (proxyConfig) => {
+    try {
+      const response = await apiClient.post(
+        '/admin/claude-accounts/generate-setup-token-url',
+        proxyConfig
+      )
+      if (response.success) {
+        return response.data // 返回整个对象，包含authUrl和sessionId
+      } else {
+        throw new Error(response.message || '生成Setup Token URL失败')
+      }
+    } catch (err) {
+      error.value = err.message
+      throw err
+    }
+  }
+
+  // 交换Claude Setup Token Code
+  const exchangeClaudeSetupTokenCode = async (data) => {
+    try {
+      const response = await apiClient.post(
+        '/admin/claude-accounts/exchange-setup-token-code',
+        data
+      )
+      if (response.success) {
+        return response.data
+      } else {
+        throw new Error(response.message || '交换Setup Token授权码失败')
+      }
+    } catch (err) {
+      error.value = err.message
+      throw err
+    }
+  }
+
   // 生成Gemini OAuth URL
   const generateGeminiAuthUrl = async (proxyConfig) => {
     try {
@@ -480,6 +516,8 @@ export const useAccountsStore = defineStore('accounts', () => {
     refreshClaudeToken,
     generateClaudeAuthUrl,
     exchangeClaudeCode,
+    generateClaudeSetupTokenUrl,
+    exchangeClaudeSetupTokenCode,
     generateGeminiAuthUrl,
     exchangeGeminiCode,
     sortAccounts,


### PR DESCRIPTION
Introduces a streamlined Setup Token authentication method that reduces the required OAuth scopes from 'org:create_api_key user:profile user:inference' to just 'user:inference', simplifying the account setup process for users who only need inference capabilities.

Key changes:
- Add Setup Token authorization endpoints in admin routes
- Implement Setup Token OAuth flow with PKCE support in oauthHelper
- Update AccountForm to support Setup Token as the default auth method
- Add automatic authorization code extraction from callback URLs
- Maintain full proxy configuration support for Setup Token flow
- Preserve existing OAuth flow for advanced users requiring API key creation

🤖 Generated with [Claude Code](https://claude.ai/code)