### PR TITLE
fix: 去掉 Gemini API 的 /models 限制

### DIFF
--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -1553,7 +1553,7 @@
                   {{ errors.baseUrl }}
                 </p>
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  填写 API 基础地址，必须以
+                  填写 API 基础地址，一般以
                   <code class="rounded bg-gray-100 px-1 dark:bg-gray-600">/models</code>
                   结尾。系统会自动拼接
                   <code class="rounded bg-gray-100 px-1 dark:bg-gray-600"
@@ -3256,7 +3256,7 @@
                 {{ errors.baseUrl }}
               </p>
               <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                填写 API 基础地址，必须以
+                填写 API 基础地址，一般以
                 <code class="rounded bg-gray-100 px-1 dark:bg-gray-600">/models</code>
                 结尾。系统会自动拼接
                 <code class="rounded bg-gray-100 px-1 dark:bg-gray-600"
@@ -4940,12 +4940,9 @@ const createAccount = async () => {
         errors.value.apiKey = '请填写 API Key'
         hasError = true
       }
-      // 验证 baseUrl 必须以 /models 结尾
+      // 验证 baseUrl
       if (!form.value.baseUrl || form.value.baseUrl.trim() === '') {
         errors.value.baseUrl = '请填写 API 基础地址'
-        hasError = true
-      } else if (!form.value.baseUrl.trim().endsWith('/models')) {
-        errors.value.baseUrl = 'API 基础地址必须以 /models 结尾'
         hasError = true
       }
     } else {
@@ -5223,15 +5220,11 @@ const updateAccount = async () => {
     return
   }
 
-  // Gemini API 的 baseUrl 验证（必须以 /models 结尾）
+  // Gemini API 的 baseUrl 验证
   if (form.value.platform === 'gemini-api') {
     const baseUrl = form.value.baseUrl?.trim() || ''
     if (!baseUrl) {
       errors.value.baseUrl = '请填写 API 基础地址'
-      return
-    }
-    if (!baseUrl.endsWith('/models')) {
-      errors.value.baseUrl = 'API 基础地址必须以 /models 结尾'
       return
     }
   }


### PR DESCRIPTION
有一些三方的`Gemini`接口转发平台中，不能用`/models`结尾的，会导致重复添加`/models`到基础 url 上，去掉这一层才能兼容的。改成建议设置`/models`结尾的。