### PR TITLE
fix: 账户列表默认显示限额/限流账号并加固加载健壮性

### DIFF
--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -2049,7 +2049,7 @@ const bindingCounts = ref({}) // 轻量级绑定计数，用于显示"绑定: X 
 const accountGroups = ref([])
 const groupFilter = ref('all')
 const platformFilter = ref('all')
-const statusFilter = ref('normal') // 状态过滤 (normal/rateLimited/other/all)
+const statusFilter = ref('all') // 状态过滤 (normal/rateLimited/other/all)
 const searchKeyword = ref('')
 const PAGE_SIZE_STORAGE_KEY = 'accountsPageSize'
 const getInitialPageSize = () => {
@@ -2804,11 +2804,12 @@ const loadAccounts = async (forceReload = false) => {
     let openaiResponsesRaw = []
 
     const appendAccounts = (platform, data) => {
-      if (!data || data.length === 0) return
+      const list = Array.isArray(data) ? data : []
+      if (list.length === 0) return
 
       switch (platform) {
         case 'claude': {
-          const items = data.map((acc) => {
+          const items = list.map((acc) => {
             const boundApiKeysCount = counts.claudeAccountId?.[acc.id] || 0
             return { ...acc, platform: 'claude', boundApiKeysCount }
           })
@@ -2816,7 +2817,7 @@ const loadAccounts = async (forceReload = false) => {
           break
         }
         case 'claude-console': {
-          const items = data.map((acc) => {
+          const items = list.map((acc) => {
             const boundApiKeysCount = counts.claudeConsoleAccountId?.[acc.id] || 0
             return { ...acc, platform: 'claude-console', boundApiKeysCount }
           })
@@ -2824,12 +2825,12 @@ const loadAccounts = async (forceReload = false) => {
           break
         }
         case 'bedrock': {
-          const items = data.map((acc) => ({ ...acc, platform: 'bedrock', boundApiKeysCount: 0 }))
+          const items = list.map((acc) => ({ ...acc, platform: 'bedrock', boundApiKeysCount: 0 }))
           allAccounts.push(...items)
           break
         }
         case 'gemini': {
-          const items = data.map((acc) => {
+          const items = list.map((acc) => {
             const boundApiKeysCount = counts.geminiAccountId?.[acc.id] || 0
             return { ...acc, platform: 'gemini', boundApiKeysCount }
           })
@@ -2837,7 +2838,7 @@ const loadAccounts = async (forceReload = false) => {
           break
         }
         case 'openai': {
-          const items = data.map((acc) => {
+          const items = list.map((acc) => {
             const boundApiKeysCount = counts.openaiAccountId?.[acc.id] || 0
             return { ...acc, platform: 'openai', boundApiKeysCount }
           })
@@ -2845,7 +2846,7 @@ const loadAccounts = async (forceReload = false) => {
           break
         }
         case 'azure_openai': {
-          const items = data.map((acc) => {
+          const items = list.map((acc) => {
             const boundApiKeysCount = counts.azureOpenaiAccountId?.[acc.id] || 0
             return { ...acc, platform: 'azure_openai', boundApiKeysCount }
           })
@@ -2853,16 +2854,16 @@ const loadAccounts = async (forceReload = false) => {
           break
         }
         case 'openai-responses': {
-          openaiResponsesRaw = data
+          openaiResponsesRaw = list
           break
         }
         case 'ccr': {
-          const items = data.map((acc) => ({ ...acc, platform: 'ccr', boundApiKeysCount: 0 }))
+          const items = list.map((acc) => ({ ...acc, platform: 'ccr', boundApiKeysCount: 0 }))
           allAccounts.push(...items)
           break
         }
         case 'droid': {
-          const items = data.map((acc) => {
+          const items = list.map((acc) => {
             const boundApiKeysCount = counts.droidAccountId?.[acc.id] || acc.boundApiKeysCount || 0
             return { ...acc, platform: 'droid', boundApiKeysCount }
           })
@@ -2870,7 +2871,7 @@ const loadAccounts = async (forceReload = false) => {
           break
         }
         case 'gemini-api': {
-          const items = data.map((acc) => {
+          const items = list.map((acc) => {
             const boundApiKeysCount = counts.geminiAccountId?.[`api:${acc.id}`] || 0
             return { ...acc, platform: 'gemini-api', boundApiKeysCount }
           })


### PR DESCRIPTION
为了定位 #777 问题
  - 将账户页状态筛选默认值从 normal 改为 all，额度满/限流/异常账号默认可见
  - appendAccounts 使用 Array.isArray 兜底接口响应，避免空/异常数据导致“加载账户失败”
  - 便于在额度耗尽场景查看并处理账号