### PR TITLE
fix: 修复 OpenAI 代理配置问题

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -226,6 +226,7 @@ const handleResponses = async (req, res) => {
     // 如果有代理，添加代理配置
     if (proxyAgent) {
       axiosConfig.httpsAgent = proxyAgent
+      axiosConfig.proxy = false
       logger.info(`🌐 Using proxy for OpenAI request: ${ProxyHelper.getProxyDescription(proxy)}`)
     } else {
       logger.debug('🌐 No proxy configured for OpenAI request')


### PR DESCRIPTION
## 概要
修复 OpenAI 路由中的代理配置问题

## 变更说明
- 在使用自定义 httpsAgent 时添加 `proxy: false` 配置
- 防止 axios 的默认代理设置与自定义代理冲突

## 测试计划
- [x] 确认代理配置不会冲突
- [x] 验证请求能正确通过配置的代理

🤖 Generated with [Claude Code](https://claude.ai/code)