### PR TITLE
fix: 添加创建Claude账户时缺失的useUnifiedUserAgent字段处理

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1902,7 +1902,8 @@ router.post('/claude-accounts', authenticateAdmin, async (req, res) => {
       priority,
       groupId,
       groupIds,
-      autoStopOnWarning
+      autoStopOnWarning,
+      useUnifiedUserAgent
     } = req.body
 
     if (!name) {
@@ -1942,7 +1943,8 @@ router.post('/claude-accounts', authenticateAdmin, async (req, res) => {
       accountType: accountType || 'shared', // 默认为共享类型
       platform,
       priority: priority || 50, // 默认优先级为50
-      autoStopOnWarning: autoStopOnWarning === true // 默认为false
+      autoStopOnWarning: autoStopOnWarning === true, // 默认为false
+      useUnifiedUserAgent: useUnifiedUserAgent === true // 默认为false
     })
 
     // 如果是分组类型，将账户添加到分组


### PR DESCRIPTION
## 问题描述
在创建Claude账户的API路由中，缺少了对 `useUnifiedUserAgent` 字段的处理，导致该配置无法通过API正确设置。

## 解决方案
- 在 `/admin/claude-accounts` POST 路由中添加 `useUnifiedUserAgent` 参数解构
- 将该参数传递给 `claudeAccountService.createAccount()` 方法
- 默认值为 `false`，与服务层保持一致

## 修改内容
- `src/routes/admin.js`：
  - 第1906行：添加 `useUnifiedUserAgent` 到请求体解构
  - 第1947行：传递 `useUnifiedUserAgent: useUnifiedUserAgent === true` 给 createAccount

## 测试
- [x] 前端 AccountForm.vue 已支持该字段
- [x] 服务层 claudeAccountService.js 已支持该参数（默认值为 false）
- [x] 修复后可正确创建账户并保存该配置