### PR TITLE
feat(Claude Console): 添加Claude Console账号每日配额

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -55,6 +55,11 @@ class Application {
       // 📊 初始化缓存监控
       await this.initializeCacheMonitoring()
 
+      // 🔄 初始化Claude Console额度重置调度器
+      logger.info('🔄 Initializing Claude Console quota reset scheduler...')
+      const quotaResetScheduler = require('./services/quotaResetScheduler')
+      await quotaResetScheduler.initialize()
+
       // 🔧 初始化管理员凭据
       logger.info('🔄 Initializing admin credentials...')
       await this.initializeAdmin()

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -2292,7 +2292,9 @@ router.post('/claude-console-accounts', authenticateAdmin, async (req, res) => {
       rateLimitDuration,
       proxy,
       accountType,
-      groupId
+      groupId,
+      dailyQuota,
+      quotaResetTime
     } = req.body
 
     if (!name || !apiUrl || !apiKey) {
@@ -2327,7 +2329,9 @@ router.post('/claude-console-accounts', authenticateAdmin, async (req, res) => {
       rateLimitDuration:
         rateLimitDuration !== undefined && rateLimitDuration !== null ? rateLimitDuration : 60,
       proxy,
-      accountType: accountType || 'shared'
+      accountType: accountType || 'shared',
+      dailyQuota: dailyQuota || 0,
+      quotaResetTime: quotaResetTime || '00:00'
     })
 
     // 如果是分组类型，将账户添加到分组
@@ -2505,6 +2509,56 @@ router.put(
     }
   }
 )
+
+// 获取Claude Console账户的使用统计
+router.get('/claude-console-accounts/:accountId/usage', authenticateAdmin, async (req, res) => {
+  try {
+    const { accountId } = req.params
+    const usageStats = await claudeConsoleAccountService.getAccountUsageStats(accountId)
+
+    if (!usageStats) {
+      return res.status(404).json({ error: 'Account not found' })
+    }
+
+    return res.json(usageStats)
+  } catch (error) {
+    logger.error('❌ Failed to get Claude Console account usage stats:', error)
+    return res.status(500).json({ error: 'Failed to get usage stats', message: error.message })
+  }
+})
+
+// 手动重置Claude Console账户的每日使用量
+router.post(
+  '/claude-console-accounts/:accountId/reset-usage',
+  authenticateAdmin,
+  async (req, res) => {
+    try {
+      const { accountId } = req.params
+      await claudeConsoleAccountService.resetDailyUsage(accountId)
+
+      logger.success(`✅ Admin manually reset daily usage for Claude Console account: ${accountId}`)
+      return res.json({ success: true, message: 'Daily usage reset successfully' })
+    } catch (error) {
+      logger.error('❌ Failed to reset Claude Console account daily usage:', error)
+      return res.status(500).json({ error: 'Failed to reset daily usage', message: error.message })
+    }
+  }
+)
+
+// 手动重置所有Claude Console账户的每日使用量
+router.post('/claude-console-accounts/reset-all-usage', authenticateAdmin, async (req, res) => {
+  try {
+    await claudeConsoleAccountService.resetAllDailyUsage()
+
+    logger.success('✅ Admin manually reset daily usage for all Claude Console accounts')
+    return res.json({ success: true, message: 'All daily usage reset successfully' })
+  } catch (error) {
+    logger.error('❌ Failed to reset all Claude Console accounts daily usage:', error)
+    return res
+      .status(500)
+      .json({ error: 'Failed to reset all daily usage', message: error.message })
+  }
+})
 
 // ☁️ Bedrock 账户管理
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -246,6 +246,14 @@ async function handleMessagesRequest(req, res) {
                   logger.error('❌ Failed to record stream usage:', error)
                 })
 
