### PR TITLE
docs: 更新 Cherry Studio 集成指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,23 +473,23 @@ Cherry Studio支持多种AI服务的接入，下面是不同账号类型的详�
 
 ```
 # API地址
-http://你的服务器:3000/claude/
+http://你的服务器:3000/claude
 
 # 模型ID示例
-claude-sonnet-4-20250514  # Claude Sonnet 4
+claude-sonnet-4-5-20250929 # Claude Sonnet 4.5
 claude-opus-4-20250514     # Claude Opus 4
 ```
 
 配置步骤：
 - 供应商类型选择"Anthropic"
-- API地址填入：`http://你的服务器:3000/claude/`
+- API地址填入：`http://你的服务器:3000/claude`
 - API Key填入：后台创建的API密钥（cr_开头）
 
 **2. Gemini账号接入：**
 
 ```
 # API地址
-http://你的服务器:3000/gemini/
+http://你的服务器:3000/gemini
 
 # 模型ID示例
 gemini-2.5-pro             # Gemini 2.5 Pro
@@ -497,14 +497,14 @@ gemini-2.5-pro             # Gemini 2.5 Pro
 
 配置步骤：
 - 供应商类型选择"Gemini"
-- API地址填入：`http://你的服务器:3000/gemini/`
+- API地址填入：`http://你的服务器:3000/gemini`
 - API Key填入：后台创建的API密钥（cr_开头）
 
 **3. Codex接入：**
 
 ```
 # API地址
-http://你的服务器:3000/openai/
+http://你的服务器:3000/openai
 
 # 模型ID（固定）
 gpt-5                      # Codex使用固定模型ID
@@ -512,9 +512,16 @@ gpt-5                      # Codex使用固定模型ID
 
 配置步骤：
 - 供应商类型选择"Openai-Response"
-- API地址填入：`http://你的服务器:3000/openai/`
+- API地址填入：`http://你的服务器:3000/openai`
 - API Key填入：后台创建的API密钥（cr_开头）
 - **重要**：Codex只支持Openai-Response标准
+
+**Cherry Studio 地址格式重要说明：**
+
+- ✅ **推荐格式**：`http://你的服务器:3000/claude`（不加结尾 `/`，让 Cherry Studio 自动加上 v1）
+- ✅ **等效格式**：`http://你的服务器:3000/claude/v1/`（手动指定 v1 并加结尾 `/`）
+- 💡 **说明**：这两种格式在 Cherry Studio 中是完全等效的
+- ❌ **错误格式**：`http://你的服务器:3000/claude/`（单独的 `/` 结尾会被 Cherry Studio 忽略 v1 版本）
 
 #### 其他第三方工具接入
 


### PR DESCRIPTION
## 概述

更新 Cherry Studio 集成指南，修正 API 端点格式以符合 Cherry Studio 的 URL 格式要求，并更新 Claude Sonnet 模型至最新版本。

## 问题描述

原有的 API 端点配置使用了尾部斜杠（如 `http://你的服务器:3000/claude/`），根据 Cherry Studio 官方文档说明："**/ 结尾忽略 v1 版本，# 结尾强制使用输入位址**"。

### 实际测试结果

- ❌ **原配置**：`http://你的服务器:3000/claude/`
  - Cherry Studio 实际请求：`http://192.168.50.5:3001/claude/messages`
  - 结果：**API error: 400**（缺少 v1 版本参数）

- ✅ **修正后**：`http://你的服务器:3000/claude`
  - Cherry Studio 实际请求：`http://192.168.50.5:3001/claude/v1/messages`
  - 结果：**正常工作**

## 主要变更

### 1. 模型版本更新
- 更新 Claude Sonnet 模型 ID：`claude-sonnet-4-20250514` → `claude-sonnet-4-5-20250929` (v4.5)

### 2. API 端点格式修正
修正所有 Cherry Studio API 端点 URL 格式，移除尾部斜杠以确保 Cherry Studio 正确添加 v1 版本参数：

- Claude 端点：`/claude/` → `/claude`
- Gemini 端点：`/gemini/` → `/gemini`
- Codex 端点：`/openai/` → `/openai`

### 3. 新增 URL 格式说明
添加 Cherry Studio 地址格式重要说明章节，解释：

- ✅ **推荐格式**：`http://你的服务器:3000/claude`（不加结尾 `/`，让 Cherry Studio 自动加上 v1）
- ✅ **等效格式**：`http://你的服务器:3000/claude/v1/`（手动指定 v1 并加结尾 `/`）
- 💡 **说明**：这两种格式在 Cherry Studio 中完全等效
- ❌ **错误格式**：`http://你的服务器:3000/claude/`（单独的 `/` 结尾会被 Cherry Studio 忽略 v1 版本）

## 测试计划

- [x] 验证文档格式正确性
- [x] 实际测试 URL 格式在 Cherry Studio 中的行为
- [x] 确认修正后的端点可以正常工作
- [x] 检查模型 ID 准确性

## 相关文档

- Cherry Studio 官方 API 说明："/ 结尾忽略 v1 版本，# 结尾强制使用输入位址"

## 影响范围

仅影响文档，不涉及代码变更。使用 Cherry Studio 的用户需要根据更新后的文档重新配置 API 端点，以避免 400 错误。
