### PR TITLE
feat: 移除API Key账号绑定的专属类型限制

### DIFF
--- a/web/admin-spa/src/components/common/AccountSelector.vue
+++ b/web/admin-spa/src/components/common/AccountSelector.vue
@@ -298,12 +298,8 @@ const filteredGroups = computed(() => {
 
 // 过滤的 OAuth 账号
 const filteredOAuthAccounts = computed(() => {
-  let accounts = sortedAccounts.value.filter(
-    (a) =>
-      a.accountType === 'dedicated' &&
-      (props.platform === 'claude'
-        ? a.platform === 'claude-oauth'
-        : a.platform !== 'claude-console')
+  let accounts = sortedAccounts.value.filter((a) =>
+    props.platform === 'claude' ? a.platform === 'claude-oauth' : a.platform !== 'claude-console'
   )
 
   if (searchQuery.value) {
@@ -318,9 +314,7 @@ const filteredOAuthAccounts = computed(() => {
 const filteredConsoleAccounts = computed(() => {
   if (props.platform !== 'claude') return []
 
-  let accounts = sortedAccounts.value.filter(
-    (a) => a.accountType === 'dedicated' && a.platform === 'claude-console'
-  )
+  let accounts = sortedAccounts.value.filter((a) => a.platform === 'claude-console')
 
   if (searchQuery.value) {
     const query = searchQuery.value.toLowerCase()


### PR DESCRIPTION
用户故事
我希望通过外置计划任务，比如每天早上 7 点检测一下账号是否封了，亦或者是人为控制会话周期。
但是我的账号是共享池调度，我希望能增加一些特殊的 API KEY，即使在共享池调度下，我可以让某一个 API KEY 强行指定一个账号，从而达到操作某个账号的效果。

改动点
- 允许所有账号类型被 API Key 绑定，不再限制必须是 dedicated 类型

维持原有调度策略：绑定账号后只使用该账号，不回退到共享池