### PR TITLE
fix(ui): correct table row striping in API Keys view

### DIFF
--- a/web/admin-spa/src/views/ApiKeysView.vue
+++ b/web/admin-spa/src/views/ApiKeysView.vue
@@ -404,7 +404,7 @@
                         'table-row transition-all duration-150',
                         index % 2 === 0
                           ? 'bg-white dark:bg-gray-800/40'
-                          : 'dark:bg-gray-850/40 bg-gray-50/70',
+                          : 'bg-gray-50/70 dark:bg-gray-700/30',
                         'border-b-2 border-gray-200/80 dark:border-gray-700/50',
                         'hover:bg-blue-50/60 hover:shadow-sm dark:hover:bg-blue-900/20'
                       ]"


### PR DESCRIPTION
## 问题描述

API Keys 管理页面存在视觉缺陷，暗黑模式下，第二行及其他奇数索引行显示为白色，未能正确呈现斑马纹效果。问题原因：
1. 使用了无效的 Tailwind CSS 类 `bg-gray-850`
2. 暗黑模式下行间对比度不足

## 解决方案

更新表格行样式，使用有效的 Tailwind CSS 类并增强对比度：
- **偶数行（0, 2, 4...）**：`bg-white dark:bg-gray-800/40`
- **奇数行（1, 3, 5...）**：`bg-gray-50/70 dark:bg-gray-700/30`

## 修改内容

- 修改 `web/admin-spa/src/views/ApiKeysView.vue`
- 将奇数行的无效类 `dark:bg-gray-850/40` 替换为 `dark:bg-gray-700/30`
- 保持偶数行原有样式不变
- 增强暗黑模式对比度

## 测试项

- 亮色模式下表格斑马纹正常显示
- 暗黑模式下对比度明显改善
- 悬停效果正常工作
- 表格功能无回归

## 影响范围

- 管理后台界面
- API Keys 管理页面
- 暗黑模式样式