### PR TITLE
feat: add usage alerts for Claude accounts with Telegram and SMTP not…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,3 +122,17 @@ DEFAULT_USER_ROLE=user
 USER_SESSION_TIMEOUT=86400000
 MAX_API_KEYS_PER_USER=1
 ALLOW_USER_DELETE_API_KEYS=false
+
+# 📊 使用额度告警配置
+# 启用使用额度告警（默认启用）
+USAGE_ALERT_ENABLED=true
+# 检查间隔（毫秒），默认 1 小时
+USAGE_ALERT_CHECK_INTERVAL=3600000
+# 告警抑制时间（毫秒），避免重复告警，默认 24 小时
+USAGE_ALERT_SUPPRESSION_TIME=86400000
+
+# 📧 Webhook 通知配置（用于 Telegram 和邮件告警）
+# Webhook 已在 Web 界面中配置，以下是参考示例：
+# Telegram Bot Token: 在 Web 界面的 Webhook 配置中添加 Telegram 平台
+# Telegram Chat ID: 在 Web 界面的 Webhook 配置中设置
+# SMTP 配置: 在 Web 界面的 Webhook 配置中添加 SMTP 平台

--- a/config/config.example.js
+++ b/config/config.example.js
@@ -175,6 +175,13 @@ const config = {
     retries: parseInt(process.env.WEBHOOK_RETRIES) || 3 // 重试3次
   },
 
