### PR TITLE
feat: 修复 userMessageQueue 配置缺失导致的 500 错误

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -203,6 +203,14 @@ const config = {
   development: {
     debug: process.env.DEBUG === 'true',
     hotReload: process.env.HOT_RELOAD === 'true'
+  },
+
+  // 📬 用户消息队列配置
+  userMessageQueue: {
+    enabled: process.env.USER_MESSAGE_QUEUE_ENABLED === 'true', // 默认关闭
+    delayMs: parseInt(process.env.USER_MESSAGE_QUEUE_DELAY_MS) || 100, // 请求间隔（毫秒）
+    timeoutMs: parseInt(process.env.USER_MESSAGE_QUEUE_TIMEOUT_MS) || 60000, // 队列等待超时（毫秒）
+    lockTtlMs: 120000 // 锁租约TTL（毫秒），会在请求期间自动续租以防死锁
   }
 }
 

--- a/src/services/userMessageQueueService.js
+++ b/src/services/userMessageQueueService.js
@@ -73,6 +73,15 @@ class UserMessageQueueService {
    * @returns {Promise<Object>} 配置对象
    */
   async getConfig() {
+    // 默认配置（防止 config.userMessageQueue 未定义）
+    const queueConfig = config.userMessageQueue || {}
+    const defaults = {
+      enabled: queueConfig.enabled ?? false,
+      delayMs: queueConfig.delayMs ?? 100,
+      timeoutMs: queueConfig.timeoutMs ?? 60000,
+      lockTtlMs: queueConfig.lockTtlMs ?? 120000
+    }
+
     // 尝试从 claudeRelayConfigService 获取 Web 界面配置
     try {
       const claudeRelayConfigService = require('./claudeRelayConfigService')
@@ -82,25 +91,20 @@ class UserMessageQueueService {
         enabled:
           webConfig.userMessageQueueEnabled !== undefined
             ? webConfig.userMessageQueueEnabled
-            : config.userMessageQueue.enabled,
+            : defaults.enabled,
         delayMs:
           webConfig.userMessageQueueDelayMs !== undefined
             ? webConfig.userMessageQueueDelayMs
-            : config.userMessageQueue.delayMs,
+            : defaults.delayMs,
         timeoutMs:
           webConfig.userMessageQueueTimeoutMs !== undefined
             ? webConfig.userMessageQueueTimeoutMs
-            : config.userMessageQueue.timeoutMs,
-        lockTtlMs: config.userMessageQueue.lockTtlMs
+            : defaults.timeoutMs,
+        lockTtlMs: defaults.lockTtlMs
       }
     } catch {
       // 回退到环境变量配置
-      return {
-        enabled: config.userMessageQueue.enabled,
-        delayMs: config.userMessageQueue.delayMs,
-        timeoutMs: config.userMessageQueue.timeoutMs,
-        lockTtlMs: config.userMessageQueue.lockTtlMs
-      }
+      return defaults
     }
   }
 


### PR DESCRIPTION
  - 在 config.example.js 添加缺失的 userMessageQueue 配置段
  - 在 userMessageQueueService.js 添加防御性代码，当配置未定义时使用默认值

  修复 #783 合并后安装报错：
  Cannot read properties of undefined (reading 'enabled')