### PR TITLE
feat(Claude Console): 添加Claude Console账号每日配额

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -2292,7 +2292,9 @@ router.post('/claude-console-accounts', authenticateAdmin, async (req, res) => {
       rateLimitDuration,
       proxy,
       accountType,
-      groupId
+      groupId,
+      dailyQuota,
+      quotaResetTime
     } = req.body
 
     if (!name || !apiUrl || !apiKey) {
@@ -2327,7 +2329,9 @@ router.post('/claude-console-accounts', authenticateAdmin, async (req, res) => {
       rateLimitDuration:
         rateLimitDuration !== undefined && rateLimitDuration !== null ? rateLimitDuration : 60,
       proxy,
-      accountType: accountType || 'shared'
+      accountType: accountType || 'shared',
+      dailyQuota: dailyQuota || 0,
+      quotaResetTime: quotaResetTime || '00:00'
     })
 
     // 如果是分组类型，将账户添加到分组
@@ -2505,6 +2509,56 @@ router.put(
     }
   }
 )
+
+// 获取Claude Console账户的使用统计
+router.get('/claude-console-accounts/:accountId/usage', authenticateAdmin, async (req, res) => {
+  try {
+    const { accountId } = req.params
+    const usageStats = await claudeConsoleAccountService.getAccountUsageStats(accountId)
+
+    if (!usageStats) {
+      return res.status(404).json({ error: 'Account not found' })
+    }
+
+    return res.json(usageStats)
+  } catch (error) {
+    logger.error('❌ Failed to get Claude Console account usage stats:', error)
+    return res.status(500).json({ error: 'Failed to get usage stats', message: error.message })
+  }
+})
+
+// 手动重置Claude Console账户的每日使用量
+router.post(
+  '/claude-console-accounts/:accountId/reset-usage',
+  authenticateAdmin,
+  async (req, res) => {
+    try {
+      const { accountId } = req.params
+      await claudeConsoleAccountService.resetDailyUsage(accountId)
+
+      logger.success(`✅ Admin manually reset daily usage for Claude Console account: ${accountId}`)
+      return res.json({ success: true, message: 'Daily usage reset successfully' })
+    } catch (error) {
+      logger.error('❌ Failed to reset Claude Console account daily usage:', error)
+      return res.status(500).json({ error: 'Failed to reset daily usage', message: error.message })
+    }
+  }
+)
+
+// 手动重置所有Claude Console账户的每日使用量
+router.post('/claude-console-accounts/reset-all-usage', authenticateAdmin, async (req, res) => {
+  try {
+    await claudeConsoleAccountService.resetAllDailyUsage()
+
+    logger.success('✅ Admin manually reset daily usage for all Claude Console accounts')
+    return res.json({ success: true, message: 'All daily usage reset successfully' })
+  } catch (error) {
+    logger.error('❌ Failed to reset all Claude Console accounts daily usage:', error)
+    return res
+      .status(500)
+      .json({ error: 'Failed to reset all daily usage', message: error.message })
+  }
+})
 
 // ☁️ Bedrock 账户管理
 

--- a/src/services/claudeConsoleRelayService.js
+++ b/src/services/claudeConsoleRelayService.js
@@ -181,6 +181,11 @@ class ClaudeConsoleRelayService {
         await claudeConsoleAccountService.markAccountUnauthorized(accountId)
       } else if (response.status === 429) {
         logger.warn(`🚫 Rate limit detected for Claude Console account ${accountId}`)
+        // 收到429先检查是否因为超过了手动配置的每日额度
+        await claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
+          logger.error('❌ Failed to check quota after 429 error:', err)
+        })
+
         await claudeConsoleAccountService.markAccountRateLimited(accountId)
       } else if (response.status === 529) {
         logger.warn(`🚫 Overload error detected for Claude Console account ${accountId}`)
@@ -377,6 +382,10 @@ class ClaudeConsoleRelayService {
               claudeConsoleAccountService.markAccountUnauthorized(accountId)
             } else if (response.status === 429) {
               claudeConsoleAccountService.markAccountRateLimited(accountId)
+              // 检查是否因为超过每日额度
+              claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
+                logger.error('❌ Failed to check quota after 429 error:', err)
+              })
             } else if (response.status === 529) {
               claudeConsoleAccountService.markAccountOverloaded(accountId)
             }
