### PR TITLE
fix: 修复日均费用计算逻辑

### DIFF
--- a/web/admin-spa/src/components/accounts/AccountUsageDetailModal.vue
+++ b/web/admin-spa/src/components/accounts/AccountUsageDetailModal.vue
@@ -38,6 +38,9 @@
               </div>
               <p class="text-xs text-gray-500 dark:text-gray-400 sm:text-sm">
                 近 {{ summary?.days || 30 }} 天内的费用与请求趋势
+                <span v-if="summary?.actualDaysUsed && summary?.actualDaysUsed < summary?.days">
+                  (日均基于实际使用 {{ summary.actualDaysUsed }} 天)
+                </span>
               </p>
             </div>
           </div>
@@ -443,7 +446,9 @@ const primaryMetrics = computed(() => [
     key: 'avgCost',
     label: '日均费用',
     value: props.summary?.avgDailyCostFormatted || formatCost(props.summary?.avgDailyCost || 0),
-    subtitle: '平均每日成本',
+    subtitle: props.summary?.actualDaysUsed && props.summary?.actualDaysUsed < props.summary?.days
+      ? `基于 ${props.summary.actualDaysUsed} 天实际使用`
+      : '平均每日成本',
     icon: 'fa-wave-square',
     iconClass: 'text-purple-500'
   },

--- a/web/admin-spa/src/components/accounts/AccountUsageDetailModal.vue
+++ b/web/admin-spa/src/components/accounts/AccountUsageDetailModal.vue
@@ -446,9 +446,10 @@ const primaryMetrics = computed(() => [
     key: 'avgCost',
     label: '日均费用',
     value: props.summary?.avgDailyCostFormatted || formatCost(props.summary?.avgDailyCost || 0),
-    subtitle: props.summary?.actualDaysUsed && props.summary?.actualDaysUsed < props.summary?.days
-      ? `基于 ${props.summary.actualDaysUsed} 天实际使用`
-      : '平均每日成本',
+    subtitle:
+      props.summary?.actualDaysUsed && props.summary?.actualDaysUsed < props.summary?.days
+        ? `基于 ${props.summary.actualDaysUsed} 天实际使用`
+        : '平均每日成本',
     icon: 'fa-wave-square',
     iconClass: 'text-purple-500'
   },


### PR DESCRIPTION
问题描述：
- 之前的日均费用计算是基于固定的30天窗口，而不是账户实际使用的天数
- 这导致新创建的账户显示的日均费用不准确

修复方案：
- 获取账户的创建时间（createdAt字段）
- 计算从账户创建到当前时间的实际天数
- 使用实际天数来计算日均费用（30天总费用 / 实际天数）
- 在前端显示实际使用天数，让用户了解计算基准

修改内容：
- 后端：在 /accounts/:accountId/usage-history 端点中添加实际天数计算逻辑
- 前端：在详情弹窗中显示基于实际使用天数的提示信息