### PR TITLE
feat: 添加Claude账户403错误处理和封禁状态支持

### DIFF
--- a/src/services/claudeRelayService.js
+++ b/src/services/claudeRelayService.js
@@ -198,6 +198,13 @@ class ClaudeRelayService {
             )
           }
         }
+        // 检查是否为403状态码（禁止访问）
+        else if (response.statusCode === 403) {
+          logger.error(
+            `🚫 Forbidden error (403) detected for account ${accountId}, marking as blocked`
+          )
+          await unifiedClaudeScheduler.markAccountBlocked(accountId, accountType, sessionHash)
+        }
         // 检查是否为5xx状态码
         else if (response.statusCode >= 500 && response.statusCode < 600) {
           logger.warn(`🔥 Server error (${response.statusCode}) detected for account ${accountId}`)
@@ -953,8 +960,32 @@ class ClaudeRelayService {
         if (res.statusCode !== 200) {
           // 将错误处理逻辑封装在一个异步函数中
           const handleErrorResponse = async () => {
-            // 增加对5xx错误的处理
-            if (res.statusCode >= 500 && res.statusCode < 600) {
+            if (res.statusCode === 401) {
+              logger.warn(`🔐 [Stream] Unauthorized error (401) detected for account ${accountId}`)
+
+              await this.recordUnauthorizedError(accountId)
+
+              const errorCount = await this.getUnauthorizedErrorCount(accountId)
+              logger.info(
+                `🔐 [Stream] Account ${accountId} has ${errorCount} consecutive 401 errors in the last 5 minutes`
+              )
+
+              if (errorCount >= 1) {
+                logger.error(
+                  `❌ [Stream] Account ${accountId} encountered 401 error (${errorCount} errors), marking as unauthorized`
+                )
+                await unifiedClaudeScheduler.markAccountUnauthorized(
+                  accountId,
+                  accountType,
+                  sessionHash
+                )
+              }
+            } else if (res.statusCode === 403) {
+              logger.error(
+                `🚫 [Stream] Forbidden error (403) detected for account ${accountId}, marking as blocked`
+              )
+              await unifiedClaudeScheduler.markAccountBlocked(accountId, accountType, sessionHash)
+            } else if (res.statusCode >= 500 && res.statusCode < 600) {
               logger.warn(
                 `🔥 [Stream] Server error (${res.statusCode}) detected for account ${accountId}`
               )

--- a/src/services/unifiedClaudeScheduler.js
+++ b/src/services/unifiedClaudeScheduler.js
@@ -636,6 +636,32 @@ class UnifiedClaudeScheduler {
     }
   }
 
+  // 🚫 标记账户为被封锁状态（403错误）
+  async markAccountBlocked(accountId, accountType, sessionHash = null) {
+    try {
+      // 只处理claude-official类型的账户，不处理claude-console和gemini
+      if (accountType === 'claude-official') {
+        await claudeAccountService.markAccountBlocked(accountId, sessionHash)
+
+        // 删除会话映射
+        if (sessionHash) {
+          await this._deleteSessionMapping(sessionHash)
+        }
+
+        logger.warn(`🚫 Account ${accountId} marked as blocked due to 403 error`)
+      } else {
+        logger.info(
+          `ℹ️ Skipping blocked marking for non-Claude OAuth account: ${accountId} (${accountType})`
+        )
+      }
+
+      return { success: true }
+    } catch (error) {
+      logger.error(`❌ Failed to mark account as blocked: ${accountId} (${accountType})`, error)
+      throw error
+    }
+  }
+
   // 🚫 标记Claude Console账户为封锁状态（模型不支持）
   async blockConsoleAccount(accountId, reason) {
     try {

--- a/src/utils/webhookNotifier.js
+++ b/src/utils/webhookNotifier.js
@@ -68,6 +68,7 @@ class WebhookNotifier {
     const errorCodes = {
       'claude-oauth': {
         unauthorized: 'CLAUDE_OAUTH_UNAUTHORIZED',
+        blocked: 'CLAUDE_OAUTH_BLOCKED',
         error: 'CLAUDE_OAUTH_ERROR',
         disabled: 'CLAUDE_OAUTH_MANUALLY_DISABLED'
       },


### PR DESCRIPTION
## 问题描述

当前系统只处理401认证错误，缺少对403禁止访问错误的处理机制。当Claude账户被官方封禁时，系统无法正确识别并停止使用该账户，导致持续的错误请求。

## 解决方案

实现Claude账户403错误自动检测和处理机制，区分401未授权和403账户封禁两种错误状态，为不同类型的错误提供相应的处理策略。

## 主要变更

### 核心功能
- **错误检测覆盖**: 在非流式和流式请求中检测401/403状态码并进行相应处理
- **403错误处理**: 检测到403状态码时立即标记Claude账户为封禁状态
- **401错误处理**: 检测到401状态码时记录错误计数后标记为未授权状态
- **状态区分**: 401错误对应`unauthorized`状态，403错误对应`blocked`状态
- **前端支持**: 利用现有前端显示逻辑，封禁账户显示橙色"已封锁"状态

### 代码优化
- **方法合并**: 创建通用的`markAccountError`方法，消除`markAccountBlocked`和`markAccountUnauthorized`的重复代码
- **配置化**: 通过配置对象统一管理不同错误类型的处理参数
- **向后兼容**: 保留现有API接口，确保调用方无需修改

### 错误处理策略
- **401错误**: 在非流式和流式请求中记录错误计数后标记为`unauthorized`状态
- **403错误**: 在非流式和流式请求中立即标记为`blocked`状态，无需计数
- **统一处理**: 流式和非流式请求采用相同的错误处理逻辑和状态管理
- **Webhook通知**: 新增`CLAUDE_OAUTH_BLOCKED`错误码用于403错误区分

## 技术细节

### 修改文件
- `src/services/claudeAccountService.js`: 新增通用错误处理方法和代码优化
- `src/services/claudeRelayService.js`: 在非流式和流式请求中添加401/403错误检测逻辑  
- `src/services/unifiedClaudeScheduler.js`: 添加封禁状态处理方法
- `src/utils/webhookNotifier.js`: 扩展错误码映射

### 数据字段
- 新增`blockedAt`时间戳字段记录封禁时间
- 更新`resetAccountStatus`方法清理封禁状态

## 测试验证

- 通过ESLint代码检查
- 保持现有调用接口兼容性
- 验证错误状态正确设置和清理

## 影响范围

仅影响Claude账户错误处理流程，不影响正常业务逻辑。现有401和403错误将在所有请求类型（流式和非流式）中被正确识别并处理，避免无效的重复请求。通过代码优化减少了重复逻辑，提升了代码可维护性。