### PR TITLE
feat(gemini): 添加 OpenAI Chat Completions 兼容路由

### DIFF
--- a/src/routes/geminiRoutes.js
+++ b/src/routes/geminiRoutes.js
@@ -45,6 +45,20 @@ const {
  */
 router.post('/messages', authenticateApiKey, handleMessages)
 
+/**
+ * POST /chat/completions
+ * OpenAI Chat Completions 兼容端点
+ * 功能与 /messages 相同，仅路径不同
+ */
+router.post('/chat/completions', authenticateApiKey, handleMessages)
+
+/**
+ * POST /v1/chat/completions
+ * OpenAI Chat Completions 兼容端点（带 v1 前缀）
+ * 并支持gemini api key的账号
+ */
+router.post('/v1/chat/completions', authenticateApiKey, handleMessages)
+
 // ============================================================================
 // 模型和信息路由
 // ============================================================================


### PR DESCRIPTION
## Summary
- 新增 `/chat/completions` 端点，提供 OpenAI Chat Completions 格式兼容
- 新增 `/v1/chat/completions` 端点（带 v1 前缀）
- 支持使用 Gemini API Key 账号通过 OpenAI 格式调用

## Test plan
- [ ] 测试 `/gemini/chat/completions` 端点正常工作
- [ ] 测试 `/gemini/v1/chat/completions` 端点正常工作
- [ ] 验证与现有 `/gemini/messages` 端点功能一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)