### PR TITLE
fix: 改进会话粘性机制，支持metadata.user_id并修复cache_control导致的会话切换问题

### DIFF
--- a/src/utils/sessionHelper.js
+++ b/src/utils/sessionHelper.js
@@ -13,11 +13,22 @@ class SessionHelper {
       return null
     }
 
+    // 1. 优先提取metadata.user_id
+    if (requestBody.metadata && requestBody.metadata.user_id) {
+      const hash = crypto
+        .createHash('sha256')
+        .update(requestBody.metadata.user_id)
+        .digest('hex')
+        .substring(0, 32)
+      logger.debug(`📋 Session hash generated from metadata.user_id: ${hash}`)
+      return hash
+    }
+
     let cacheableContent = ''
     const system = requestBody.system || ''
     const messages = requestBody.messages || []
 
-    // 1. 优先提取带有cache_control: {"type": "ephemeral"}的内容
+    // 2. 提取带有cache_control: {"type": "ephemeral"}的内容
     // 检查system中的cacheable内容
     if (Array.isArray(system)) {
       for (const part of system) {
@@ -30,13 +41,13 @@ class SessionHelper {
     // 检查messages中的cacheable内容
     for (const msg of messages) {
       const content = msg.content || ''
+      let hasCacheControl = false
+
       if (Array.isArray(content)) {
         for (const part of content) {
           if (part && part.cache_control && part.cache_control.type === 'ephemeral') {
-            if (part.type === 'text') {
-              cacheableContent += part.text || ''
-            }
-            // 其他类型（如image）不参与hash计算
+            hasCacheControl = true
+            break
           }
         }
       } else if (
@@ -44,12 +55,31 @@ class SessionHelper {
         msg.cache_control &&
         msg.cache_control.type === 'ephemeral'
       ) {
-        // 罕见情况，但需要检查
-        cacheableContent += content
+        hasCacheControl = true
+      }
+
+      if (hasCacheControl) {
+        for (const message of messages) {
+          let messageText = ''
+          if (typeof message.content === 'string') {
+            messageText = message.content
+          } else if (Array.isArray(message.content)) {
+            messageText = message.content
+              .filter((part) => part.type === 'text')
+              .map((part) => part.text || '')
+              .join('')
+          }
+
+          if (messageText) {
+            cacheableContent += messageText
+            break
+          }
+        }
+        break
       }
     }
 
-    // 2. 如果有cacheable内容，直接使用
+    // 3. 如果有cacheable内容，直接使用
     if (cacheableContent) {
       const hash = crypto
         .createHash('sha256')
@@ -60,7 +90,7 @@ class SessionHelper {
       return hash
     }
 
-    // 3. Fallback: 使用system内容
+    // 4. Fallback: 使用system内容
     if (system) {
       let systemText = ''
       if (typeof system === 'string') {
@@ -76,7 +106,7 @@ class SessionHelper {
       }
     }
 
-    // 4. 最后fallback: 使用第一条消息内容
+    // 5. 最后fallback: 使用第一条消息内容
     if (messages.length > 0) {
       const firstMessage = messages[0]
       let firstMessageText = ''


### PR DESCRIPTION
## 问题描述

在使用 Anthropic Prompt Caching 功能时，当用户消息中包含 `cache_control: {"type": "ephemeral"}` 标记时，会导致会话粘性机制失效。

**根本原因**：原有逻辑会提取所有带 `cache_control` 的内容生成会话哈希，包括动态变化的用户消息。按照 Anthropic 官方文档示例，最后一条用户消息带有 cache_control 标记，每次对话内容不同导致哈希不同。
[prompt-caching#continuing-a-multi-turn-conversation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#continuing-a-multi-turn-conversation)

**实际影响**：每次用户发送新消息都会切换到不同的 Claude 账户，完全失去会话连续性。

## 解决方案

### 1. 新增 metadata.user_id 支持
允许客户端显式控制会话标识：

```javascript
{
  "metadata": {"user_id": "user_4fc160aac4184d5acb27468a84f7f4f1317e4357b9bb64d9f89959ab70d1fdcf_account__session_435395a4-cecb-4661-b9ec-c38edb6ec9c5"},
  "messages": [...]
}
```

### 2. 优化 messages 中 cache_control 处理逻辑
当检测到 messages 中存在 `cache_control` 时：
- 原逻辑：使用缓存断点的具体内容（动态变化）
- 新逻辑：使用第一条包含文字的消息（相对稳定）

### 3. 新的哈希生成优先级
```
1. metadata.user_id（显式会话ID）
2. system 中的 cache_control 内容 + 检测到 messages 有 cache_control → 使用第一条包含文字的消息
3. 完整 system 内容（fallback）
4. 第一条消息内容（最后 fallback）
```

## 技术实现

**修改文件**：`src/utils/sessionHelper.js`

**核心变更**：
1. 在 `generateSessionHash()` 方法开头添加 `metadata.user_id` 检查
2. 重构 messages 中 `cache_control` 检测逻辑，循环查找第一条包含文字的消息
3. 保持所有现有功能的向后兼容性

**代码统计**：+40 行，-10 行

## 测试验证

### 示例场景修复
```javascript
// 相同 system，不同的最后消息 cache_control
const req1 = {
  system: [{text: "Knowledge base", cache_control: {type: "ephemeral"}}],
  messages: [
    {content: "First message"},
    {content: [{text: "Different cache content A", cache_control: {type: "ephemeral"}}]}
  ]
}

const req2 = {
  system: [{text: "Knowledge base", cache_control: {type: "ephemeral"}}],
  messages: [
    {content: "First message"},  // 相同的第一条消息  
    {content: "Response..."},
    {content: [{text: "Different cache content B", cache_control: {type: "ephemeral"}}]}
  ]
}

// 结果：生成相同哈希，会话保持
```

### 边缘情况处理
- 第一条消息只包含图片：正确跳过，使用下一条包含文字的消息
- 所有消息都没有文字：回退到其他哈希策略
- metadata.user_id 存在时：优先使用，忽略所有其他内容变化

## 影响评估

**正面影响**：
- 修复 prompt caching 导致的会话切换问题
- 减少不必要的账户切换，提高 cache 命中率
- 对话连续性得到保障，上下文不会丢失
- 现有客户端无需任何修改即可受益

**预期改进**：
- 会话切换频率显著降低（特别是使用 prompt caching 的场景）
- Claude 账户负载更均匀
- 用户对话体验改善

## 变更类型
- [x] Bug 修复
- [x] 功能改进
- [ ] 破坏性变更

## 检查清单
- [x] 代码已通过本地测试
- [x] 保持向后兼容性
- [x] 提交信息清晰描述了变更内容