### PR TITLE
fix: 用户登录接口在开发环境 404 错误

### DIFF
--- a/web/admin-spa/src/stores/user.js
+++ b/web/admin-spa/src/stores/user.js
@@ -1,8 +1,9 @@
 import { defineStore } from 'pinia'
 import axios from 'axios'
 import { showToast } from '@/utils/toast'
+import { API_PREFIX } from '@/config/api'
 
-const API_BASE = '/users'
+const API_BASE = `${API_PREFIX}/users`
 
 export const useUserStore = defineStore('user', {
   state: () => ({


### PR DESCRIPTION
  修复 user.js 中未使用 API_PREFIX 导致的路径问题。
  现在开发环境正确使用 /webapi 前缀进行代理转发。