### PR TITLE
fix: improve group display layout in accounts view

### DIFF
--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -272,7 +272,9 @@
                       >
                         <i class="fas fa-share-alt mr-1" />共享
                       </span>
-                      <!-- 显示所有分组 -->
+                    </div>
+                    <!-- 显示所有分组 - 换行显示 -->
+                    <div v-if="account.groupInfos && account.groupInfos.length > 0" class="flex items-center gap-2">
                       <span
                         v-for="group in account.groupInfos"
                         :key="group.id"


### PR DESCRIPTION
Move group display to new line for better layout and readability.

🤖 Generated with [Claude Code](https://claude.ai/code)