@@ -589,6 +598,10 @@ class ClaudeConsoleRelayService {
               claudeConsoleAccountService.markAccountUnauthorized(accountId)
             } else if (error.response.status === 429) {
               claudeConsoleAccountService.markAccountRateLimited(accountId)
+              // 检查是否因为超过每日额度
+              claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
+                logger.error('❌ Failed to check quota after 429 error:', err)
+              })
             } else if (error.response.status === 529) {
               claudeConsoleAccountService.markAccountOverloaded(accountId)
             }

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -584,6 +584,44 @@
                     </div>
                   </div>
                 </div>
+                <!-- Claude Console: 显示每日额度使用进度 -->
+                <div v-else-if="account.platform === 'claude-console'" class="space-y-2">
+                  <div v-if="Number(account.dailyQuota) > 0">
+                    <div class="flex items-center justify-between text-xs">
+                      <span class="text-gray-600 dark:text-gray-300">额度进度</span>
+                      <span class="font-medium text-gray-700 dark:text-gray-200">
+                        {{ getQuotaUsagePercent(account).toFixed(1) }}%
+                      </span>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <div class="h-2 w-24 rounded-full bg-gray-200 dark:bg-gray-700">
+                        <div
+                          :class="[
+                            'h-2 rounded-full transition-all duration-300',
+                            getQuotaBarClass(getQuotaUsagePercent(account))
+                          ]"
+                          :style="{ width: Math.min(100, getQuotaUsagePercent(account)) + '%' }"
+                        />
+                      </div>
+                      <span
+                        class="min-w-[32px] text-xs font-medium text-gray-700 dark:text-gray-200"
+                      >
+                        ${{ formatCost(account.usage?.daily?.cost || 0) }} / ${{
+                          Number(account.dailyQuota).toFixed(2)
+                        }}
+                      </span>
+                    </div>
+                    <div class="text-xs text-gray-600 dark:text-gray-400">
+                      剩余 ${{ formatRemainingQuota(account) }}
+                      <span class="ml-2 text-gray-400"
+                        >重置 {{ account.quotaResetTime || '00:00' }}</span
+                      >
+                    </div>
+                  </div>
+                  <div v-else class="text-sm text-gray-400">
+                    <i class="fas fa-minus" />
+                  </div>
+                </div>
                 <div v-else-if="account.platform === 'claude'" class="text-sm text-gray-400">
                   <i class="fas fa-minus" />
                 </div>
@@ -1786,6 +1824,29 @@ const formatCost = (cost) => {
   if (cost < 0.01) return cost.toFixed(6)
   if (cost < 1) return cost.toFixed(4)
   return cost.toFixed(2)
+}
+
+// 额度使用百分比（Claude Console）
+const getQuotaUsagePercent = (account) => {
+  const used = Number(account?.usage?.daily?.cost || 0)
+  const quota = Number(account?.dailyQuota || 0)
+  if (!quota || quota <= 0) return 0
+  return (used / quota) * 100
+}
+
+// 额度进度条颜色（Claude Console）
+const getQuotaBarClass = (percent) => {
+  if (percent >= 90) return 'bg-red-500'
+  if (percent >= 70) return 'bg-yellow-500'
+  return 'bg-green-500'
+}
+
+// 剩余额度（Claude Console）
+const formatRemainingQuota = (account) => {
+  const used = Number(account?.usage?.daily?.cost || 0)
+  const quota = Number(account?.dailyQuota || 0)
+  if (!quota || quota <= 0) return '0.00'
+  return Math.max(0, quota - used).toFixed(2)
 }
 
 // 计算每日费用（使用后端返回的精确费用数据）


### PR DESCRIPTION
1. 额度检查优先级更高：即使不启用限流机制，超额仍会禁用账户
2. 状态会被覆盖：quota_exceeded 会覆盖 rate_limited
3. 两种恢复时间：
  - 限流恢复：分钟级（如60分钟）
  - 额度恢复：天级（第二天重置）
4. 独立控制：
  - rateLimitDuration = 0：只管理额度，忽略429
  - rateLimitDuration > 0：同时管理限流和额度