### PR TITLE
feat: publish image to ghcr

### DIFF
--- a/.github/workflows/auto-release-pipeline.yml
+++ b/.github/workflows/auto-release-pipeline.yml
@@ -417,7 +417,7 @@ jobs:
 
     - name: Build and push Docker image
       if: steps.check.outputs.needs_bump == 'true'
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         platforms: linux/amd64,linux/arm64
@@ -432,6 +432,7 @@ jobs:
         labels: |
           org.opencontainers.image.version=${{ steps.next_version.outputs.new_version }}
           org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/.github/workflows/auto-release-pipeline.yml
+++ b/.github/workflows/auto-release-pipeline.yml
@@ -246,6 +246,23 @@ jobs:
         git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
         git push origin HEAD:main "$NEW_TAG"
 
+    - name: Prepare image names
+      id: image_names
+      if: steps.check.outputs.needs_bump == 'true'
+      run: |
+        DOCKER_USERNAME="${{ secrets.DOCKERHUB_USERNAME }}"
+        if [ -z "$DOCKER_USERNAME" ]; then
+          DOCKER_USERNAME="weishaw"
+        fi
+
+        DOCKER_IMAGE=$(echo "${DOCKER_USERNAME}/claude-relay-service" | tr '[:upper:]' '[:lower:]')
+        GHCR_IMAGE=$(echo "ghcr.io/${{ github.repository_owner }}/claude-relay-service" | tr '[:upper:]' '[:lower:]')
+
+        {
+          echo "docker_image=${DOCKER_IMAGE}"
+          echo "ghcr_image=${GHCR_IMAGE}"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Create GitHub Release
       if: steps.check.outputs.needs_bump == 'true'
       uses: softprops/action-gh-release@v1
@@ -256,8 +273,10 @@ jobs:
           ## 🐳 Docker 镜像
           
           ```bash
-          docker pull ${{ secrets.DOCKERHUB_USERNAME || 'weishaw' }}/claude-relay-service:${{ steps.next_version.outputs.new_tag }}
-          docker pull ${{ secrets.DOCKERHUB_USERNAME || 'weishaw' }}/claude-relay-service:latest
+          docker pull ${{ steps.image_names.outputs.docker_image }}:${{ steps.next_version.outputs.new_tag }}
+          docker pull ${{ steps.image_names.outputs.docker_image }}:latest
+          docker pull ${{ steps.image_names.outputs.ghcr_image }}:${{ steps.next_version.outputs.new_tag }}
+          docker pull ${{ steps.image_names.outputs.ghcr_image }}:latest
           ```
           
           ## 📦 主要更新
@@ -388,6 +407,14 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Log in to GitHub Container Registry
+      if: steps.check.outputs.needs_bump == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build and push Docker image
       if: steps.check.outputs.needs_bump == 'true'
       uses: docker/build-push-action@v5
@@ -396,9 +423,12 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ${{ secrets.DOCKERHUB_USERNAME }}/claude-relay-service:${{ steps.next_version.outputs.new_tag }}
-          ${{ secrets.DOCKERHUB_USERNAME }}/claude-relay-service:latest
-          ${{ secrets.DOCKERHUB_USERNAME }}/claude-relay-service:${{ steps.next_version.outputs.new_version }}
+          ${{ steps.image_names.outputs.docker_image }}:${{ steps.next_version.outputs.new_tag }}
+          ${{ steps.image_names.outputs.docker_image }}:latest
+          ${{ steps.image_names.outputs.docker_image }}:${{ steps.next_version.outputs.new_version }}
+          ${{ steps.image_names.outputs.ghcr_image }}:${{ steps.next_version.outputs.new_tag }}
+          ${{ steps.image_names.outputs.ghcr_image }}:latest
+          ${{ steps.image_names.outputs.ghcr_image }}:${{ steps.next_version.outputs.new_version }}
         labels: |
           org.opencontainers.image.version=${{ steps.next_version.outputs.new_version }}
           org.opencontainers.image.revision=${{ github.sha }}
@@ -410,6 +440,8 @@ jobs:
       env:
         TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        DOCKER_IMAGE: ${{ steps.image_names.outputs.docker_image }}
+        GHCR_IMAGE: ${{ steps.image_names.outputs.ghcr_image }}
       continue-on-error: true
       run: |
         VERSION="${{ steps.next_version.outputs.new_version }}"
@@ -430,13 +462,16 @@ jobs:
         MESSAGE+="${CHANGELOG_TRUNCATED}"$'\n'$'\n'
         MESSAGE+="🐳 *Docker 部署:*"$'\n'
         MESSAGE+="\`\`\`bash"$'\n'
-        MESSAGE+="docker pull weishaw/claude-relay-service:${TAG}"$'\n'
-        MESSAGE+="docker pull weishaw/claude-relay-service:latest"$'\n'
+        MESSAGE+="docker pull ${DOCKER_IMAGE}:${TAG}"$'\n'
+        MESSAGE+="docker pull ${DOCKER_IMAGE}:latest"$'\n'
+        MESSAGE+="docker pull ${GHCR_IMAGE}:${TAG}"$'\n'
+        MESSAGE+="docker pull ${GHCR_IMAGE}:latest"$'\n'
         MESSAGE+="\`\`\`"$'\n'$'\n'
         MESSAGE+="🔗 *相关链接:*"$'\n'
         MESSAGE+="• [GitHub Release](https://github.com/${REPO}/releases/tag/${TAG})"$'\n'
         MESSAGE+="• [完整更新日志](https://github.com/${REPO}/releases)"$'\n'
-        MESSAGE+="• [Docker Hub](https://hub.docker.com/r/weishaw/claude-relay-service)"$'\n'$'\n'
+        MESSAGE+="• [Docker Hub](https://hub.docker.com/r/${DOCKER_IMAGE%/*}/claude-relay-service)"$'\n'
+        MESSAGE+="• [GHCR](https://ghcr.io/${GHCR_IMAGE#ghcr.io/})"$'\n'$'\n'
         MESSAGE+="#ClaudeRelay #Update #v${VERSION//./_}"
         
         # 使用 jq 构建 JSON 并发送


### PR DESCRIPTION
添加 Workflow 发布容器镜像到 GitHub Container Registry (ghcr.io) 以避免拉取镜像时遭遇 Docker Hub 的速率限制

添加了必要的镜像元数据以便 GHCR 上镜像可以自动关联到仓库并继承权限