### PR TITLE
fix: 修复 Claude Console 账户创建时的验证逻辑错误

### DIFF
--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -2882,7 +2882,8 @@ const errors = ref({
   secretAccessKey: '',
   region: '',
   azureEndpoint: '',
-  deploymentName: ''
+  deploymentName: '',
+  baseApi: ''
 })
 
 // 计算是否可以进入下一步
@@ -3218,6 +3219,7 @@ const createAccount = async () => {
   errors.value.accessToken = ''
   errors.value.apiUrl = ''
   errors.value.apiKey = ''
+  errors.value.baseApi = ''
 
   let hasError = false
 
@@ -3277,7 +3279,7 @@ const createAccount = async () => {
       hasError = true
     }
   } else if (form.value.addType === 'manual') {
-    // 手动模式验证
+    // 手动模式验证 - 只对需要OAuth的平台进行验证
     if (form.value.platform === 'openai') {
       // OpenAI 平台必须有 Refresh Token
       if (!form.value.refreshToken || form.value.refreshToken.trim() === '') {
@@ -3285,8 +3287,8 @@ const createAccount = async () => {
         hasError = true
       }
       // Access Token 可选，如果没有会通过 Refresh Token 获取
-    } else {
-      // 其他平台（Gemini）需要 Access Token
+    } else if (form.value.platform === 'claude' || form.value.platform === 'gemini') {
+      // Claude 和 Gemini 平台需要 Access Token
       if (!form.value.accessToken || form.value.accessToken.trim() === '') {
         errors.value.accessToken = '请填写 Access Token'
         hasError = true


### PR DESCRIPTION
问题：

- Claude Console 账户创建时无法触发 POST 请求
- 手动模式验证逻辑错误地要求所有非 OpenAI 平台都填写 AccessToken

修复：

- 明确指定只有 Claude 和 Gemini 平台在手动模式下需要 Access Token
- Claude Console 使用独立的 API Key 验证，不需要 OAuth