+              // 检查 Claude Console 账户额度（非阻塞）
+              if (usageAccountId) {
+                const claudeConsoleAccountService = require('../services/claudeConsoleAccountService')
+                claudeConsoleAccountService.checkQuotaUsage(usageAccountId).catch((error) => {
+                  logger.error('❌ Failed to check Claude Console quota:', error)
+                })
+              }
+
               // 更新时间窗口内的token计数和费用
               if (req.rateLimitInfo) {
                 const totalTokens = inputTokens + outputTokens + cacheCreateTokens + cacheReadTokens

--- a/src/services/claudeConsoleRelayService.js
+++ b/src/services/claudeConsoleRelayService.js
@@ -182,6 +182,10 @@ class ClaudeConsoleRelayService {
       } else if (response.status === 429) {
         logger.warn(`🚫 Rate limit detected for Claude Console account ${accountId}`)
         await claudeConsoleAccountService.markAccountRateLimited(accountId)
+        // 检查是否因为超过每日额度
+        await claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
+          logger.error('❌ Failed to check quota after 429 error:', err)
+        })
       } else if (response.status === 529) {
         logger.warn(`🚫 Overload error detected for Claude Console account ${accountId}`)
         await claudeConsoleAccountService.markAccountOverloaded(accountId)
@@ -377,6 +381,10 @@ class ClaudeConsoleRelayService {
               claudeConsoleAccountService.markAccountUnauthorized(accountId)
             } else if (response.status === 429) {
               claudeConsoleAccountService.markAccountRateLimited(accountId)
+              // 检查是否因为超过每日额度
+              claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
+                logger.error('❌ Failed to check quota after 429 error:', err)
+              })
             } else if (response.status === 529) {
               claudeConsoleAccountService.markAccountOverloaded(accountId)
             }
@@ -589,6 +597,10 @@ class ClaudeConsoleRelayService {
               claudeConsoleAccountService.markAccountUnauthorized(accountId)
             } else if (error.response.status === 429) {
               claudeConsoleAccountService.markAccountRateLimited(accountId)
+              // 检查是否因为超过每日额度
+              claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
+                logger.error('❌ Failed to check quota after 429 error:', err)
+              })
             } else if (error.response.status === 529) {
               claudeConsoleAccountService.markAccountOverloaded(accountId)
             }