+  // 📊 使用额度告警配置
+  usageAlert: {
+    enabled: process.env.USAGE_ALERT_ENABLED !== 'false', // 默认启用
+    checkInterval: parseInt(process.env.USAGE_ALERT_CHECK_INTERVAL) || 3600000, // 检查间隔，默认1小时
+    suppressionTime: parseInt(process.env.USAGE_ALERT_SUPPRESSION_TIME) || 86400000 // 告警抑制时间，默认24小时
+  },
+
   // 🛠️ 开发配置
   development: {
     debug: process.env.DEBUG === 'true',

--- a/scripts/test-usage-alerts.js
+++ b/scripts/test-usage-alerts.js
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+
+/**
+ * 测试使用额度告警系统
+ *
+ * 此脚本用于测试 Claude 账号使用额度告警功能
+ * 可以模拟设置账号使用量，并触发告警通知
+ *
+ * 使用方法:
+ *   node scripts/test-usage-alerts.js [options]
+ *
+ * 选项:
+ *   --account-id <id>     指定要测试的账号ID
+ *   --usage-percent <n>   设置使用百分比 (0-100)
+ *   --trigger             手动触发一次检查
+ *   --clear-history <id>  清除指定账号的告警历史
+ *   --list-accounts       列出所有活跃账号
+ */
+
+require('dotenv').config()
+const redis = require('../src/models/redis')
+const logger = require('../src/utils/logger')
+const usageAlertService = require('../src/services/usageAlertService')
+const claudeAccountService = require('../src/services/claudeAccountService')
+const claudeConsoleAccountService = require('../src/services/claudeConsoleAccountService')
+
+// 解析命令行参数
+function parseArgs() {
+  const args = process.argv.slice(2)
+  const options = {
+    accountId: null,
+    usagePercent: null,
+    trigger: false,
+    clearHistory: null,
+    listAccounts: false
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    switch (arg) {
+      case '--account-id':
+        options.accountId = args[++i]
+        break
+      case '--usage-percent':
+        options.usagePercent = parseFloat(args[++i])
+        break
+      case '--trigger':
+        options.trigger = true
+        break
+      case '--clear-history':
+        options.clearHistory = args[++i]
+        break
+      case '--list-accounts':
+        options.listAccounts = true
+        break
+      case '--help':
+      case '-h':
+        showHelp()
+        process.exit(0)
+        break
+      default:
+        console.error(`❌ Unknown option: ${arg}`)
+        showHelp()
+        process.exit(1)
+    }
+  }
+
+  return options
+}
+
+function showHelp() {
+  console.log(`
+使用额度告警测试脚本
+
+使用方法:
+  node scripts/test-usage-alerts.js [options]
+
+选项:
+  --account-id <id>        指定要测试的账号ID
+  --usage-percent <n>      设置使用百分比 (0-100)，需要配合 --account-id 使用
+  --trigger                手动触发一次告警检查
+  --clear-history <id>     清除指定账号的告警历史，允许重新发送告警
+  --list-accounts          列出所有活跃的 Claude 账号
+  --help, -h               显示此帮助信息
+
+示例:
+  # 列出所有账号
+  node scripts/test-usage-alerts.js --list-accounts
+
+  # 模拟账号使用量达到 85%
+  node scripts/test-usage-alerts.js --account-id <account-id> --usage-percent 85
+
+  # 手动触发一次告警检查
+  node scripts/test-usage-alerts.js --trigger
+
+  # 清除账号告警历史（允许重新发送告警）
+  node scripts/test-usage-alerts.js --clear-history <account-id>
+`)
+}
+
+/**
+ * 列出所有活跃账号
+ */
+async function listAccounts() {
+  console.log('📋 正在获取所有 Claude 账号...\n')
+
+  const officialAccounts = await claudeAccountService.getAllAccounts()
+  const consoleAccounts = await claudeConsoleAccountService.getAllAccounts()
+
+  const allAccounts = [
+    ...officialAccounts.map((acc) => ({ ...acc, accountType: 'claude-official' })),
+    ...consoleAccounts.map((acc) => ({ ...acc, accountType: 'claude-console' }))
+  ]
+
+  if (allAccounts.length === 0) {
+    console.log('⚠️  没有找到任何账号')
+    return
+  }
+
+  console.log(`找到 ${allAccounts.length} 个账号:\n`)
+
+  for (const account of allAccounts) {
+    const statusIcon = account.status === 'active' && account.isActive === 'true' ? '✅' : '⏸️ '
+    const subscriptionInfo = account.subscriptionInfo ? JSON.parse(account.subscriptionInfo) : null
+    const monthlyLimit = subscriptionInfo?.monthlyLimit || 'N/A'
+
+    console.log(`${statusIcon} ${account.name}`)
+    console.log(`   ID: ${account.id}`)
+    console.log(`   类型: ${account.accountType || account.platform}`)
+    console.log(`   状态: ${account.status} (${account.isActive === 'true' ? '激活' : '未激活'})`)
+    console.log(`   月度限额: ${monthlyLimit} USD`)
+    console.log()
+  }
+}
+
+/**
+ * 设置账号使用量（模拟）
+ * @param {string} accountId - 账号ID
+ * @param {number} usagePercent - 使用百分比 (0-100)
+ */
+async function setAccountUsage(accountId, usagePercent) {
+  console.log(`📊 正在为账号 ${accountId} 设置使用量为 ${usagePercent}%...\n`)
+
+  // 获取账号信息
+  let account = await claudeAccountService.getAccountById(accountId)
+  if (!account) {
+    account = await claudeConsoleAccountService.getAccountById(accountId)
+  }
+
+  if (!account) {
+    console.error(`❌ 账号 ${accountId} 不存在`)
+    return
+  }
+
+  // 解析订阅信息
+  const subscriptionInfo = account.subscriptionInfo ? JSON.parse(account.subscriptionInfo) : null
+  if (!subscriptionInfo || !subscriptionInfo.monthlyLimit) {
+    console.error(`❌ 账号 ${account.name} 没有配置月度限额`)
+    console.log(
+      '   提示: 请在 Web 界面中为该账号设置 subscriptionInfo，格式如: {"monthlyLimit": 100}'
+    )
+    return
+  }
+
+  const monthlyLimit = subscriptionInfo.monthlyLimit
+  const targetCost = (monthlyLimit * usagePercent) / 100
+
+  console.log(`账号信息:`)
+  console.log(`  名称: ${account.name}`)
+  console.log(`  月度限额: ${monthlyLimit} USD`)
+  console.log(`  目标使用量: ${targetCost.toFixed(2)} USD (${usagePercent}%)`)
+  console.log()
+
+  // 获取当前月份
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const currentMonth = `${year}-${month}`
+
+  // 设置月度使用统计
+  const usageKey = `account_usage:monthly:${accountId}:${currentMonth}`
+  await redis.hset(usageKey, {
+    totalCost: targetCost.toString(),
+    inputTokens: '1000000',
+    outputTokens: '500000',
+    requestCount: '100'
+  })
+
+  // 同时设置总使用统计
+  const totalUsageKey = `account_usage:${accountId}`
+  await redis.hset(totalUsageKey, {
+    totalCost: targetCost.toString(),
+    inputTokens: '1000000',
+    outputTokens: '500000',
+    requestCount: '100'
+  })
+
+  console.log(`✅ 已设置账号使用量: ${targetCost.toFixed(2)} USD`)
+  console.log(`   Redis键: ${usageKey}`)
+  console.log()
+  console.log('💡 提示: 运行 --trigger 触发告警检查')
+}
+
+/**
+ * 手动触发告警检查
+ */
+async function triggerCheck() {
+  console.log('🔍 正在手动触发使用额度检查...\n')
+  await usageAlertService.triggerCheck()
+  console.log('\n✅ 检查完成')
+}
+
+/**
+ * 清除账号告警历史
+ * @param {string} accountId - 账号ID
+ */
+async function clearHistory(accountId) {
+  console.log(`🧹 正在清除账号 ${accountId} 的告警历史...\n`)
+  await usageAlertService.clearAlertHistory(accountId)
+  console.log('✅ 告警历史已清除，可以重新发送告警')
+}
+
+/**
+ * 主函数
+ */
+async function main() {
+  try {
+    const options = parseArgs()
+
+    // 连接 Redis
+    console.log('🔗 正在连接 Redis...')
+    await redis.connect()
+    console.log('✅ Redis 连接成功\n')
+
+    // 执行操作
+    if (options.listAccounts) {
+      await listAccounts()
+    } else if (options.accountId && options.usagePercent !== null) {
+      await setAccountUsage(options.accountId, options.usagePercent)
+    } else if (options.trigger) {
+      await triggerCheck()
+    } else if (options.clearHistory) {
+      await clearHistory(options.clearHistory)
+    } else {
+      console.error('❌ 请指定操作选项')
+      showHelp()
+      process.exit(1)
+    }
+
+    // 断开 Redis
+    await redis.disconnect()
+    console.log('\n👋 测试完成')
+    process.exit(0)
+  } catch (error) {
+    console.error('❌ 测试失败:', error)
+    logger.error('Test failed:', error)
+    process.exit(1)
+  }
+}
+
+// 运行主函数
+main()

--- a/src/app.js
+++ b/src/app.js
@@ -620,6 +620,16 @@ class Application {
     }, 60000) // 每分钟执行一次
 
     logger.info('🔢 Concurrency cleanup task started (running every 1 minute)')
