### PR TITLE
  feat: enhance concurrency queue with health check and admin endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,8 @@ TOKEN_USAGE_RETENTION=2592000000
 HEALTH_CHECK_INTERVAL=60000
 TIMEZONE_OFFSET=8  # UTC偏移小时数，默认+8（中国时区）
 METRICS_WINDOW=5  # 实时指标统计窗口（分钟），可选1-60，默认5分钟
+# 启动时清理残留的并发排队计数器（默认true，多实例部署时建议设为false）
+CLEAR_CONCURRENCY_QUEUES_ON_STARTUP=true
 
 # 🎨 Web 界面配置
 WEB_TITLE=Claude Relay Service

--- a/src/routes/admin/claudeRelayConfig.js
+++ b/src/routes/admin/claudeRelayConfig.js
@@ -43,7 +43,11 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       sessionBindingTtlDays,
       userMessageQueueEnabled,
       userMessageQueueDelayMs,
-      userMessageQueueTimeoutMs
+      userMessageQueueTimeoutMs,
+      concurrentRequestQueueEnabled,
+      concurrentRequestQueueMaxSize,
+      concurrentRequestQueueMaxSizeMultiplier,
+      concurrentRequestQueueTimeoutMs
     } = req.body
 
     // 验证输入
@@ -110,6 +114,54 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       }
     }
 
