### PR TITLE
feat: 为 Claude Console 账户添加完整的到期时间和每日限制功能

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -2684,7 +2684,9 @@ router.post('/claude-console-accounts', authenticateAdmin, async (req, res) => {
       accountType,
       groupId,
       dailyQuota,
-      quotaResetTime
+      quotaResetTime,
+      dailyLimit,
+      subscriptionExpiresAt
     } = req.body
 
     if (!name || !apiUrl || !apiKey) {
@@ -2721,7 +2723,9 @@ router.post('/claude-console-accounts', authenticateAdmin, async (req, res) => {
       proxy,
       accountType: accountType || 'shared',
       dailyQuota: dailyQuota || 0,
-      quotaResetTime: quotaResetTime || '00:00'
+      quotaResetTime: quotaResetTime || '00:00',
+      dailyLimit: dailyLimit || 0,
+      subscriptionExpiresAt: subscriptionExpiresAt || null
     })
 
     // 如果是分组类型，将账户添加到分组（CCR 归属 Claude 平台分组）

--- a/web/admin-spa/src/components/accounts/AccountExpiryEditModal.vue
+++ b/web/admin-spa/src/components/accounts/AccountExpiryEditModal.vue
@@ -220,11 +220,16 @@ const quickOptions = [
   { value: '730d', label: '2 年' }
 ]
 
-// 计算最小日期时间
+// 计算最小日期时间（本地时间）
 const minDateTime = computed(() => {
   const now = new Date()
   now.setMinutes(now.getMinutes() + 1)
-  return now.toISOString().slice(0, 16)
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
 })
 
 // 监听显示状态，初始化表单
@@ -253,7 +258,14 @@ const initializeForm = () => {
 
   if (props.account.expiresAt) {
     localForm.expireDuration = 'custom'
-    localForm.customExpireDate = new Date(props.account.expiresAt).toISOString().slice(0, 16)
+    // 转换为本地时间字符串（YYYY-MM-DDTHH:mm格式）
+    const date = new Date(props.account.expiresAt)
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    const hours = String(date.getHours()).padStart(2, '0')
+    const minutes = String(date.getMinutes()).padStart(2, '0')
+    localForm.customExpireDate = `${year}-${month}-${day}T${hours}:${minutes}`
     localForm.expiresAt = props.account.expiresAt
   } else {
     localForm.expireDuration = ''


### PR DESCRIPTION
- 添加 subscriptionExpiresAt 字段支持账户到期时间设置
- 添加 dailyLimit 字段支持每日请求次数限制
- 修复账户到期时间的时区显示问题（UTC与本地时间转换）
- 在创建和编辑表单中添加到期时间和每日限制输入字段
- 优化时间选择器，支持快捷选项（30天、90天、180天、365天等）
- 移除重复的到期时间字段，统一使用通用字段