+
+    // 📊 启动使用额度告警服务
+    try {
+      const usageAlertService = require('./services/usageAlertService')
+      usageAlertService.start().catch((error) => {
+        logger.error('❌ Failed to start usage alert service:', error)
+      })
+    } catch (error) {
+      logger.error('❌ Failed to load usage alert service:', error)
+    }
   }
 
   setupGracefulShutdown() {
@@ -654,6 +664,15 @@ class Application {
             logger.info('🚨 Rate limit cleanup service stopped')
           } catch (error) {
             logger.error('❌ Error stopping rate limit cleanup service:', error)
+          }
+
+          // 停止使用额度告警服务
+          try {
+            const usageAlertService = require('./services/usageAlertService')
+            usageAlertService.stop()
+            logger.info('📊 Usage alert service stopped')
+          } catch (error) {
+            logger.error('❌ Error stopping usage alert service:', error)
           }
 
           // 🔢 清理所有并发计数（Phase 1 修复：防止重启泄漏）

--- a/src/services/usageAlertService.js
+++ b/src/services/usageAlertService.js
@@ -1,0 +1,375 @@
+const redis = require('../models/redis')
+const logger = require('../utils/logger')
+const webhookService = require('./webhookService')
+const claudeAccountService = require('./claudeAccountService')
+const claudeConsoleAccountService = require('./claudeConsoleAccountService')
+const config = require('../../config/config')
+
+/**
+ * 使用额度告警服务
+ * 监控 Claude 账号的使用情况，当达到阈值时发送告警
+ */
+class UsageAlertService {
+  constructor() {
+    // 告警阈值配置（百分比）
+    this.thresholds = [
+      { level: 80, key: '80' },
+      { level: 90, key: '90' }
+    ]
+
+    // 检查间隔（默认每小时检查一次）
+    this.checkInterval = parseInt(process.env.USAGE_ALERT_CHECK_INTERVAL) || 60 * 60 * 1000 // 1 hour
+
+    // 告警抑制时间（避免重复告警，默认24小时）
+    this.alertSuppressionTime =
+      parseInt(process.env.USAGE_ALERT_SUPPRESSION_TIME) || 24 * 60 * 60 * 1000 // 24 hours
+
+    // 是否启用告警
+    this.enabled = process.env.USAGE_ALERT_ENABLED !== 'false'
+
+    // 定时器引用
+    this.intervalId = null
+
+    logger.info('📊 Usage Alert Service initialized', {
+      enabled: this.enabled,
+      checkInterval: `${this.checkInterval / 1000}s`,
+      alertSuppressionTime: `${this.alertSuppressionTime / 1000}s`,
+      thresholds: this.thresholds.map((t) => `${t.level}%`)
+    })
+  }
+
+  /**
+   * 启动告警服务
+   */
+  async start() {
+    if (!this.enabled) {
+      logger.info('⏸️  Usage Alert Service is disabled')
+      return
+    }
+
+    logger.info('🚀 Starting Usage Alert Service...')
+
+    // 立即执行一次检查
+    await this.checkAllAccounts()
+
+    // 设置定期检查
+    this.intervalId = setInterval(async () => {
+      try {
+        await this.checkAllAccounts()
+      } catch (error) {
+        logger.error('❌ Usage alert check failed:', error)
+      }
+    }, this.checkInterval)
+
+    logger.info(`✅ Usage Alert Service started, checking every ${this.checkInterval / 1000}s`)
+  }
+
+  /**
+   * 停止告警服务
+   */
+  stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+      logger.info('🛑 Usage Alert Service stopped')
+    }
+  }
+
+  /**
+   * 检查所有账号的使用情况
+   */
+  async checkAllAccounts() {
+    try {
+      logger.debug('🔍 Checking usage for all Claude accounts...')
+
+      // 获取所有 Claude 账号（claude-official 和 claude-console）
+      const officialAccounts = await claudeAccountService.getAllAccounts()
+      const consoleAccounts = await claudeConsoleAccountService.getAllAccounts()
+
+      const allAccounts = [
+        ...officialAccounts.map((acc) => ({ ...acc, accountType: 'claude-official' })),
+        ...consoleAccounts.map((acc) => ({ ...acc, accountType: 'claude-console' }))
+      ]
+
+      logger.debug(`📋 Found ${allAccounts.length} Claude accounts to check`)
+
+      let alertCount = 0
+
+      // 检查每个账号
+      for (const account of allAccounts) {
+        try {
+          // 只检查活跃账号
+          if (account.status !== 'active' || account.isActive !== 'true') {
+            continue
+          }
+
+          const shouldAlert = await this.checkAccountUsage(account)
+          if (shouldAlert) {
+            alertCount++
+          }
+        } catch (error) {
+          logger.error(`❌ Failed to check usage for account ${account.name}:`, error)
+        }
+      }
+
+      if (alertCount > 0) {
+        logger.info(`📢 Sent ${alertCount} usage alerts`)
+      } else {
+        logger.debug('✅ All accounts within usage limits')
+      }
+    } catch (error) {
+      logger.error('❌ Failed to check all accounts:', error)
+      throw error
+    }
+  }
+
+  /**
+   * 检查单个账号的使用情况
+   * @param {Object} account - 账号信息
+   * @returns {boolean} - 是否发送了告警
+   */
+  async checkAccountUsage(account) {
+    try {
+      // 获取账号的订阅信息
+      const subscriptionInfo = this.getSubscriptionInfo(account)
+      if (!subscriptionInfo || !subscriptionInfo.monthlyLimit) {
+        logger.debug(`⏭️  Skipping account ${account.name}: no subscription info or monthly limit`)
+        return false
+      }
+
+      // 获取账号的使用情况
+      const usage = await this.getAccountUsage(account)
+      if (!usage) {
+        logger.debug(`⏭️  Skipping account ${account.name}: unable to get usage data`)
+        return false
+      }
+
+      // 计算使用百分比
+      const usagePercent = (usage.totalCost / subscriptionInfo.monthlyLimit) * 100
+
+      logger.debug(
+        `📊 Account ${account.name}: ${usage.totalCost.toFixed(2)}/${subscriptionInfo.monthlyLimit} USD (${usagePercent.toFixed(1)}%)`
+      )
+
+      // 检查是否超过任何阈值
+      for (const threshold of this.thresholds) {
+        if (usagePercent >= threshold.level) {
+          // 检查是否已经发送过告警（避免重复告警）
+          const alreadyAlerted = await this.hasRecentAlert(account.id, threshold.key)
+          if (!alreadyAlerted) {
+            await this.sendAlert(account, usage, subscriptionInfo, threshold.level, usagePercent)
+            await this.markAlertSent(account.id, threshold.key)
+            return true
+          } else {
+            logger.debug(
+              `⏭️  Skipping alert for ${account.name} at ${threshold.level}%: recently alerted`
+            )
+          }
+        }
+      }
+
+      return false
+    } catch (error) {
+      logger.error(`❌ Failed to check usage for account ${account.name}:`, error)
+      return false
+    }
+  }
+
+  /**
+   * 获取账号的订阅信息
+   * @param {Object} account - 账号信息
+   * @returns {Object|null} - 订阅信息
+   */
+  getSubscriptionInfo(account) {
+    try {
+      if (!account.subscriptionInfo || account.subscriptionInfo === '') {
+        return null
+      }
+
+      const subscriptionInfo =
+        typeof account.subscriptionInfo === 'string'
+          ? JSON.parse(account.subscriptionInfo)
+          : account.subscriptionInfo
+
+      // 支持不同格式的订阅信息
+      // 格式1: { monthlyLimit: 100 } (USD)
+      // 格式2: { plan: 'pro', limit: { monthly: 100 } }
+      // 格式3: { quota: { monthly: 100 } }
+      let monthlyLimit = null
+
+      if (subscriptionInfo.monthlyLimit) {
+        monthlyLimit = subscriptionInfo.monthlyLimit
+      } else if (subscriptionInfo.limit && subscriptionInfo.limit.monthly) {
+        monthlyLimit = subscriptionInfo.limit.monthly
+      } else if (subscriptionInfo.quota && subscriptionInfo.quota.monthly) {
+        monthlyLimit = subscriptionInfo.quota.monthly
+      }
+
+      if (!monthlyLimit || monthlyLimit <= 0) {
+        return null
+      }
+
+      return {
+        ...subscriptionInfo,
+        monthlyLimit
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to parse subscription info for ${account.name}:`, error)
+      return null
+    }
+  }
+
+  /**
+   * 获取账号的使用情况
+   * @param {Object} account - 账号信息
+   * @returns {Object|null} - 使用情况 { totalCost, inputTokens, outputTokens, requestCount }
+   */
+  async getAccountUsage(account) {
+    try {
+      // 获取当前月份的使用数据
+      const now = new Date()
+      const year = now.getFullYear()
+      const month = String(now.getMonth() + 1).padStart(2, '0')
+      const currentMonth = `${year}-${month}`
+
+      // 从 Redis 获取账号的月度使用统计
+      // 键格式: account_usage:monthly:{accountId}:{month}
+      const usageKey = `account_usage:monthly:${account.id}:${currentMonth}`
+      const usageData = await redis.hgetall(usageKey)
+
+      if (!usageData || Object.keys(usageData).length === 0) {
+        // 如果没有月度统计，尝试获取总使用统计
+        const totalUsageKey = `account_usage:${account.id}`
+        const totalUsageData = await redis.hgetall(totalUsageKey)
+
+        if (!totalUsageData || Object.keys(totalUsageData).length === 0) {
+          return null
+        }
+
+        // 使用总统计数据
+        return {
+          totalCost: parseFloat(totalUsageData.totalCost || 0),
+          inputTokens: parseInt(totalUsageData.inputTokens || 0),
+          outputTokens: parseInt(totalUsageData.outputTokens || 0),
+          requestCount: parseInt(totalUsageData.requestCount || 0)
+        }
+      }
+
+      // 返回月度统计数据
+      return {
+        totalCost: parseFloat(usageData.totalCost || 0),
+        inputTokens: parseInt(usageData.inputTokens || 0),
+        outputTokens: parseInt(usageData.outputTokens || 0),
+        requestCount: parseInt(usageData.requestCount || 0)
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to get usage for account ${account.name}:`, error)
+      return null
+    }
+  }
+
+  /**
+   * 发送使用额度告警
+   * @param {Object} account - 账号信息
+   * @param {Object} usage - 使用情况
+   * @param {Object} subscriptionInfo - 订阅信息
+   * @param {number} threshold - 告警阈值
+   * @param {number} usagePercent - 实际使用百分比
+   */
+  async sendAlert(account, usage, subscriptionInfo, threshold, usagePercent) {
+    try {
+      const alertData = {
+        accountName: account.name,
+        accountId: account.id,
+        platform: account.accountType || account.platform || 'claude',
+        threshold: `${threshold}%`,
+        usage: usagePercent.toFixed(1),
+        usageCost: usage.totalCost.toFixed(2),
+        monthlyLimit: subscriptionInfo.monthlyLimit.toFixed(2),
+        remainingCost: (subscriptionInfo.monthlyLimit - usage.totalCost).toFixed(2),
+        inputTokens: usage.inputTokens.toLocaleString(),
+        outputTokens: usage.outputTokens.toLocaleString(),
+        requestCount: usage.requestCount.toLocaleString(),
+        message: `账号 "${account.name}" 使用额度已达 ${usagePercent.toFixed(1)}%（${usage.totalCost.toFixed(2)}/${subscriptionInfo.monthlyLimit.toFixed(2)} USD），剩余额度 ${(subscriptionInfo.monthlyLimit - usage.totalCost).toFixed(2)} USD`
+      }
+
+      logger.warn(`⚠️  Usage alert for ${account.name}: ${alertData.message}`)
+
+      // 发送 webhook 通知
+      await webhookService.sendNotification('quotaWarning', alertData)
+
+      logger.info(`✅ Usage alert sent for ${account.name} at ${threshold}% threshold`)
+    } catch (error) {
+      logger.error(`❌ Failed to send usage alert for ${account.name}:`, error)
+    }
+  }
+
+  /**
+   * 检查是否最近已发送过告警
+   * @param {string} accountId - 账号ID
+   * @param {string} thresholdKey - 阈值键（80, 90）
+   * @returns {boolean} - 是否最近已告警
+   */
+  async hasRecentAlert(accountId, thresholdKey) {
+    try {
+      const alertKey = `usage_alert:${accountId}:${thresholdKey}`
+      const lastAlertTime = await redis.get(alertKey)
+
+      if (!lastAlertTime) {
+        return false
+      }
+
+      const lastAlertTimestamp = parseInt(lastAlertTime)
+      const now = Date.now()
+
+      // 检查是否在抑制时间内
+      return now - lastAlertTimestamp < this.alertSuppressionTime
+    } catch (error) {
+      logger.error('❌ Failed to check alert status:', error)
+      return false
+    }
+  }
+
+  /**
+   * 标记告警已发送
+   * @param {string} accountId - 账号ID
+   * @param {string} thresholdKey - 阈值键（80, 90）
+   */
+  async markAlertSent(accountId, thresholdKey) {
+    try {
+      const alertKey = `usage_alert:${accountId}:${thresholdKey}`
+      const now = Date.now()
+
+      // 设置告警时间戳，带过期时间
+      await redis.setex(alertKey, Math.floor(this.alertSuppressionTime / 1000), now.toString())
+    } catch (error) {
+      logger.error('❌ Failed to mark alert sent:', error)
+    }
+  }
+
+  /**
+   * 手动触发检查（用于测试）
+   */
+  async triggerCheck() {
+    logger.info('🔧 Manually triggering usage check...')
+    await this.checkAllAccounts()
+  }
+
+  /**
+   * 清除指定账号的告警记录（用于测试）
+   * @param {string} accountId - 账号ID
+   */
+  async clearAlertHistory(accountId) {
+    try {
+      for (const threshold of this.thresholds) {
+        const alertKey = `usage_alert:${accountId}:${threshold.key}`
+        await redis.del(alertKey)
+      }
+      logger.info(`✅ Cleared alert history for account ${accountId}`)
+    } catch (error) {
+      logger.error(`❌ Failed to clear alert history for account ${accountId}:`, error)
+    }
+  }
+}
+
+module.exports = new UsageAlertService()


