### PR TITLE
fix: 修复会话粘性机制下Pro账户被错误调度用于Opus请求的问题

### DIFF
--- a/src/services/unifiedClaudeScheduler.js
+++ b/src/services/unifiedClaudeScheduler.js
@@ -20,6 +20,77 @@ class UnifiedClaudeScheduler {
     return schedulable !== false && schedulable !== 'false'
   }
 
+  // 🔍 检查账户是否支持请求的模型
+  _isModelSupportedByAccount(account, accountType, requestedModel, context = '') {
+    if (!requestedModel) {
+      return true // 没有指定模型时，默认支持
+    }
+
+    // Claude OAuth 账户的 Opus 模型检查
+    if (accountType === 'claude-official') {
+      if (requestedModel.toLowerCase().includes('opus')) {
+        if (account.subscriptionInfo) {
+          try {
+            const info =
+              typeof account.subscriptionInfo === 'string'
+                ? JSON.parse(account.subscriptionInfo)
+                : account.subscriptionInfo
+
+            // Pro 和 Free 账号不支持 Opus
+            if (info.hasClaudePro === true && info.hasClaudeMax !== true) {
+              logger.info(
+                `🚫 Claude account ${account.name} (Pro) does not support Opus model${context ? ` ${context}` : ''}`
+              )
+              return false
+            }
+            if (info.accountType === 'claude_pro' || info.accountType === 'claude_free') {
+              logger.info(
+                `🚫 Claude account ${account.name} (${info.accountType}) does not support Opus model${context ? ` ${context}` : ''}`
+              )
+              return false
+            }
+          } catch (e) {
+            // 解析失败，假设为旧数据，默认支持（兼容旧数据为 Max）
+            logger.debug(
+              `Account ${account.name} has invalid subscriptionInfo${context ? ` ${context}` : ''}, assuming Max`
+            )
+          }
+        }
+        // 没有订阅信息的账号，默认当作支持（兼容旧数据）
+      }
+    }
+
+    // Claude Console 账户的模型支持检查
+    if (accountType === 'claude-console' && account.supportedModels) {
+      // 兼容旧格式（数组）和新格式（对象）
+      if (Array.isArray(account.supportedModels)) {
+        // 旧格式：数组
+        if (
+          account.supportedModels.length > 0 &&
+          !account.supportedModels.includes(requestedModel)
+        ) {
+          logger.info(
+            `🚫 Claude Console account ${account.name} does not support model ${requestedModel}${context ? ` ${context}` : ''}`
+          )
+          return false
+        }
+      } else if (typeof account.supportedModels === 'object') {
+        // 新格式：映射表
+        if (
+          Object.keys(account.supportedModels).length > 0 &&
+          !claudeConsoleAccountService.isModelSupported(account.supportedModels, requestedModel)
+        ) {
+          logger.info(
+            `🚫 Claude Console account ${account.name} does not support model ${requestedModel}${context ? ` ${context}` : ''}`
+          )
+          return false
+        }
+      }
+    }
+
+    return true
+  }
+
   // 🎯 统一调度Claude账号（官方和Console）
   async selectAccountForApiKey(apiKeyData, sessionHash = null, requestedModel = null) {
     try {
@@ -102,7 +173,8 @@ class UnifiedClaudeScheduler {
           // 验证映射的账户是否仍然可用
           const isAvailable = await this._isAccountAvailable(
             mappedAccount.accountId,
-            mappedAccount.accountType
+            mappedAccount.accountType,
+            requestedModel
           )
           if (isAvailable) {
             logger.info(
@@ -269,33 +341,9 @@ class UnifiedClaudeScheduler {
       ) {
         // 检查是否可调度
 
-        // 检查模型支持（如果请求的是 Opus 模型）
-        if (requestedModel && requestedModel.toLowerCase().includes('opus')) {
-          // 检查账号的订阅信息
-          if (account.subscriptionInfo) {
-            try {
-              const info =
-                typeof account.subscriptionInfo === 'string'
-                  ? JSON.parse(account.subscriptionInfo)
-                  : account.subscriptionInfo
-
-              // Pro 和 Free 账号不支持 Opus
-              if (info.hasClaudePro === true && info.hasClaudeMax !== true) {
-                logger.info(`🚫 Claude account ${account.name} (Pro) does not support Opus model`)
-                continue // Claude Pro 不支持 Opus
-              }
-              if (info.accountType === 'claude_pro' || info.accountType === 'claude_free') {
-                logger.info(
-                  `🚫 Claude account ${account.name} (${info.accountType}) does not support Opus model`
-                )
-                continue // 明确标记为 Pro 或 Free 的账号不支持
-              }
-            } catch (e) {
-              // 解析失败，假设为旧数据，默认支持（兼容旧数据为 Max）
-              logger.debug(`Account ${account.name} has invalid subscriptionInfo, assuming Max`)
-            }
-          }
-          // 没有订阅信息的账号，默认当作支持（兼容旧数据）
+        // 检查模型支持
+        if (!this._isModelSupportedByAccount(account, 'claude-official', requestedModel)) {
+          continue
         }
 
         // 检查是否被限流
@@ -330,32 +378,9 @@ class UnifiedClaudeScheduler {
       ) {
         // 检查是否可调度
 
-        // 检查模型支持（如果有请求的模型）
-        if (requestedModel && account.supportedModels) {
-          // 兼容旧格式（数组）和新格式（对象）
-          if (Array.isArray(account.supportedModels)) {
-            // 旧格式：数组
-            if (
-              account.supportedModels.length > 0 &&
-              !account.supportedModels.includes(requestedModel)
-            ) {
-              logger.info(
-                `🚫 Claude Console account ${account.name} does not support model ${requestedModel}`
-              )
-              continue
-            }
-          } else if (typeof account.supportedModels === 'object') {
-            // 新格式：映射表
-            if (
-              Object.keys(account.supportedModels).length > 0 &&
-              !claudeConsoleAccountService.isModelSupported(account.supportedModels, requestedModel)
-            ) {
-              logger.info(
-                `🚫 Claude Console account ${account.name} does not support model ${requestedModel}`
-              )
-              continue
-            }
-          }
+        // 检查模型支持
+        if (!this._isModelSupportedByAccount(account, 'claude-console', requestedModel)) {
+          continue
         }
 
         // 检查是否被限流
@@ -439,7 +464,7 @@ class UnifiedClaudeScheduler {
   }
 
   // 🔍 检查账户是否可用
-  async _isAccountAvailable(accountId, accountType) {
+  async _isAccountAvailable(accountId, accountType, requestedModel = null) {
     try {
       if (accountType === 'claude-official') {
         const account = await redis.getClaudeAccount(accountId)
@@ -456,6 +481,19 @@ class UnifiedClaudeScheduler {
           logger.info(`🚫 Account ${accountId} is not schedulable`)
           return false
         }
+
+        // 检查模型兼容性
+        if (
+          !this._isModelSupportedByAccount(
+            account,
+            'claude-official',
+            requestedModel,
+            'in session check'
+          )
+        ) {
+          return false
+        }
+
         return !(await claudeAccountService.isAccountRateLimited(accountId))
       } else if (accountType === 'claude-console') {
         const account = await claudeConsoleAccountService.getAccount(accountId)
@@ -475,6 +513,19 @@ class UnifiedClaudeScheduler {
           logger.info(`🚫 Claude Console account ${accountId} is not schedulable`)
           return false
         }
+
+        // 检查模型支持
+        if (
+          !this._isModelSupportedByAccount(
+            account,
+            'claude-console',
+            requestedModel,
+            'in session check'
+          )
+        ) {
+          return false
+        }
+
         // 检查是否被限流
         if (await claudeConsoleAccountService.isAccountRateLimited(accountId)) {
           return false
@@ -693,7 +744,8 @@ class UnifiedClaudeScheduler {
           if (memberIds.includes(mappedAccount.accountId)) {
             const isAvailable = await this._isAccountAvailable(
               mappedAccount.accountId,
-              mappedAccount.accountType
+              mappedAccount.accountType,
+              requestedModel
             )
             if (isAvailable) {
               logger.info(
@@ -756,19 +808,9 @@ class UnifiedClaudeScheduler {
             : account.status === 'active'
 
         if (isActive && status && this._isSchedulable(account.schedulable)) {
-          // 检查模型支持（Console账户）
-          if (
-            accountType === 'claude-console' &&
-            requestedModel &&
-            account.supportedModels &&
-            account.supportedModels.length > 0
-          ) {
-            if (!account.supportedModels.includes(requestedModel)) {
-              logger.info(
-                `🚫 Account ${account.name} in group does not support model ${requestedModel}`
-              )
-              continue
-            }
+          // 检查模型支持
+          if (!this._isModelSupportedByAccount(account, accountType, requestedModel, 'in group')) {
+            continue
           }
 
           // 检查是否被限流


### PR DESCRIPTION
## 问题描述

在当前的会话粘性机制实现中，存在一个严重的调度缺陷：

1. 用户首次请求Sonnet模型时，系统可能分配一个Pro账户并建立会话映射
2. 同一会话后续请求Opus模型时，系统会继续使用该Pro账户
3. 由于Pro账户不支持Opus模型，导致请求失败

根本原因是 `_isAccountAvailable` 方法只检查账户的基本状态（激活、错误、限流等），而没有验证账户是否支持请求的具体模型。

## 解决方案

### 1. 增强账户可用性检查
- 在 `_isAccountAvailable` 方法中添加 `requestedModel` 参数
- 检查账户是否支持请求的模型，不支持则返回false

### 2. 创建统一的模型兼容性检查方法
- 新增 `_isModelSupportedByAccount` 方法，统一处理所有模型兼容性验证
- 支持Claude OAuth账户的订阅类型检查（Pro/Free/Max）
- 支持Claude Console账户的supportedModels配置检查
- 消除了原有的重复代码，提高可维护性

### 3. 更新所有相关调用点
- `selectAccountForApiKey` 中的会话粘性检查
- `selectAccountFromGroup` 中的会话粘性检查
- `_getAllAvailableAccounts` 中的账户筛选逻辑

## 技术细节

### 模型兼容性规则

**Claude OAuth账户：**
- Max账户：支持所有模型包括Opus
- Pro账户：不支持Opus模型
- Free账户：不支持Opus模型
- 无订阅信息的账户：默认视为Max（兼容旧数据）

**Claude Console账户：**
- 根据supportedModels配置判断
- 支持数组格式和对象格式的配置

## 影响范围

- 所有使用会话粘性的Claude API请求
- 账户组调度逻辑
- 不影响现有的其他功能