### PR TITLE
fix: 修复账户到期时间的时区偏差问题

### DIFF
--- a/web/admin-spa/src/components/accounts/AccountExpiryEditModal.vue
+++ b/web/admin-spa/src/components/accounts/AccountExpiryEditModal.vue
@@ -304,7 +304,14 @@ const selectQuickOption = (value) => {
 // 更新自定义过期时间
 const updateCustomExpiryPreview = () => {
   if (localForm.customExpireDate) {
-    localForm.expiresAt = new Date(localForm.customExpireDate).toISOString()
+    // 手动解析日期时间字符串，确保它被正确解释为本地时间
+    const [datePart, timePart] = localForm.customExpireDate.split('T')
+    const [year, month, day] = datePart.split('-').map(Number)
+    const [hours, minutes] = timePart.split(':').map(Number)
+
+    // 使用构造函数创建本地时间的 Date 对象，然后转换为 UTC ISO 字符串
+    const localDate = new Date(year, month - 1, day, hours, minutes, 0, 0)
+    localForm.expiresAt = localDate.toISOString()
   }
 }
 


### PR DESCRIPTION
修复了在编辑账户到期时间时，保存后显示时间相差8小时的问题。

问题原因：
- datetime-local 输入框的值使用 new Date(string) 解析时
- 部分浏览器会错误地将其解释为 UTC 时间
- 导致保存和显示时出现时区转换不一致

解决方案：
- 手动解析日期时间字符串的各个部分
- 使用 Date 构造函数明确创建本地时间对象
- 然后统一转换为 UTC ISO 字符串存储
- 确保时区转换的一致性

修改文件：
- web/admin-spa/src/components/accounts/AccountExpiryEditModal.vue

🤖 Generated with [Claude Code](https://claude.com/claude-code)