--- a/src/services/quotaResetScheduler.js
+++ b/src/services/quotaResetScheduler.js
@@ -1,0 +1,158 @@
+const logger = require('../utils/logger')
+const claudeConsoleAccountService = require('./claudeConsoleAccountService')
+const { formatDateWithTimezone } = require('../utils/dateHelper')
+
+class QuotaResetScheduler {
+  constructor() {
+    this.checkIntervalId = null
+    this.isInitialized = false
+    this.checkInterval = 60000 // 每分钟检查一次
+    this.lastResetHour = null
+  }
+
+  // 🚀 初始化定时任务
+  async initialize() {
+    if (this.isInitialized) {
+      logger.warn('⚠️ Quota reset scheduler already initialized')
+      return
+    }
+
+    try {
+      // 启动时立即检查并重置需要重置的账户
+      await this.checkAndResetQuotas()
+
+      // 设置定时检查任务（每分钟检查一次）
+      this.checkIntervalId = setInterval(async () => {
+        try {
+          await this.checkAndResetQuotas()
+        } catch (error) {
+          logger.error('❌ Error in scheduled quota check:', error)
+        }
+      }, this.checkInterval)
+
+      this.isInitialized = true
+      logger.success('✅ Claude Console quota reset scheduler initialized successfully')
+    } catch (error) {
+      logger.error('❌ Failed to initialize quota reset scheduler:', error)
+      // 清理已设置的interval（如果有）
+      if (this.checkIntervalId) {
+        clearInterval(this.checkIntervalId)
+        this.checkIntervalId = null
+      }
+      throw error
+    }
+  }
+
+  // 🔄 检查并重置需要重置的账户额度
+  async checkAndResetQuotas() {
+    try {
+      const now = new Date()
+
+      // 使用 dateHelper 获取系统时区的时间字符串
+      const localTimeStr = formatDateWithTimezone(now, false) // 不包含时区后缀
+      // 格式为 "YYYY-MM-DD HH:mm:ss"，提取时间部分
+      const timeParts = localTimeStr.split(' ')[1].split(':')
+      const currentHour = parseInt(timeParts[0])
+      const currentMinute = parseInt(timeParts[1])
+
+      // 优化：只获取有额度限制的账户
+      const accounts = await claudeConsoleAccountService.getAllAccounts()
+      const accountsWithQuota = accounts.filter(
+        (account) => account.dailyQuota && parseFloat(account.dailyQuota) > 0
+      )
+
+      if (accountsWithQuota.length === 0) {
+        return // 没有需要检查的账户
+      }
+
+      // 日志显示当前检查时间（带时区）
+      const localTimeWithTZ = formatDateWithTimezone(now, true) // 包含时区信息
+      logger.debug(
+        `🔍 Checking quota reset for ${accountsWithQuota.length} accounts at ${localTimeWithTZ}`
+      )
+
+      for (const account of accountsWithQuota) {
+        // 获取账户的重置时间（默认00:00）
+        const resetTime = account.quotaResetTime || '00:00'
+        const [resetHour, resetMinute] = resetTime.split(':').map((n) => parseInt(n))
+
+        // 检查是否到了重置时间
+        if (currentHour === resetHour && currentMinute === resetMinute) {
+          // 避免在同一分钟内重复重置
+          const today = now.toISOString().split('T')[0]
+          if (account.lastResetDate !== today) {
+            await claudeConsoleAccountService.resetDailyUsage(account.id)
+            logger.info(
+              `🔄 Reset quota for account: ${account.name} (${account.id}) at ${localTimeWithTZ}`
+            )
+          }
+        }
+      }
+    } catch (error) {
+      logger.error('❌ Failed to check and reset quotas:', error)
+    }
+  }
+
+  // 🛑 停止定时任务
+  stop() {
+    if (this.checkIntervalId) {
+      clearInterval(this.checkIntervalId)
+      this.checkIntervalId = null
+      this.isInitialized = false
+      logger.info('🛑 Claude Console quota reset scheduler stopped')
+    }
+  }
+
+  // 🔄 重新加载定时任务
+  async reload() {
+    logger.info('🔄 Reloading quota reset scheduler...')
+
+    // 停止现有任务
+    this.stop()
+
+    // 重新初始化
+    await this.initialize()
+  }
+
+  // 📊 获取调度器状态
+  getStatus() {
+    return {
+      isRunning: this.isInitialized,
+      checkInterval: this.checkInterval,
+      nextCheckIn: this.checkIntervalId ? 'Active' : 'Stopped'
+    }
+  }
+
+  // 🔧 手动触发所有账户的额度重置
+  async manualResetAll() {
+    logger.info('🔧 Manual quota reset triggered for all Claude Console accounts')
+
+    try {
+      await claudeConsoleAccountService.resetAllDailyUsage()
+      logger.success('✅ Manual quota reset completed')
+      return { success: true, message: 'All Claude Console quotas reset successfully' }
+    } catch (error) {
+      logger.error('❌ Manual quota reset failed:', error)
+      return { success: false, error: error.message }
+    }
+  }
+
+  // 🔧 手动触发单个账户的额度重置
+  async manualResetAccount(accountId) {
+    logger.info(`🔧 Manual quota reset triggered for account: ${accountId}`)
+
+    try {
+      await claudeConsoleAccountService.resetDailyUsage(accountId)
+      logger.success(`✅ Manual quota reset completed for account: ${accountId}`)
+      return { success: true, message: `Quota reset successfully for account: ${accountId}` }
+    } catch (error) {
+      logger.error(`❌ Manual quota reset failed for account ${accountId}:`, error)
+      return { success: false, error: error.message }
+    }
+  }
+}
+
+// 创建单例实例
+const quotaResetScheduler = new QuotaResetScheduler()
+
+module.exports = quotaResetScheduler


### PR DESCRIPTION
1. 额度检查优先级更高：即使不启用限流机制，超额仍会禁用账户
2. 状态会被覆盖：quota_exceeded 会覆盖 rate_limited
3. 两种恢复时间：
  - 限流恢复：分钟级（如60分钟）
  - 额度恢复：天级（第二天重置）
4. 独立控制：
  - rateLimitDuration = 0：只管理额度，忽略429
  - rateLimitDuration > 0：同时管理限流和额度