+    // 验证并发请求排队配置
+    if (
+      concurrentRequestQueueEnabled !== undefined &&
+      typeof concurrentRequestQueueEnabled !== 'boolean'
+    ) {
+      return res.status(400).json({ error: 'concurrentRequestQueueEnabled must be a boolean' })
+    }
+
+    if (concurrentRequestQueueMaxSize !== undefined) {
+      if (
+        typeof concurrentRequestQueueMaxSize !== 'number' ||
+        !Number.isInteger(concurrentRequestQueueMaxSize) ||
+        concurrentRequestQueueMaxSize < 1 ||
+        concurrentRequestQueueMaxSize > 100
+      ) {
+        return res
+          .status(400)
+          .json({ error: 'concurrentRequestQueueMaxSize must be an integer between 1 and 100' })
+      }
+    }
+
+    if (concurrentRequestQueueMaxSizeMultiplier !== undefined) {
+      // 使用 Number.isFinite() 同时排除 NaN、Infinity、-Infinity 和非数字类型
+      if (
+        !Number.isFinite(concurrentRequestQueueMaxSizeMultiplier) ||
+        concurrentRequestQueueMaxSizeMultiplier < 0 ||
+        concurrentRequestQueueMaxSizeMultiplier > 10
+      ) {
+        return res.status(400).json({
+          error: 'concurrentRequestQueueMaxSizeMultiplier must be a finite number between 0 and 10'
+        })
+      }
+    }
+
+    if (concurrentRequestQueueTimeoutMs !== undefined) {
+      if (
+        typeof concurrentRequestQueueTimeoutMs !== 'number' ||
+        !Number.isInteger(concurrentRequestQueueTimeoutMs) ||
+        concurrentRequestQueueTimeoutMs < 5000 ||
+        concurrentRequestQueueTimeoutMs > 300000
+      ) {
+        return res.status(400).json({
+          error:
+            'concurrentRequestQueueTimeoutMs must be an integer between 5000 and 300000 (5 seconds to 5 minutes)'
+        })
+      }
+    }
+
     const updateData = {}
     if (claudeCodeOnlyEnabled !== undefined) {
       updateData.claudeCodeOnlyEnabled = claudeCodeOnlyEnabled
@@ -131,6 +183,18 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
     }
     if (userMessageQueueTimeoutMs !== undefined) {
       updateData.userMessageQueueTimeoutMs = userMessageQueueTimeoutMs
+    }
+    if (concurrentRequestQueueEnabled !== undefined) {
+      updateData.concurrentRequestQueueEnabled = concurrentRequestQueueEnabled
+    }
+    if (concurrentRequestQueueMaxSize !== undefined) {
+      updateData.concurrentRequestQueueMaxSize = concurrentRequestQueueMaxSize
+    }
+    if (concurrentRequestQueueMaxSizeMultiplier !== undefined) {
+      updateData.concurrentRequestQueueMaxSizeMultiplier = concurrentRequestQueueMaxSizeMultiplier
+    }
+    if (concurrentRequestQueueTimeoutMs !== undefined) {
+      updateData.concurrentRequestQueueTimeoutMs = concurrentRequestQueueTimeoutMs
     }
 
     const updatedConfig = await claudeRelayConfigService.updateConfig(

--- a/src/routes/admin/concurrency.js
+++ b/src/routes/admin/concurrency.js
@@ -8,6 +8,7 @@ const router = express.Router()
 const redis = require('../../models/redis')
 const logger = require('../../utils/logger')
 const { authenticateAdmin } = require('../../middleware/auth')
+const { calculateWaitTimeStats } = require('../../utils/statsHelper')
 
 /**
  * GET /admin/concurrency
@@ -17,23 +18,185 @@ router.get('/concurrency', authenticateAdmin, async (req, res) => {
   try {
     const status = await redis.getAllConcurrencyStatus()
 
+    // 为每个 API Key 获取排队计数
+    const statusWithQueue = await Promise.all(
+      status.map(async (s) => {
+        const queueCount = await redis.getConcurrencyQueueCount(s.apiKeyId)
+        return {
+          ...s,
+          queueCount
+        }
+      })
+    )
+
     // 计算汇总统计
     const summary = {
-      totalKeys: status.length,
-      totalActiveRequests: status.reduce((sum, s) => sum + s.activeCount, 0),
-      totalExpiredRequests: status.reduce((sum, s) => sum + s.expiredCount, 0)
+      totalKeys: statusWithQueue.length,
+      totalActiveRequests: statusWithQueue.reduce((sum, s) => sum + s.activeCount, 0),
+      totalExpiredRequests: statusWithQueue.reduce((sum, s) => sum + s.expiredCount, 0),
+      totalQueuedRequests: statusWithQueue.reduce((sum, s) => sum + s.queueCount, 0)
     }
 
     res.json({
       success: true,
       summary,
-      concurrencyStatus: status
+      concurrencyStatus: statusWithQueue
     })
   } catch (error) {
     logger.error('❌ Failed to get concurrency status:', error)
     res.status(500).json({
       success: false,
       error: 'Failed to get concurrency status',
+      message: error.message
+    })
+  }
+})
+
+/**
+ * GET /admin/concurrency-queue/stats
+ * 获取排队统计信息
+ */
+router.get('/concurrency-queue/stats', authenticateAdmin, async (req, res) => {
+  try {
+    // 获取所有有统计数据的 API Key
+    const statsKeys = await redis.scanConcurrencyQueueStatsKeys()
+    const queueKeys = await redis.scanConcurrencyQueueKeys()
+
+    // 合并所有相关的 API Key
+    const allApiKeyIds = [...new Set([...statsKeys, ...queueKeys])]
+
+    // 获取各 API Key 的详细统计
+    const perKeyStats = await Promise.all(
+      allApiKeyIds.map(async (apiKeyId) => {
+        const [queueCount, stats, waitTimes] = await Promise.all([
+          redis.getConcurrencyQueueCount(apiKeyId),
+          redis.getConcurrencyQueueStats(apiKeyId),
+          redis.getQueueWaitTimes(apiKeyId)
+        ])
+
+        return {
+          apiKeyId,
+          currentQueueCount: queueCount,
+          stats,
+          waitTimeStats: calculateWaitTimeStats(waitTimes)
+        }
+      })
+    )
+
+    // 获取全局等待时间统计
+    const globalWaitTimes = await redis.getGlobalQueueWaitTimes()
+    const globalWaitTimeStats = calculateWaitTimeStats(globalWaitTimes)
+
+    // 计算全局汇总
+    const globalStats = {
+      totalEntered: perKeyStats.reduce((sum, s) => sum + s.stats.entered, 0),
+      totalSuccess: perKeyStats.reduce((sum, s) => sum + s.stats.success, 0),
+      totalTimeout: perKeyStats.reduce((sum, s) => sum + s.stats.timeout, 0),
+      totalCancelled: perKeyStats.reduce((sum, s) => sum + s.stats.cancelled, 0),
+      totalSocketChanged: perKeyStats.reduce((sum, s) => sum + (s.stats.socket_changed || 0), 0),
+      totalRejectedOverload: perKeyStats.reduce(
+        (sum, s) => sum + (s.stats.rejected_overload || 0),
+        0
+      ),
+      currentTotalQueued: perKeyStats.reduce((sum, s) => sum + s.currentQueueCount, 0),
+      // 队列资源利用率指标
+      peakQueueSize:
+        perKeyStats.length > 0 ? Math.max(...perKeyStats.map((s) => s.currentQueueCount)) : 0,
+      avgQueueSize:
+        perKeyStats.length > 0
+          ? Math.round(
+              perKeyStats.reduce((sum, s) => sum + s.currentQueueCount, 0) / perKeyStats.length
+            )
+          : 0,
+      activeApiKeys: perKeyStats.filter((s) => s.currentQueueCount > 0).length
+    }
+
+    // 计算成功率
+    if (globalStats.totalEntered > 0) {
+      globalStats.successRate = Math.round(
+        (globalStats.totalSuccess / globalStats.totalEntered) * 100
+      )
+      globalStats.timeoutRate = Math.round(
+        (globalStats.totalTimeout / globalStats.totalEntered) * 100
+      )
+      globalStats.cancelledRate = Math.round(
+        (globalStats.totalCancelled / globalStats.totalEntered) * 100
+      )
+    }
+
+    // 从全局等待时间统计中提取关键指标
+    if (globalWaitTimeStats) {
+      globalStats.avgWaitTimeMs = globalWaitTimeStats.avg
+      globalStats.p50WaitTimeMs = globalWaitTimeStats.p50
+      globalStats.p90WaitTimeMs = globalWaitTimeStats.p90
+      globalStats.p99WaitTimeMs = globalWaitTimeStats.p99
+      // 多实例采样策略标记（详见 design.md Decision 9）
+      // 全局 P90 仅用于可视化和监控，不用于系统决策
+      // 健康检查使用 API Key 级别的 P90（每 Key 独立采样）
+      globalWaitTimeStats.globalP90ForVisualizationOnly = true
+    }
+
+    res.json({
+      success: true,
+      globalStats,
+      globalWaitTimeStats,
+      perKeyStats
+    })
+  } catch (error) {
+    logger.error('❌ Failed to get queue stats:', error)
+    res.status(500).json({
+      success: false,
+      error: 'Failed to get queue stats',
+      message: error.message
+    })
+  }
+})
+
+/**
+ * DELETE /admin/concurrency-queue/:apiKeyId
+ * 清理特定 API Key 的排队计数
+ */
+router.delete('/concurrency-queue/:apiKeyId', authenticateAdmin, async (req, res) => {
+  try {
+    const { apiKeyId } = req.params
+    await redis.clearConcurrencyQueue(apiKeyId)
+
+    logger.warn(`🧹 Admin ${req.admin?.username || 'unknown'} cleared queue for key ${apiKeyId}`)
+
+    res.json({
+      success: true,
+      message: `Successfully cleared queue for API key ${apiKeyId}`
+    })
+  } catch (error) {
+    logger.error(`❌ Failed to clear queue for ${req.params.apiKeyId}:`, error)
+    res.status(500).json({
+      success: false,
+      error: 'Failed to clear queue',
+      message: error.message
+    })
+  }
+})
+
+/**
+ * DELETE /admin/concurrency-queue
+ * 清理所有排队计数
+ */
+router.delete('/concurrency-queue', authenticateAdmin, async (req, res) => {
+  try {
+    const cleared = await redis.clearAllConcurrencyQueues()
+
+    logger.warn(`🧹 Admin ${req.admin?.username || 'unknown'} cleared ALL queues`)
+
+    res.json({
+      success: true,
+      message: 'Successfully cleared all queues',
+      cleared
+    })
+  } catch (error) {
+    logger.error('❌ Failed to clear all queues:', error)
+    res.status(500).json({
+      success: false,
+      error: 'Failed to clear all queues',
       message: error.message
     })
   }
@@ -47,10 +210,14 @@ router.get('/concurrency/:apiKeyId', authenticateAdmin, async (req, res) => {
   try {
     const { apiKeyId } = req.params
     const status = await redis.getConcurrencyStatus(apiKeyId)
+    const queueCount = await redis.getConcurrencyQueueCount(apiKeyId)
 
     res.json({
       success: true,
-      concurrencyStatus: status
+      concurrencyStatus: {
+        ...status,
+        queueCount
+      }
     })
   } catch (error) {
     logger.error(`❌ Failed to get concurrency status for ${req.params.apiKeyId}:`, error)

--- a/src/services/bedrockRelayService.js
+++ b/src/services/bedrockRelayService.js
@@ -243,10 +243,11 @@ class BedrockRelayService {
             isBackendError ? { backendError: queueResult.errorMessage } : {}
           )
           if (!res.headersSent) {
+            const existingConnection = res.getHeader ? res.getHeader('Connection') : null
             res.writeHead(statusCode, {
               'Content-Type': 'text/event-stream',
               'Cache-Control': 'no-cache',
-              Connection: 'keep-alive',
+              Connection: existingConnection || 'keep-alive',
               'x-user-message-queue-error': errorType
             })
           }
@@ -309,10 +310,17 @@ class BedrockRelayService {
       }
 
       // 设置SSE响应头
+      // ⚠️ 关键修复：尊重 auth.js 提前设置的 Connection: close
+      const existingConnection = res.getHeader ? res.getHeader('Connection') : null
+      if (existingConnection) {
+        logger.debug(
+          `🔌 [Bedrock Stream] Preserving existing Connection header: ${existingConnection}`
+        )
+      }
       res.writeHead(200, {
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
-        Connection: 'keep-alive',
+        Connection: existingConnection || 'keep-alive',
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Headers': 'Content-Type, Authorization'
       })

--- a/src/services/claudeRelayConfigService.js
+++ b/src/services/claudeRelayConfigService.js
@@ -20,6 +20,15 @@ const DEFAULT_CONFIG = {
   userMessageQueueDelayMs: 200, // 请求间隔（毫秒）
   userMessageQueueTimeoutMs: 5000, // 队列等待超时（毫秒），优化后锁持有时间短无需长等待
   userMessageQueueLockTtlMs: 5000, // 锁TTL（毫秒），请求发送后立即释放无需长TTL
+  // 并发请求排队配置
+  concurrentRequestQueueEnabled: false, // 是否启用并发请求排队（默认关闭）
+  concurrentRequestQueueMaxSize: 3, // 固定最小排队数（默认3）
+  concurrentRequestQueueMaxSizeMultiplier: 0, // 并发数的倍数（默认0，仅使用固定值）
+  concurrentRequestQueueTimeoutMs: 10000, // 排队超时（毫秒，默认10秒）
+  concurrentRequestQueueMaxRedisFailCount: 5, // 连续 Redis 失败阈值（默认5次）
+  // 排队健康检查配置
+  concurrentRequestQueueHealthCheckEnabled: true, // 是否启用排队健康检查（默认开启）
+  concurrentRequestQueueHealthThreshold: 0.8, // 健康检查阈值（P90 >= 超时 × 阈值时拒绝新请求）
   updatedAt: null,
   updatedBy: null
 }
@@ -105,7 +114,8 @@ class ClaudeRelayConfigService {
 
       logger.info(`✅ Claude relay config updated by ${updatedBy}:`, {
         claudeCodeOnlyEnabled: updatedConfig.claudeCodeOnlyEnabled,
-        globalSessionBindingEnabled: updatedConfig.globalSessionBindingEnabled
+        globalSessionBindingEnabled: updatedConfig.globalSessionBindingEnabled,
+        concurrentRequestQueueEnabled: updatedConfig.concurrentRequestQueueEnabled
       })
 
       return updatedConfig

--- a/src/utils/statsHelper.js
+++ b/src/utils/statsHelper.js
@@ -1,0 +1,105 @@
+/**
+ * 统计计算工具函数
+ * 提供百分位数计算、等待时间统计等通用统计功能
+ */
+
+/**
+ * 计算百分位数（使用 nearest-rank 方法）
+ * @param {number[]} sortedArray - 已排序的数组（升序）
+ * @param {number} percentile - 百分位数 (0-100)
+ * @returns {number} 百分位值
+ *
+ * 边界情况说明：
+ * - percentile=0: 返回最小值 (index=0)
+ * - percentile=100: 返回最大值 (index=len-1)
+ * - percentile=50 且 len=2: 返回第一个元素（nearest-rank 向下取）
+ *
+ * 算法说明（nearest-rank 方法）：
+ * - index = ceil(percentile / 100 * len) - 1
+ * - 示例：len=100, P50 → ceil(50) - 1 = 49（第50个元素，0-indexed）
+ * - 示例：len=100, P99 → ceil(99) - 1 = 98（第99个元素）
+ */
+function getPercentile(sortedArray, percentile) {
+  const len = sortedArray.length
+  if (len === 0) {
+    return 0
+  }
+  if (len === 1) {
+    return sortedArray[0]
+  }
+
+  // 边界处理：percentile <= 0 返回最小值
+  if (percentile <= 0) {
+    return sortedArray[0]
+  }
+  // 边界处理：percentile >= 100 返回最大值
+  if (percentile >= 100) {
+    return sortedArray[len - 1]
+  }
+
+  const index = Math.ceil((percentile / 100) * len) - 1
+  return sortedArray[index]
+}
+
+/**
+ * 计算等待时间分布统计
+ * @param {number[]} waitTimes - 等待时间数组（无需预先排序）
+ * @returns {Object|null} 统计对象，空数组返回 null
+ *
+ * 返回对象包含：
+ * - sampleCount: 样本数量（始终包含，便于调用方判断可靠性）
+ * - count: 样本数量（向后兼容）
+ * - min: 最小值
+ * - max: 最大值
+ * - avg: 平均值（四舍五入）
+ * - p50: 50百分位数（中位数）
+ * - p90: 90百分位数
+ * - p99: 99百分位数
+ * - sampleSizeWarning: 样本量不足时的警告信息（样本 < 10）
+ * - p90Unreliable: P90 统计不可靠标记（样本 < 10）
+ * - p99Unreliable: P99 统计不可靠标记（样本 < 100）
+ *
+ * 可靠性标记说明（详见 design.md Decision 6）：
+ * - 样本 < 10: P90 和 P99 都不可靠
+ * - 样本 < 100: P99 不可靠（P90 需要 10 个样本，P99 需要 100 个样本）
+ * - 即使标记为不可靠，仍返回计算值供参考
+ */
+function calculateWaitTimeStats(waitTimes) {
+  if (!waitTimes || waitTimes.length === 0) {
+    return null
+  }
+
+  const sorted = [...waitTimes].sort((a, b) => a - b)
+  const sum = sorted.reduce((a, b) => a + b, 0)
+  const len = sorted.length
+
+  const stats = {
+    sampleCount: len, // 新增：始终包含样本数
+    count: len, // 向后兼容
+    min: sorted[0],
+    max: sorted[len - 1],
+    avg: Math.round(sum / len),
+    p50: getPercentile(sorted, 50),
+    p90: getPercentile(sorted, 90),
+    p99: getPercentile(sorted, 99)
+  }
+
+  // 渐进式可靠性标记（详见 design.md Decision 6）
+  // 样本 < 10: P90 不可靠（P90 至少需要 ceil(100/10) = 10 个样本）
+  if (len < 10) {
+    stats.sampleSizeWarning = 'Results may be inaccurate due to small sample size'
+    stats.p90Unreliable = true
+  }
+
+  // 样本 < 100: P99 不可靠（P99 至少需要 ceil(100/1) = 100 个样本）
+  if (len < 100) {
+    stats.p99Unreliable = true
+  }
+
+  return stats
+}
+
+module.exports = {
+  getPercentile,
+  calculateWaitTimeStats
+}

--- a/src/utils/streamHelper.js
+++ b/src/utils/streamHelper.js
@@ -1,0 +1,36 @@
+/**
+ * Stream Helper Utilities
+ * 流处理辅助工具函数
+ */
+
+/**
+ * 检查响应流是否仍然可写（客户端连接是否有效）
+ * @param {import('http').ServerResponse} stream - HTTP响应流
+ * @returns {boolean} 如果流可写返回true，否则返回false
+ */
+function isStreamWritable(stream) {
+  if (!stream) {
+    return false
+  }
+
+  // 检查流是否已销毁
+  if (stream.destroyed) {
+    return false
+  }
+
+  // 检查底层socket是否已销毁
+  if (stream.socket?.destroyed) {
+    return false
+  }
+
+  // 检查流是否已结束写入
+  if (stream.writableEnded) {
+    return false
+  }
+
+  return true
+}
+
+module.exports = {
+  isStreamWritable
+}

--- a/tests/concurrencyQueue.integration.test.js
+++ b/tests/concurrencyQueue.integration.test.js
@@ -1,0 +1,860 @@
+/**
+ * 并发请求排队功能集成测试
+ *
+ * 测试分为三个层次：
+ * 1. Mock 测试 - 测试核心逻辑，不需要真实 Redis
+ * 2. Redis 方法测试 - 测试 Redis 操作的原子性和正确性
+ * 3. 端到端场景测试 - 测试完整的排队流程
+ *
+ * 运行方式：
+ * - npm test -- concurrencyQueue.integration  # 运行所有测试（Mock 部分）
+ * - REDIS_TEST=1 npm test -- concurrencyQueue.integration  # 包含真实 Redis 测试
+ */
+
+// Mock logger to avoid console output during tests
+jest.mock('../src/utils/logger', () => ({
+  api: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  database: jest.fn(),
+  security: jest.fn()
+}))
+
+const redis = require('../src/models/redis')
+const claudeRelayConfigService = require('../src/services/claudeRelayConfigService')
+
+// Helper: sleep function
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Helper: 创建模拟的 req/res 对象
+function createMockReqRes() {
+  const listeners = {}
+  const req = {
+    destroyed: false,
+    once: jest.fn((event, handler) => {
+      listeners[`req:${event}`] = handler
+    }),
+    removeListener: jest.fn((event) => {
+      delete listeners[`req:${event}`]
+    }),
+    // 触发事件的辅助方法
+    emit: (event) => {
+      const handler = listeners[`req:${event}`]
+      if (handler) {
+        handler()
+      }
+    }
+  }
+
+  const res = {
+    once: jest.fn((event, handler) => {
+      listeners[`res:${event}`] = handler
+    }),
+    removeListener: jest.fn((event) => {
+      delete listeners[`res:${event}`]
+    }),
+    emit: (event) => {
+      const handler = listeners[`res:${event}`]
+      if (handler) {
+        handler()
+      }
+    }
+  }
+
+  return { req, res, listeners }
+}
+
+// ============================================
+// 第一部分：Mock 测试 - waitForConcurrencySlot 核心逻辑
+// ============================================
+describe('ConcurrencyQueue Integration Tests', () => {
+  describe('Part 1: waitForConcurrencySlot Logic (Mocked)', () => {
+    // 导入 auth 模块中的 waitForConcurrencySlot
+    // 由于它是内部函数，我们需要通过测试其行为来验证
+    // 这里我们模拟整个流程
+
+    let mockRedis
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+
+      // 创建 Redis mock
+      mockRedis = {
+        concurrencyCount: {},
+        queueCount: {},
+        stats: {},
+        waitTimes: {},
+        globalWaitTimes: []
+      }
+
+      // Mock Redis 并发方法
+      jest.spyOn(redis, 'incrConcurrency').mockImplementation(async (keyId, requestId, _lease) => {
+        if (!mockRedis.concurrencyCount[keyId]) {
+          mockRedis.concurrencyCount[keyId] = new Set()
+        }
+        mockRedis.concurrencyCount[keyId].add(requestId)
+        return mockRedis.concurrencyCount[keyId].size
+      })
+
+      jest.spyOn(redis, 'decrConcurrency').mockImplementation(async (keyId, requestId) => {
+        if (mockRedis.concurrencyCount[keyId]) {
+          mockRedis.concurrencyCount[keyId].delete(requestId)
+          return mockRedis.concurrencyCount[keyId].size
+        }
+        return 0
+      })
+
+      // Mock 排队计数方法
+      jest.spyOn(redis, 'incrConcurrencyQueue').mockImplementation(async (keyId) => {
+        mockRedis.queueCount[keyId] = (mockRedis.queueCount[keyId] || 0) + 1
+        return mockRedis.queueCount[keyId]
+      })
+
+      jest.spyOn(redis, 'decrConcurrencyQueue').mockImplementation(async (keyId) => {
+        mockRedis.queueCount[keyId] = Math.max(0, (mockRedis.queueCount[keyId] || 0) - 1)
+        return mockRedis.queueCount[keyId]
+      })
+
+      jest
+        .spyOn(redis, 'getConcurrencyQueueCount')
+        .mockImplementation(async (keyId) => mockRedis.queueCount[keyId] || 0)
+
+      // Mock 统计方法
+      jest.spyOn(redis, 'incrConcurrencyQueueStats').mockImplementation(async (keyId, field) => {
+        if (!mockRedis.stats[keyId]) {
+          mockRedis.stats[keyId] = {}
+        }
+        mockRedis.stats[keyId][field] = (mockRedis.stats[keyId][field] || 0) + 1
+        return mockRedis.stats[keyId][field]
+      })
+
+      jest.spyOn(redis, 'recordQueueWaitTime').mockResolvedValue(undefined)
+      jest.spyOn(redis, 'recordGlobalQueueWaitTime').mockResolvedValue(undefined)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    describe('Slot Acquisition Flow', () => {
+      it('should acquire slot immediately when under concurrency limit', async () => {
+        // 模拟 waitForConcurrencySlot 的行为
+        const keyId = 'test-key-1'
+        const requestId = 'req-1'
+        const concurrencyLimit = 5
+
+        // 直接测试 incrConcurrency 的行为
+        const count = await redis.incrConcurrency(keyId, requestId, 300)
+
+        expect(count).toBe(1)
+        expect(count).toBeLessThanOrEqual(concurrencyLimit)
+      })
+
+      it('should track multiple concurrent requests correctly', async () => {
+        const keyId = 'test-key-2'
+        const concurrencyLimit = 3
+
+        // 模拟多个并发请求
+        const results = []
+        for (let i = 1; i <= 5; i++) {
+          const count = await redis.incrConcurrency(keyId, `req-${i}`, 300)
+          results.push({ requestId: `req-${i}`, count, exceeds: count > concurrencyLimit })
+        }
+
+        // 前3个应该在限制内
+        expect(results[0].exceeds).toBe(false)
+        expect(results[1].exceeds).toBe(false)
+        expect(results[2].exceeds).toBe(false)
+        // 后2个超过限制
+        expect(results[3].exceeds).toBe(true)
+        expect(results[4].exceeds).toBe(true)
+      })
+
+      it('should release slot and allow next request', async () => {
+        const keyId = 'test-key-3'
+        const concurrencyLimit = 1
+
+        // 第一个请求获取槽位
+        const count1 = await redis.incrConcurrency(keyId, 'req-1', 300)
+        expect(count1).toBe(1)
+
+        // 第二个请求超限
+        const count2 = await redis.incrConcurrency(keyId, 'req-2', 300)
+        expect(count2).toBe(2)
+        expect(count2).toBeGreaterThan(concurrencyLimit)
+
+        // 释放第二个请求（因为超限）
+        await redis.decrConcurrency(keyId, 'req-2')
+
+        // 释放第一个请求
+        await redis.decrConcurrency(keyId, 'req-1')
+
+        // 现在第三个请求应该能获取
+        const count3 = await redis.incrConcurrency(keyId, 'req-3', 300)
+        expect(count3).toBe(1)
+      })
+    })
+
+    describe('Queue Count Management', () => {
+      it('should increment and decrement queue count atomically', async () => {
+        const keyId = 'test-key-4'
+
+        // 增加排队计数
+        const count1 = await redis.incrConcurrencyQueue(keyId, 60000)
+        expect(count1).toBe(1)
+
+        const count2 = await redis.incrConcurrencyQueue(keyId, 60000)
+        expect(count2).toBe(2)
+
+        // 减少排队计数
+        const count3 = await redis.decrConcurrencyQueue(keyId)
+        expect(count3).toBe(1)
+
+        const count4 = await redis.decrConcurrencyQueue(keyId)
+        expect(count4).toBe(0)
+      })
+
+      it('should not go below zero on decrement', async () => {
+        const keyId = 'test-key-5'
+
+        // 直接减少（没有先增加）
+        const count = await redis.decrConcurrencyQueue(keyId)
+        expect(count).toBe(0)
+      })
+
+      it('should handle concurrent queue operations', async () => {
+        const keyId = 'test-key-6'
+
+        // 并发增加
+        const increments = await Promise.all([
+          redis.incrConcurrencyQueue(keyId, 60000),
+          redis.incrConcurrencyQueue(keyId, 60000),
+          redis.incrConcurrencyQueue(keyId, 60000)
+        ])
+
+        // 所有增量应该是连续的
+        const sortedIncrements = [...increments].sort((a, b) => a - b)
+        expect(sortedIncrements).toEqual([1, 2, 3])
+      })
+    })
+
+    describe('Statistics Tracking', () => {
+      it('should track entered/success/timeout/cancelled stats', async () => {
+        const keyId = 'test-key-7'
+
+        await redis.incrConcurrencyQueueStats(keyId, 'entered')
+        await redis.incrConcurrencyQueueStats(keyId, 'entered')
+        await redis.incrConcurrencyQueueStats(keyId, 'success')
+        await redis.incrConcurrencyQueueStats(keyId, 'timeout')
+        await redis.incrConcurrencyQueueStats(keyId, 'cancelled')
+
+        expect(mockRedis.stats[keyId]).toEqual({
+          entered: 2,
+          success: 1,
+          timeout: 1,
+          cancelled: 1
+        })
+      })
+    })
+
+    describe('Client Disconnection Handling', () => {
+      it('should detect client disconnection via close event', async () => {
+        const { req } = createMockReqRes()
+
+        let clientDisconnected = false
+
+        // 设置监听器
+        req.once('close', () => {
+          clientDisconnected = true
+        })
+
+        // 模拟客户端断开
+        req.emit('close')
+
+        expect(clientDisconnected).toBe(true)
+      })
+
+      it('should detect pre-destroyed request', () => {
+        const { req } = createMockReqRes()
+        req.destroyed = true
+
+        expect(req.destroyed).toBe(true)
+      })
+    })
+
+    describe('Exponential Backoff Simulation', () => {
+      it('should increase poll interval with backoff', () => {
+        const config = {
+          pollIntervalMs: 200,
+          maxPollIntervalMs: 2000,
+          backoffFactor: 1.5,
+          jitterRatio: 0 // 禁用抖动以便测试
+        }
+
+        let interval = config.pollIntervalMs
+        const intervals = [interval]
+
+        for (let i = 0; i < 5; i++) {
+          interval = Math.min(interval * config.backoffFactor, config.maxPollIntervalMs)
+          intervals.push(interval)
+        }
+
+        // 验证指数增长
+        expect(intervals[1]).toBe(300) // 200 * 1.5
+        expect(intervals[2]).toBe(450) // 300 * 1.5
+        expect(intervals[3]).toBe(675) // 450 * 1.5
+        expect(intervals[4]).toBe(1012.5) // 675 * 1.5
+        expect(intervals[5]).toBe(1518.75) // 1012.5 * 1.5
+      })
+
+      it('should cap interval at maximum', () => {
+        const config = {
+          pollIntervalMs: 1000,
+          maxPollIntervalMs: 2000,
+          backoffFactor: 1.5
+        }
+
+        let interval = config.pollIntervalMs
+
+        for (let i = 0; i < 10; i++) {
+          interval = Math.min(interval * config.backoffFactor, config.maxPollIntervalMs)
+        }
+
+        expect(interval).toBe(2000)
+      })
+
+      it('should apply jitter within expected range', () => {
+        const baseInterval = 1000
+        const jitterRatio = 0.2 // ±20%
+        const results = []
+
+        for (let i = 0; i < 100; i++) {
+          const randomValue = Math.random()
+          const jitter = baseInterval * jitterRatio * (randomValue * 2 - 1)
+          const finalInterval = baseInterval + jitter
+          results.push(finalInterval)
+        }
+
+        const min = Math.min(...results)
+        const max = Math.max(...results)
+
+        // 所有结果应该在 [800, 1200] 范围内
+        expect(min).toBeGreaterThanOrEqual(800)
+        expect(max).toBeLessThanOrEqual(1200)
+      })
+    })
+  })
+
+  // ============================================
+  // 第二部分：并发竞争场景测试
+  // ============================================
+  describe('Part 2: Concurrent Race Condition Tests', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    describe('Race Condition: Multiple Requests Competing for Same Slot', () => {
+      it('should handle race condition when multiple requests try to acquire last slot', async () => {
+        const keyId = 'race-test-1'
+        const concurrencyLimit = 1
+        const concurrencyState = { count: 0, holders: new Set() }
+
+        // 模拟原子的 incrConcurrency
+        jest.spyOn(redis, 'incrConcurrency').mockImplementation(async (key, reqId) => {
+          // 模拟原子操作
+          concurrencyState.count++
+          concurrencyState.holders.add(reqId)
+          return concurrencyState.count
+        })
+
+        jest.spyOn(redis, 'decrConcurrency').mockImplementation(async (key, reqId) => {
+          if (concurrencyState.holders.has(reqId)) {
+            concurrencyState.count--
+            concurrencyState.holders.delete(reqId)
+          }
+          return concurrencyState.count
+        })
+
+        // 5个请求同时竞争1个槽位
+        const requests = Array.from({ length: 5 }, (_, i) => `req-${i + 1}`)
+
+        const acquireResults = await Promise.all(
+          requests.map(async (reqId) => {
+            const count = await redis.incrConcurrency(keyId, reqId, 300)
+            const acquired = count <= concurrencyLimit
+
+            if (!acquired) {
+              // 超限，释放
+              await redis.decrConcurrency(keyId, reqId)
+            }
+
+            return { reqId, count, acquired }
+          })
+        )
+
+        // 只有一个请求应该成功获取槽位
+        const successfulAcquires = acquireResults.filter((r) => r.acquired)
+        expect(successfulAcquires.length).toBe(1)
+
+        // 最终并发计数应该是1
+        expect(concurrencyState.count).toBe(1)
+      })
+
+      it('should maintain consistency under high contention', async () => {
+        const keyId = 'race-test-2'
+        const concurrencyLimit = 3
+        const requestCount = 20
+        const concurrencyState = { count: 0, maxSeen: 0 }
+
+        jest.spyOn(redis, 'incrConcurrency').mockImplementation(async () => {
+          concurrencyState.count++
+          concurrencyState.maxSeen = Math.max(concurrencyState.maxSeen, concurrencyState.count)
+          return concurrencyState.count
+        })
+
+        jest.spyOn(redis, 'decrConcurrency').mockImplementation(async () => {
+          concurrencyState.count = Math.max(0, concurrencyState.count - 1)
+          return concurrencyState.count
+        })
+
+        // 模拟多轮请求
+        const activeRequests = []
+
+        for (let i = 0; i < requestCount; i++) {
+          const count = await redis.incrConcurrency(keyId, `req-${i}`, 300)
+
+          if (count <= concurrencyLimit) {
+            activeRequests.push(`req-${i}`)
+
+            // 模拟处理时间后释放
+            setTimeout(async () => {
+              await redis.decrConcurrency(keyId, `req-${i}`)
+            }, Math.random() * 50)
+          } else {
+            await redis.decrConcurrency(keyId, `req-${i}`)
+          }
+
+          // 随机延迟
+          await sleep(Math.random() * 10)
+        }
+
+        // 等待所有请求完成
+        await sleep(100)
+
+        // 最大并发不应超过限制
+        expect(concurrencyState.maxSeen).toBeLessThanOrEqual(concurrencyLimit + requestCount) // 允许短暂超限
+      })
+    })
+
+    describe('Queue Overflow Protection', () => {
+      it('should reject requests when queue is full', async () => {
+        const keyId = 'overflow-test-1'
+        const maxQueueSize = 5
+        const queueState = { count: 0 }
+
+        jest.spyOn(redis, 'incrConcurrencyQueue').mockImplementation(async () => {
+          queueState.count++
+          return queueState.count
+        })
+
+        jest.spyOn(redis, 'decrConcurrencyQueue').mockImplementation(async () => {
+          queueState.count = Math.max(0, queueState.count - 1)
+          return queueState.count
+        })
+
+        const results = []
+
+        // 尝试10个请求进入队列
+        for (let i = 0; i < 10; i++) {
+          const queueCount = await redis.incrConcurrencyQueue(keyId, 60000)
+
+          if (queueCount > maxQueueSize) {
+            // 队列满，释放并拒绝
+            await redis.decrConcurrencyQueue(keyId)
+            results.push({ index: i, accepted: false })
+          } else {
+            results.push({ index: i, accepted: true, position: queueCount })
+          }
+        }
+
+        const accepted = results.filter((r) => r.accepted)
+        const rejected = results.filter((r) => !r.accepted)
+
+        expect(accepted.length).toBe(5)
+        expect(rejected.length).toBe(5)
+      })
+    })
+  })
+
+  // ============================================
+  // 第三部分：真实 Redis 集成测试（可选）
+  // ============================================
+  describe('Part 3: Real Redis Integration Tests', () => {
+    const skipRealRedis = !process.env.REDIS_TEST
+
+    // 辅助函数：检查 Redis 连接
+    async function checkRedisConnection() {
+      try {
+        const client = redis.getClient()
+        if (!client) {
+          return false
+        }
+        await client.ping()
+        return true
+      } catch {
+        return false
+      }
+    }
+
+    beforeAll(async () => {
+      if (skipRealRedis) {
+        console.log('⏭️  Skipping real Redis tests (set REDIS_TEST=1 to enable)')
+        return
+      }
+
+      const connected = await checkRedisConnection()
+      if (!connected) {
+        console.log('⚠️  Redis not connected, skipping real Redis tests')
+      }
+    })
+
+    // 清理测试数据
+    afterEach(async () => {
+      if (skipRealRedis) {
+        return
+      }
+
+      try {
+        const client = redis.getClient()
+        if (!client) {
+          return
+        }
+
+        // 清理测试键
+        const testKeys = await client.keys('concurrency:queue:test-*')
+        if (testKeys.length > 0) {
+          await client.del(...testKeys)
+        }
+      } catch {
+        // 忽略清理错误
+      }
+    })
+
+    describe('Redis Queue Operations', () => {
+      const testOrSkip = skipRealRedis ? it.skip : it
+
+      testOrSkip('should atomically increment queue count with TTL', async () => {
+        const keyId = 'test-redis-queue-1'
+        const timeoutMs = 5000
+
+        const count1 = await redis.incrConcurrencyQueue(keyId, timeoutMs)
+        expect(count1).toBe(1)
+
+        const count2 = await redis.incrConcurrencyQueue(keyId, timeoutMs)
+        expect(count2).toBe(2)
+
+        // 验证 TTL 被设置
+        const client = redis.getClient()
+        const ttl = await client.ttl(`concurrency:queue:${keyId}`)
+        expect(ttl).toBeGreaterThan(0)
+        expect(ttl).toBeLessThanOrEqual(Math.ceil(timeoutMs / 1000) + 30)
+      })
+
+      testOrSkip('should atomically decrement and delete when zero', async () => {
+        const keyId = 'test-redis-queue-2'
+
+        await redis.incrConcurrencyQueue(keyId, 60000)
+        const count = await redis.decrConcurrencyQueue(keyId)
+
+        expect(count).toBe(0)
+
+        // 验证键已删除
+        const client = redis.getClient()
+        const exists = await client.exists(`concurrency:queue:${keyId}`)
+        expect(exists).toBe(0)
+      })
+
+      testOrSkip('should handle concurrent increments correctly', async () => {
+        const keyId = 'test-redis-queue-3'
+        const numRequests = 10
+
+        // 并发增加
+        const results = await Promise.all(
+          Array.from({ length: numRequests }, () => redis.incrConcurrencyQueue(keyId, 60000))
+        )
+
+        // 所有结果应该是 1 到 numRequests
+        const sorted = [...results].sort((a, b) => a - b)
+        expect(sorted).toEqual(Array.from({ length: numRequests }, (_, i) => i + 1))
+      })
+    })
+
+    describe('Redis Stats Operations', () => {
+      const testOrSkip = skipRealRedis ? it.skip : it
+
+      testOrSkip('should track queue statistics correctly', async () => {
+        const keyId = 'test-redis-stats-1'
+
+        await redis.incrConcurrencyQueueStats(keyId, 'entered')
+        await redis.incrConcurrencyQueueStats(keyId, 'entered')
+        await redis.incrConcurrencyQueueStats(keyId, 'success')
+        await redis.incrConcurrencyQueueStats(keyId, 'timeout')
+
+        const stats = await redis.getConcurrencyQueueStats(keyId)
+
+        expect(stats.entered).toBe(2)
+        expect(stats.success).toBe(1)
+        expect(stats.timeout).toBe(1)
+        expect(stats.cancelled).toBe(0)
+      })
+
+      testOrSkip('should record and retrieve wait times', async () => {
+        const keyId = 'test-redis-wait-1'
+        const waitTimes = [100, 200, 150, 300, 250]
+
+        for (const wt of waitTimes) {
+          await redis.recordQueueWaitTime(keyId, wt)
+        }
+
+        const recorded = await redis.getQueueWaitTimes(keyId)
+
+        // 应该按 LIFO 顺序存储
+        expect(recorded.length).toBe(5)
+        expect(recorded[0]).toBe(250) // 最后插入的在前面
+      })
+
+      testOrSkip('should record global wait times', async () => {
+        const waitTimes = [500, 600, 700]
+
+        for (const wt of waitTimes) {
+          await redis.recordGlobalQueueWaitTime(wt)
+        }
+
+        const recorded = await redis.getGlobalQueueWaitTimes()
+
+        expect(recorded.length).toBeGreaterThanOrEqual(3)
+      })
+    })
+
+    describe('Redis Cleanup Operations', () => {
+      const testOrSkip = skipRealRedis ? it.skip : it
+
+      testOrSkip('should clear specific queue', async () => {
+        const keyId = 'test-redis-clear-1'
+
+        await redis.incrConcurrencyQueue(keyId, 60000)
+        await redis.incrConcurrencyQueue(keyId, 60000)
+
+        const cleared = await redis.clearConcurrencyQueue(keyId)
+        expect(cleared).toBe(true)
+
+        const count = await redis.getConcurrencyQueueCount(keyId)
+        expect(count).toBe(0)
+      })
+
+      testOrSkip('should clear all queues but preserve stats', async () => {
+        const keyId1 = 'test-redis-clearall-1'
+        const keyId2 = 'test-redis-clearall-2'
+
+        // 创建队列和统计
+        await redis.incrConcurrencyQueue(keyId1, 60000)
+        await redis.incrConcurrencyQueue(keyId2, 60000)
+        await redis.incrConcurrencyQueueStats(keyId1, 'entered')
+
+        // 清理所有队列
+        const cleared = await redis.clearAllConcurrencyQueues()
+        expect(cleared).toBeGreaterThanOrEqual(2)
+
+        // 验证队列已清理
+        const count1 = await redis.getConcurrencyQueueCount(keyId1)
+        const count2 = await redis.getConcurrencyQueueCount(keyId2)
+        expect(count1).toBe(0)
+        expect(count2).toBe(0)
+
+        // 统计应该保留
+        const stats = await redis.getConcurrencyQueueStats(keyId1)
+        expect(stats.entered).toBe(1)
+      })
+    })
+  })
+
+  // ============================================
+  // 第四部分：配置服务集成测试
+  // ============================================
+  describe('Part 4: Configuration Service Integration', () => {
+    beforeEach(() => {
+      // 清除配置缓存
+      claudeRelayConfigService.clearCache()
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    describe('Queue Configuration', () => {
+      it('should return default queue configuration', async () => {
+        jest.spyOn(redis, 'getClient').mockReturnValue(null)
+
+        const config = await claudeRelayConfigService.getConfig()
+
+        expect(config.concurrentRequestQueueEnabled).toBe(false)
+        expect(config.concurrentRequestQueueMaxSize).toBe(3)
+        expect(config.concurrentRequestQueueMaxSizeMultiplier).toBe(0)
+        expect(config.concurrentRequestQueueTimeoutMs).toBe(10000)
+      })
+
+      it('should calculate max queue size correctly', async () => {
+        const testCases = [
+          { concurrencyLimit: 5, multiplier: 2, fixedMin: 3, expected: 10 }, // 5*2=10 > 3
+          { concurrencyLimit: 1, multiplier: 1, fixedMin: 5, expected: 5 }, // 1*1=1 < 5
+          { concurrencyLimit: 10, multiplier: 0.5, fixedMin: 3, expected: 5 }, // 10*0.5=5 > 3
+          { concurrencyLimit: 2, multiplier: 1, fixedMin: 10, expected: 10 } // 2*1=2 < 10
+        ]
+
+        for (const tc of testCases) {
+          const maxQueueSize = Math.max(tc.concurrencyLimit * tc.multiplier, tc.fixedMin)
+          expect(maxQueueSize).toBe(tc.expected)
+        }
+      })
+    })
+  })
+
+  // ============================================
+  // 第五部分：端到端场景测试
+  // ============================================
+  describe('Part 5: End-to-End Scenario Tests', () => {
+    describe('Scenario: Claude Code Agent Parallel Tool Calls', () => {
+      it('should handle burst of parallel tool results', async () => {
+        // 模拟 Claude Code Agent 发送多个并行工具结果的场景
+        const concurrencyLimit = 2
+        const maxQueueSize = 5
+
+        const state = {
+          concurrency: 0,
+          queue: 0,
+          completed: 0,
+          rejected: 0
+        }
+
+        // 模拟 8 个并行工具结果请求
+        const requests = Array.from({ length: 8 }, (_, i) => ({
+          id: `tool-result-${i + 1}`,
+          startTime: Date.now()
+        }))
+
+        // 模拟处理逻辑
+        async function processRequest(req) {
+          // 尝试获取并发槽位
+          state.concurrency++
+
+          if (state.concurrency > concurrencyLimit) {
+            // 超限，进入队列
+            state.concurrency--
+            state.queue++
+
+            if (state.queue > maxQueueSize) {
+              // 队列满，拒绝
+              state.queue--
+              state.rejected++
+              return { ...req, status: 'rejected', reason: 'queue_full' }
+            }
+
+            // 等待槽位（模拟）
+            await sleep(Math.random() * 100)
+            state.queue--
+            state.concurrency++
+          }
+
+          // 处理请求
+          await sleep(50) // 模拟处理时间
+          state.concurrency--
+          state.completed++
+
+          return { ...req, status: 'completed', duration: Date.now() - req.startTime }
+        }
+
+        const results = await Promise.all(requests.map(processRequest))
+
+        const completed = results.filter((r) => r.status === 'completed')
+        const rejected = results.filter((r) => r.status === 'rejected')
+
+        // 大部分请求应该完成
+        expect(completed.length).toBeGreaterThan(0)
+        // 可能有一些被拒绝
+        expect(state.rejected).toBe(rejected.length)
+
+        console.log(
+          `  ✓ Completed: ${completed.length}, Rejected: ${rejected.length}, Max concurrent: ${concurrencyLimit}`
+        )
+      })
+    })
+
+    describe('Scenario: Graceful Degradation', () => {
+      it('should fallback when Redis fails', async () => {
+        jest
+          .spyOn(redis, 'incrConcurrencyQueue')
+          .mockRejectedValue(new Error('Redis connection lost'))
+
+        // 模拟降级行为：Redis 失败时直接拒绝而不是崩溃
+        let result
+        try {
+          await redis.incrConcurrencyQueue('fallback-test', 60000)
+          result = { success: true }
+        } catch (error) {
+          // 优雅降级：返回 429 而不是 500
+          result = { success: false, fallback: true, error: error.message }
+        }
+
+        expect(result.fallback).toBe(true)
+        expect(result.error).toContain('Redis')
+      })
+    })
+
+    describe('Scenario: Timeout Behavior', () => {
+      it('should respect queue timeout', async () => {
+        const timeoutMs = 100
+        const startTime = Date.now()
+
+        // 模拟等待超时
+        await new Promise((resolve) => setTimeout(resolve, timeoutMs))
+
+        const elapsed = Date.now() - startTime
+        expect(elapsed).toBeGreaterThanOrEqual(timeoutMs - 10) // 允许 10ms 误差
+      })
+
+      it('should track timeout statistics', async () => {
+        const stats = { entered: 0, success: 0, timeout: 0, cancelled: 0 }
+
+        // 模拟多个请求，部分超时
+        const requests = [
+          { id: 'req-1', willTimeout: false },
+          { id: 'req-2', willTimeout: true },
+          { id: 'req-3', willTimeout: false },
+          { id: 'req-4', willTimeout: true }
+        ]
+
+        for (const req of requests) {
+          stats.entered++
+          if (req.willTimeout) {
+            stats.timeout++
+          } else {
+            stats.success++
+          }
+        }
+
+        expect(stats.entered).toBe(4)
+        expect(stats.success).toBe(2)
+        expect(stats.timeout).toBe(2)
+
+        // 成功率应该是 50%
+        const successRate = (stats.success / stats.entered) * 100
+        expect(successRate).toBe(50)
+      })
+    })
+  })
+})

--- a/tests/concurrencyQueue.test.js
+++ b/tests/concurrencyQueue.test.js
@@ -1,0 +1,278 @@
+/**
+ * 并发请求排队功能测试
+ * 测试排队逻辑中的核心算法：百分位数计算、等待时间统计、指数退避等
+ *
+ * 注意：Redis 方法的测试需要集成测试环境，这里主要测试纯算法逻辑
+ */
+
+// Mock logger to avoid console output during tests
+jest.mock('../src/utils/logger', () => ({
+  api: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  database: jest.fn(),
+  security: jest.fn()
+}))
+
+// 使用共享的统计工具函数（与生产代码一致）
+const { getPercentile, calculateWaitTimeStats } = require('../src/utils/statsHelper')
+
+describe('ConcurrencyQueue', () => {
+  describe('Percentile Calculation (nearest-rank method)', () => {
+    // 直接测试共享工具函数，确保与生产代码行为一致
+    it('should return 0 for empty array', () => {
+      expect(getPercentile([], 50)).toBe(0)
+    })
+
+    it('should return single element for single-element array', () => {
+      expect(getPercentile([100], 50)).toBe(100)
+      expect(getPercentile([100], 99)).toBe(100)
+    })
+
+    it('should return min for percentile 0', () => {
+      expect(getPercentile([10, 20, 30, 40, 50], 0)).toBe(10)
+    })
+
+    it('should return max for percentile 100', () => {
+      expect(getPercentile([10, 20, 30, 40, 50], 100)).toBe(50)
+    })
+
+    it('should calculate P50 correctly for len=10', () => {
+      // For [10, 20, 30, 40, 50, 60, 70, 80, 90, 100] (len=10)
+      // P50: ceil(50/100 * 10) - 1 = ceil(5) - 1 = 4 → value at index 4 = 50
+      const arr = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+      expect(getPercentile(arr, 50)).toBe(50)
+    })
+
+    it('should calculate P90 correctly for len=10', () => {
+      // For len=10, P90: ceil(90/100 * 10) - 1 = ceil(9) - 1 = 8 → value at index 8 = 90
+      const arr = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+      expect(getPercentile(arr, 90)).toBe(90)
+    })
+
+    it('should calculate P99 correctly for len=100', () => {
+      // For len=100, P99: ceil(99/100 * 100) - 1 = ceil(99) - 1 = 98
+      const arr = Array.from({ length: 100 }, (_, i) => i + 1)
+      expect(getPercentile(arr, 99)).toBe(99)
+    })
+
+    it('should handle two-element array correctly', () => {
+      // For [10, 20] (len=2)
+      // P50: ceil(50/100 * 2) - 1 = ceil(1) - 1 = 0 → value = 10
+      expect(getPercentile([10, 20], 50)).toBe(10)
+    })
+
+    it('should handle negative percentile as 0', () => {
+      expect(getPercentile([10, 20, 30], -10)).toBe(10)
+    })
+
+    it('should handle percentile > 100 as 100', () => {
+      expect(getPercentile([10, 20, 30], 150)).toBe(30)
+    })
+  })
+
+  describe('Wait Time Stats Calculation', () => {
+    // 直接测试共享工具函数
+    it('should return null for empty array', () => {
+      expect(calculateWaitTimeStats([])).toBeNull()
+    })
+
+    it('should return null for null input', () => {
+      expect(calculateWaitTimeStats(null)).toBeNull()
+    })
+
+    it('should return null for undefined input', () => {
+      expect(calculateWaitTimeStats(undefined)).toBeNull()
+    })
+
+    it('should calculate stats correctly for typical data', () => {
+      const waitTimes = [100, 200, 150, 300, 250, 180, 220, 280, 190, 210]
+      const stats = calculateWaitTimeStats(waitTimes)
+
+      expect(stats.count).toBe(10)
+      expect(stats.min).toBe(100)
+      expect(stats.max).toBe(300)
+      // Sum: 100+150+180+190+200+210+220+250+280+300 = 2080
+      expect(stats.avg).toBe(208)
+      expect(stats.sampleSizeWarning).toBeUndefined()
+    })
+
+    it('should add warning for small sample size (< 10)', () => {
+      const waitTimes = [100, 200, 300]
+      const stats = calculateWaitTimeStats(waitTimes)
+
+      expect(stats.count).toBe(3)
+      expect(stats.sampleSizeWarning).toBe('Results may be inaccurate due to small sample size')
+    })
+
+    it('should handle single value', () => {
+      const stats = calculateWaitTimeStats([500])
+
+      expect(stats.count).toBe(1)
+      expect(stats.min).toBe(500)
+      expect(stats.max).toBe(500)
+      expect(stats.avg).toBe(500)
+      expect(stats.p50).toBe(500)
+      expect(stats.p90).toBe(500)
+      expect(stats.p99).toBe(500)
+    })
+
+    it('should sort input array before calculating', () => {
+      const waitTimes = [500, 100, 300, 200, 400]
+      const stats = calculateWaitTimeStats(waitTimes)
+
+      expect(stats.min).toBe(100)
+      expect(stats.max).toBe(500)
+    })
+
+    it('should not modify original array', () => {
+      const waitTimes = [500, 100, 300]
+      calculateWaitTimeStats(waitTimes)
+
+      expect(waitTimes).toEqual([500, 100, 300])
+    })
+  })
+
+  describe('Exponential Backoff with Jitter', () => {
+    /**
+     * 指数退避计算函数（与 auth.js 中的实现一致）
+     * @param {number} currentInterval - 当前轮询间隔
+     * @param {number} backoffFactor - 退避系数
+     * @param {number} jitterRatio - 抖动比例
+     * @param {number} maxInterval - 最大间隔
+     * @param {number} randomValue - 随机值 [0, 1)，用于确定性测试
+     */
+    function calculateNextInterval(
+      currentInterval,
+      backoffFactor,
+      jitterRatio,
+      maxInterval,
+      randomValue
+    ) {
+      let nextInterval = currentInterval * backoffFactor
+      // 抖动范围：[-jitterRatio, +jitterRatio]
+      const jitter = nextInterval * jitterRatio * (randomValue * 2 - 1)
+      nextInterval = nextInterval + jitter
+      return Math.max(1, Math.min(nextInterval, maxInterval))
+    }
+
+    it('should apply exponential backoff without jitter (randomValue=0.5)', () => {
+      // randomValue = 0.5 gives jitter = 0
+      const next = calculateNextInterval(100, 1.5, 0.2, 1000, 0.5)
+      expect(next).toBe(150) // 100 * 1.5 = 150
+    })
+
+    it('should apply maximum positive jitter (randomValue=1.0)', () => {
+      // randomValue = 1.0 gives maximum positive jitter (+20%)
+      const next = calculateNextInterval(100, 1.5, 0.2, 1000, 1.0)
+      // 100 * 1.5 = 150, jitter = 150 * 0.2 * 1 = 30
+      expect(next).toBe(180) // 150 + 30
+    })
+
+    it('should apply maximum negative jitter (randomValue=0.0)', () => {
+      // randomValue = 0.0 gives maximum negative jitter (-20%)
+      const next = calculateNextInterval(100, 1.5, 0.2, 1000, 0.0)
+      // 100 * 1.5 = 150, jitter = 150 * 0.2 * -1 = -30
+      expect(next).toBe(120) // 150 - 30
+    })
+
+    it('should respect maximum interval', () => {
+      const next = calculateNextInterval(800, 1.5, 0.2, 1000, 1.0)
+      // 800 * 1.5 = 1200, with +20% jitter = 1440, capped at 1000
+      expect(next).toBe(1000)
+    })
+
+    it('should never go below 1ms even with extreme negative jitter', () => {
+      const next = calculateNextInterval(1, 1.0, 0.9, 1000, 0.0)
+      // 1 * 1.0 = 1, jitter = 1 * 0.9 * -1 = -0.9
+      // 1 - 0.9 = 0.1, but Math.max(1, ...) ensures minimum is 1
+      expect(next).toBe(1)
+    })
+
+    it('should handle zero jitter ratio', () => {
+      const next = calculateNextInterval(100, 2.0, 0, 1000, 0.0)
+      expect(next).toBe(200) // Pure exponential, no jitter
+    })
+
+    it('should handle large backoff factor', () => {
+      const next = calculateNextInterval(100, 3.0, 0.1, 1000, 0.5)
+      expect(next).toBe(300) // 100 * 3.0 = 300
+    })
+
+    describe('jitter distribution', () => {
+      it('should produce values in expected range', () => {
+        const results = []
+        // Test with various random values
+        for (let r = 0; r <= 1; r += 0.1) {
+          results.push(calculateNextInterval(100, 1.5, 0.2, 1000, r))
+        }
+        // All values should be between 120 (150 - 30) and 180 (150 + 30)
+        expect(Math.min(...results)).toBeGreaterThanOrEqual(120)
+        expect(Math.max(...results)).toBeLessThanOrEqual(180)
+      })
+    })
+  })
+
+  describe('Queue Size Calculation', () => {
+    /**
+     * 最大排队数计算（与 auth.js 中的实现一致）
+     */
+    function calculateMaxQueueSize(concurrencyLimit, multiplier, fixedMin) {
+      return Math.max(concurrencyLimit * multiplier, fixedMin)
+    }
+
+    it('should use multiplier when result is larger', () => {
+      // concurrencyLimit=10, multiplier=2, fixedMin=5
+      // max(10*2, 5) = max(20, 5) = 20
+      expect(calculateMaxQueueSize(10, 2, 5)).toBe(20)
+    })
+
+    it('should use fixed minimum when multiplier result is smaller', () => {
+      // concurrencyLimit=2, multiplier=1, fixedMin=5
+      // max(2*1, 5) = max(2, 5) = 5
+      expect(calculateMaxQueueSize(2, 1, 5)).toBe(5)
+    })
+
+    it('should handle zero multiplier', () => {
+      // concurrencyLimit=10, multiplier=0, fixedMin=3
+      // max(10*0, 3) = max(0, 3) = 3
+      expect(calculateMaxQueueSize(10, 0, 3)).toBe(3)
+    })
+
+    it('should handle fractional multiplier', () => {
+      // concurrencyLimit=10, multiplier=1.5, fixedMin=5
+      // max(10*1.5, 5) = max(15, 5) = 15
+      expect(calculateMaxQueueSize(10, 1.5, 5)).toBe(15)
+    })
+  })
+
+  describe('TTL Calculation', () => {
+    /**
+     * 排队计数器 TTL 计算（与 redis.js 中的实现一致）
+     */
+    function calculateQueueTtl(timeoutMs, bufferSeconds = 30) {
+      return Math.ceil(timeoutMs / 1000) + bufferSeconds
+    }
+
+    it('should calculate TTL with default buffer', () => {
+      // 60000ms = 60s + 30s buffer = 90s
+      expect(calculateQueueTtl(60000)).toBe(90)
+    })
+
+    it('should round up milliseconds to seconds', () => {
+      // 61500ms = ceil(61.5) = 62s + 30s = 92s
+      expect(calculateQueueTtl(61500)).toBe(92)
+    })
+
+    it('should handle custom buffer', () => {
+      // 30000ms = 30s + 60s buffer = 90s
+      expect(calculateQueueTtl(30000, 60)).toBe(90)
+    })
+
+    it('should handle very short timeout', () => {
+      // 1000ms = 1s + 30s = 31s
+      expect(calculateQueueTtl(1000)).toBe(31)
+    })
+  })
+})

--- a/web/admin-spa/src/views/SettingsView.vue
+++ b/web/admin-spa/src/views/SettingsView.vue
@@ -898,6 +898,120 @@
               </div>
             </div>
 
+            <!-- 并发请求排队 -->
+            <div
+              class="mb-6 rounded-lg bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:bg-gray-800/80"
+            >
+              <div class="flex items-center justify-between">
+                <div class="flex items-center">
+                  <div
+                    class="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-r from-blue-500 to-cyan-500 text-white shadow-lg"
+                  >
+                    <i class="fas fa-layer-group text-xl"></i>
+                  </div>
+                  <div class="ml-4">
+                    <h4 class="text-lg font-semibold text-gray-900 dark:text-white">
+                      并发请求排队
+                    </h4>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                      当 API Key 并发请求超限时进入队列等待，而非直接拒绝
+                    </p>
+                  </div>
+                </div>
+                <label class="relative inline-flex cursor-pointer items-center">
+                  <input
+                    v-model="claudeConfig.concurrentRequestQueueEnabled"
+                    class="peer sr-only"
+                    type="checkbox"
+                    @change="saveClaudeConfig"
+                  />
+                  <div
+                    class="peer h-6 w-11 rounded-full bg-gray-200 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-blue-500 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-700 dark:peer-focus:ring-blue-800"
+                  ></div>
+                </label>
+              </div>
+
+              <!-- 排队配置详情（仅在启用时显示） -->
+              <div v-if="claudeConfig.concurrentRequestQueueEnabled" class="mt-6 space-y-4">
+                <!-- 固定最小排队数 -->
+                <div>
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <i class="fas fa-list-ol mr-2 text-gray-400"></i>
+                    固定最小排队数
+                  </label>
+                  <input
+                    v-model.number="claudeConfig.concurrentRequestQueueMaxSize"
+                    class="mt-1 block w-full max-w-xs rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-500 dark:bg-gray-700 dark:text-white sm:text-sm"
+                    max="100"
+                    min="1"
+                    placeholder="3"
+                    type="number"
+                    @change="saveClaudeConfig"
+                  />
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    最大排队数的固定最小值（1-100）
+                  </p>
+                </div>
+
+                <!-- 排队数倍数 -->
+                <div>
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <i class="fas fa-times mr-2 text-gray-400"></i>
+                    排队数倍数
+                  </label>
+                  <input
+                    v-model.number="claudeConfig.concurrentRequestQueueMaxSizeMultiplier"
+                    class="mt-1 block w-full max-w-xs rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-500 dark:bg-gray-700 dark:text-white sm:text-sm"
+                    max="10"
+                    min="0"
+                    placeholder="1"
+                    step="0.5"
+                    type="number"
+                    @change="saveClaudeConfig"
+                  />
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    最大排队数 = MAX(倍数 × 并发限制, 固定值)，设为 0 则仅使用固定值
+                  </p>
+                </div>
+
+                <!-- 排队超时时间 -->
+                <div>
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <i class="fas fa-stopwatch mr-2 text-gray-400"></i>
+                    排队超时时间（毫秒）
+                  </label>
+                  <input
+                    v-model.number="claudeConfig.concurrentRequestQueueTimeoutMs"
+                    class="mt-1 block w-full max-w-xs rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-500 dark:bg-gray-700 dark:text-white sm:text-sm"
+                    max="300000"
+                    min="5000"
+                    placeholder="10000"
+                    type="number"
+                    @change="saveClaudeConfig"
+                  />
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    请求在排队中等待的最大时间，超时将返回 429 错误（5秒-5分钟，默认10秒）
+                  </p>
+                </div>
+              </div>
+
+              <div class="mt-4 rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
+                <div class="flex">
+                  <i class="fas fa-info-circle mt-0.5 text-blue-500"></i>
+                  <div class="ml-3">
+                    <p class="text-sm text-blue-700 dark:text-blue-300">
+                      <strong>工作原理：</strong>当 API Key 的并发请求超过
+                      <code class="rounded bg-blue-100 px-1 dark:bg-blue-800"
+                        >concurrencyLimit</code
+                      >
+                      时，超限请求会进入队列等待而非直接返回 429。适合 Claude Code Agent
+                      并行工具调用场景。
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
             <!-- 配置更新信息 -->
             <div
               v-if="claudeConfig.updatedAt"
@@ -1563,9 +1677,13 @@ const claudeConfig = ref({
   globalSessionBindingEnabled: false,
   sessionBindingErrorMessage: '你的本地session已污染，请清理后使用。',
   sessionBindingTtlDays: 30,
-  userMessageQueueEnabled: true,
+  userMessageQueueEnabled: false, // 与后端默认值保持一致
   userMessageQueueDelayMs: 200,
-  userMessageQueueTimeoutMs: 30000,
+  userMessageQueueTimeoutMs: 5000, // 与后端默认值保持一致（优化后锁持有时间短无需长等待）
+  concurrentRequestQueueEnabled: false,
+  concurrentRequestQueueMaxSize: 3,
+  concurrentRequestQueueMaxSizeMultiplier: 0,
+  concurrentRequestQueueTimeoutMs: 10000,
   updatedAt: null,
   updatedBy: null
 })
@@ -1835,9 +1953,14 @@ const loadClaudeConfig = async () => {
         sessionBindingErrorMessage:
           response.config?.sessionBindingErrorMessage || '你的本地session已污染，请清理后使用。',
         sessionBindingTtlDays: response.config?.sessionBindingTtlDays ?? 30,
-        userMessageQueueEnabled: response.config?.userMessageQueueEnabled ?? true,
+        userMessageQueueEnabled: response.config?.userMessageQueueEnabled ?? false, // 与后端默认值保持一致
         userMessageQueueDelayMs: response.config?.userMessageQueueDelayMs ?? 200,
-        userMessageQueueTimeoutMs: response.config?.userMessageQueueTimeoutMs ?? 30000,
+        userMessageQueueTimeoutMs: response.config?.userMessageQueueTimeoutMs ?? 5000, // 与后端默认值保持一致
+        concurrentRequestQueueEnabled: response.config?.concurrentRequestQueueEnabled ?? false,
+        concurrentRequestQueueMaxSize: response.config?.concurrentRequestQueueMaxSize ?? 3,
+        concurrentRequestQueueMaxSizeMultiplier:
+          response.config?.concurrentRequestQueueMaxSizeMultiplier ?? 0,
+        concurrentRequestQueueTimeoutMs: response.config?.concurrentRequestQueueTimeoutMs ?? 10000,
         updatedAt: response.config?.updatedAt || null,
         updatedBy: response.config?.updatedBy || null
       }
@@ -1865,7 +1988,12 @@ const saveClaudeConfig = async () => {
       sessionBindingTtlDays: claudeConfig.value.sessionBindingTtlDays,
       userMessageQueueEnabled: claudeConfig.value.userMessageQueueEnabled,
       userMessageQueueDelayMs: claudeConfig.value.userMessageQueueDelayMs,
-      userMessageQueueTimeoutMs: claudeConfig.value.userMessageQueueTimeoutMs
+      userMessageQueueTimeoutMs: claudeConfig.value.userMessageQueueTimeoutMs,
+      concurrentRequestQueueEnabled: claudeConfig.value.concurrentRequestQueueEnabled,
+      concurrentRequestQueueMaxSize: claudeConfig.value.concurrentRequestQueueMaxSize,
+      concurrentRequestQueueMaxSizeMultiplier:
+        claudeConfig.value.concurrentRequestQueueMaxSizeMultiplier,
+      concurrentRequestQueueTimeoutMs: claudeConfig.value.concurrentRequestQueueTimeoutMs
     }
 
     const response = await apiClient.put('/admin/claude-relay-config', payload, {


### PR DESCRIPTION
为API key用户添加针对concurrency的队列机制(可选功能开启方式: 系统设置->Claude 转发->并发请求排队), 减少429 Too many concurrent requests. Limit: 2 concurrent requests
  - Add queue health check for fast-fail when overloaded (P90 > threshold)
  - Implement socket identity verification with UUID token
  - Add wait time statistics (P50/P90/P99) and queue stats tracking
  - Add admin endpoints for queue stats and cleanup
  - Add CLEAR_CONCURRENCY_QUEUES_ON_STARTUP config option
  - Update documentation with troubleshooting and proxy config guide