### PR TITLE
feat: add rate limit recovery webhook notifications

### DIFF
--- a/src/services/webhookConfigService.js
+++ b/src/services/webhookConfigService.js
@@ -18,7 +18,17 @@ class WebhookConfigService {
         // 返回默认配置
         return this.getDefaultConfig()
       }
-      return JSON.parse(configStr)
+
+      const storedConfig = JSON.parse(configStr)
+      const defaultConfig = this.getDefaultConfig()
+
+      // 合并默认通知类型，确保新增类型有默认值
+      storedConfig.notificationTypes = {
+        ...defaultConfig.notificationTypes,
+        ...(storedConfig.notificationTypes || {})
+      }
+
+      return storedConfig
     } catch (error) {
       logger.error('获取webhook配置失败:', error)
       return this.getDefaultConfig()
@@ -30,6 +40,13 @@ class WebhookConfigService {
    */
   async saveConfig(config) {
     try {
+      const defaultConfig = this.getDefaultConfig()
+
+      config.notificationTypes = {
+        ...defaultConfig.notificationTypes,
+        ...(config.notificationTypes || {})
+      }
+
       // 验证配置
       this.validateConfig(config)
 
@@ -312,6 +329,7 @@ class WebhookConfigService {
         quotaWarning: true, // 配额警告
         systemError: true, // 系统错误
         securityAlert: true, // 安全警报
+        rateLimitRecovery: true, // 限流恢复
         test: true // 测试通知
       },
       retrySettings: {


### PR DESCRIPTION
添加限流恢复的 webhook 通知功能，当账户从限流状态自动恢复时发送通知。

主要改进:

1. **新增通知类型** (webhookConfigService.js)
   - 添加 `rateLimitRecovery` 通知类型
   - 在配置获取和保存时自动合并默认通知类型
   - 确保新增的通知类型有默认值

2. **增强限流清理服务** (rateLimitCleanupService.js)
   - 改进自动停止账户的检测逻辑
   - 在 `finally` 块中确保 `clearedAccounts` 列表被重置，避免重复通知
   - 对自动停止的账户显式调用 `removeAccountRateLimit`
   - 为 Claude 和 Claude Console 账户添加 `autoStopped` 和 `needsAutoStopRecovery` 检测

3. **改进 Claude Console 限流移除** (claudeConsoleAccountService.js)
   - 检测并恢复因自动停止而禁用调度的账户
   - 清理过期的 `rateLimitAutoStopped` 标志
   - 增加详细的日志记录

4. **前端 UI 支持** (SettingsView.vue)
   - 在 Webhook 设置中添加"限流恢复"通知类型选项
   - 更新默认通知类型配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)