### PR TITLE
fix: improve logging for client disconnections in relay services

### DIFF
--- a/src/services/ccrRelayService.js
+++ b/src/services/ccrRelayService.js
@@ -448,7 +448,14 @@ class CcrRelayService {
       // 更新最后使用时间
       await this._updateLastUsedTime(accountId)
     } catch (error) {
-      logger.error(`❌ CCR stream relay failed (Account: ${account?.name || accountId}):`, error)
+      // 客户端主动断开连接是正常情况，使用 INFO 级别
+      if (error.message === 'Client disconnected') {
+        logger.info(
+          `🔌 CCR stream relay ended: Client disconnected (Account: ${account?.name || accountId})`
+        )
+      } else {
+        logger.error(`❌ CCR stream relay failed (Account: ${account?.name || accountId}):`, error)
+      }
       throw error
     } finally {
       // 📬 释放用户消息队列锁

--- a/src/services/claudeConsoleRelayService.js
+++ b/src/services/claudeConsoleRelayService.js
@@ -635,10 +635,17 @@ class ClaudeConsoleRelayService {
       // 更新最后使用时间
       await this._updateLastUsedTime(accountId)
     } catch (error) {
-      logger.error(
-        `❌ Claude Console stream relay failed (Account: ${account?.name || accountId}):`,
-        error
-      )
+      // 客户端主动断开连接是正常情况，使用 INFO 级别
+      if (error.message === 'Client disconnected') {
+        logger.info(
+          `🔌 Claude Console stream relay ended: Client disconnected (Account: ${account?.name || accountId})`
+        )
+      } else {
+        logger.error(
+          `❌ Claude Console stream relay failed (Account: ${account?.name || accountId}):`,
+          error
+        )
+      }
       throw error
     } finally {
       // 🛑 清理租约刷新定时器

--- a/src/services/claudeRelayService.js
+++ b/src/services/claudeRelayService.js
@@ -1428,7 +1428,12 @@ class ClaudeRelayService {
         isDedicatedOfficialAccount
       )
     } catch (error) {
-      logger.error(`❌ Claude stream relay with usage capture failed:`, error)
+      // 客户端主动断开连接是正常情况，使用 INFO 级别
+      if (error.message === 'Client disconnected') {
+        logger.info(`🔌 Claude stream relay ended: Client disconnected`)
+      } else {
+        logger.error(`❌ Claude stream relay with usage capture failed:`, error)
+      }
       throw error
     } finally {
       // 📬 释放用户消息队列锁

--- a/src/services/droidRelayService.js
+++ b/src/services/droidRelayService.js
@@ -336,7 +336,12 @@ class DroidRelayService {
         )
       }
     } catch (error) {
-      logger.error(`❌ Droid relay error: ${error.message}`, error)
+      // 客户端主动断开连接是正常情况，使用 INFO 级别
+      if (error.message === 'Client disconnected') {
+        logger.info(`🔌 Droid relay ended: Client disconnected`)
+      } else {
+        logger.error(`❌ Droid relay error: ${error.message}`, error)
+      }
 
       const status = error?.response?.status
       if (status >= 400 && status < 500) {


### PR DESCRIPTION
当客户端主动断开连接时，改为使用 INFO 级别记录而不是 ERROR 级别，
因为这是正常情况而非错误。

- ccrRelayService: 区分客户端断开与实际错误
- claudeConsoleRelayService: 区分客户端断开与实际错误
- claudeRelayService: 区分客户端断开与实际错误
- droidRelayService: 区分客户端断开与实际错误