### PR DESCRIPTION
…ifications

添加 Claude 账号使用额度告警功能，支持 Telegram 和邮件 SMTP 通知

新增功能:
- 使用额度监控服务 (usageAlertService.js)
  - 定期检查所有 Claude 账号的使用情况
  - 支持 80% 和 90% 两个告警阈值
  - 自动从 Redis 读取账号使用统计和订阅限额
  - 告警抑制机制，避免重复发送通知

- Telegram Bot 通知
  - 通过现有的 webhookService 发送 Telegram 消息
  - 支持自定义 API 地址和代理配置
  - 格式化的告警消息，包含账号名称、使用量、剩余额度等

- SMTP 邮件通知
  - 通过现有的 webhookService 发送邮件告警
  - HTML 和纯文本双格式支持
  - 美观的邮件模板设计

- 配置选项
  - USAGE_ALERT_ENABLED: 启用/禁用告警 (默认启用)
  - USAGE_ALERT_CHECK_INTERVAL: 检查间隔 (默认 1 小时)
  - USAGE_ALERT_SUPPRESSION_TIME: 告警抑制时间 (默认 24 小时)

- 测试脚本 (scripts/test-usage-alerts.js)
  - 列出所有活跃账号
  - 模拟设置账号使用量
  - 手动触发告警检查
  - 清除告警历史

修改文件:
- src/services/usageAlertService.js (新增)
- scripts/test-usage-alerts.js (新增)
- src/app.js (集成告警服务)
- .env.example (添加配置说明)
- config/config.example.js (添加配置项)
- CLAUDE.md (添加使用说明)

使用方法:
1. 在 .env 中启用告警: USAGE_ALERT_ENABLED=true
2. 在 Web 界面配置账号月度限额: subscriptionInfo.monthlyLimit
3. 在 Web 界面配置 Telegram/SMTP Webhook
4. 系统自动每小时检查一次，达到阈值时发送通知

测试方法:
node scripts/test-usage-alerts.js --list-accounts
node scripts/test-usage-alerts.js --account-id <id> --usage-percent 85 node scripts/test-usage-alerts.js --trigger