### PR TITLE
fix: 添加对gpt-5.1模型的提示词判断

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -260,7 +260,8 @@ const handleResponses = async (req, res) => {
     // 判断是否为 Codex CLI 的请求
     const isCodexCLI =
       req.body?.instructions?.startsWith('You are a coding agent running in the Codex CLI') ||
-      req.body?.instructions?.startsWith('You are Codex')
+      req.body?.instructions?.startsWith('You are Codex') ||
+      req.body?.instructions?.startsWith('You are GPT-5.1 running in the Codex CLI')
 
     // 如果不是 Codex CLI 请求，则进行适配
     if (!isCodexCLI) {


### PR DESCRIPTION
```
You are GPT-5.1 running in the Codex CLI, a terminal-based coding assistant. Codex CLI is an open source project led by OpenAI. You are expected to be precise, safe, and helpful.
```
添加对gpt5.1模型的提示词检测
选择5.1模型会导致判断为非cli客户端，5.1的提示词被覆盖