### PR TITLE
fix: 修复统一客户端标识的布尔值判断

### DIFF
--- a/src/services/claudeRelayService.js
+++ b/src/services/claudeRelayService.js
@@ -429,7 +429,7 @@ class ClaudeRelayService {
     }
 
     // 处理统一的客户端标识
-    if (account && account.useUnifiedClientId && account.unifiedClientId) {
+    if (account && account.useUnifiedClientId === 'true' && account.unifiedClientId) {
       this._replaceClientId(processedBody, account.unifiedClientId)
     }
 


### PR DESCRIPTION
将 useUnifiedClientId 的判断从直接布尔值比较改为字符串 'true' 比较，修复配置值为字符串时的判断问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)