### PR TITLE
修复用户自行创建的API Key缺少服务权限信息的问题

### DIFF
--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -315,7 +315,8 @@ router.post('/api-keys', authenticateUser, async (req, res) => {
       expiresAt: expiresAt || null,
       dailyCostLimit: dailyCostLimit || null,
       createdBy: 'user',
-      permissions: ['messages'] // 用户创建的API Key默认只有messages权限
+      // 设置服务权限为全部服务，确保前端显示“服务权限”为“全部服务”且具备完整访问权限
+      permissions: 'all'
     }
 
     const newApiKey = await apiKeyService.createApiKey(apiKeyData)


### PR DESCRIPTION
问题现象：用户自行创建API Key后，只能调用Claude Code模型，无法使用Codex/Gemini。
修复后：用户创建的API Key默认允许调用全部服务。