### PR TITLE
[fix] Add cache token capture for Droid OpenAI endpoint

### DIFF
--- a/src/services/droidRelayService.js
+++ b/src/services/droidRelayService.js
@@ -737,6 +737,14 @@ class DroidRelayService {
                 currentUsageData.output_tokens = 0
               }
 
+              // Capture cache tokens from OpenAI format
+              currentUsageData.cache_read_input_tokens =
+                data.usage.input_tokens_details?.cached_tokens || 0
+              currentUsageData.cache_creation_input_tokens =
+                data.usage.input_tokens_details?.cache_creation_input_tokens ||
+                data.usage.cache_creation_input_tokens ||
+                0
+
               logger.debug('📊 Droid OpenAI usage:', currentUsageData)
             }
 
@@ -757,6 +765,14 @@ class DroidRelayService {
               } else {
                 currentUsageData.output_tokens = 0
               }
+
+              // Capture cache tokens from OpenAI Response API format
+              currentUsageData.cache_read_input_tokens =
+                usage.input_tokens_details?.cached_tokens || 0
+              currentUsageData.cache_creation_input_tokens =
+                usage.input_tokens_details?.cache_creation_input_tokens ||
+                usage.cache_creation_input_tokens ||
+                0
 
               logger.debug('📊 Droid OpenAI response usage:', currentUsageData)
             }


### PR DESCRIPTION
## Summary

- Add cache token extraction in `_parseOpenAIUsageFromSSE` method for Droid relay service
- Captures `cache_read_input_tokens` from `input_tokens_details.cached_tokens`
- Captures `cache_creation_input_tokens` from both `input_tokens_details` and top-level usage object

## Problem

The Droid relay service correctly captures cache tokens for Anthropic endpoint (in `_parseAnthropicUsageFromSSE`), but the OpenAI endpoint (`_parseOpenAIUsageFromSSE`) was missing this functionality. This caused:

- Cache statistics not being recorded for OpenAI models (GPT-5/Codex) via Droid provider
- Incorrect cost calculation (all tokens counted as regular input instead of cheaper cached tokens)

## Changes

Added cache token capture in two places within `_parseOpenAIUsageFromSSE`:
1. Traditional Chat Completions format (`data.usage`)
2. New Response API format (`data.response.usage`)

## Test plan

- [ ] Send request through Droid OpenAI endpoint to GPT-5/Codex
- [ ] Verify `cache_read_input_tokens` and `cache_creation_input_tokens` appear in logs
- [ ] Repeat request and confirm `cache_read_input_tokens > 0` on cache hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)