### PR TITLE
fix: 修复 Gemini API 模型列表返回格式不符合 Google 规范

### DIFF
--- a/src/routes/standardGeminiRoutes.js
+++ b/src/routes/standardGeminiRoutes.js
@@ -229,6 +229,64 @@ router.get('/v1/models', authenticateApiKey, ensureGeminiPermissionMiddleware, (
   handleModels(req, res)
 })
 
+/**
+ * GET /models
+ * 获取模型列表（简化路径，兼容 Cherry Studio 等客户端）
+ */
+router.get('/models', authenticateApiKey, ensureGeminiPermissionMiddleware, (req, res) => {
+  logger.info('Standard Gemini API models request (simplified path)')
+  handleModels(req, res)
+})
+
+// ============================================================================
+// 简化路径路由（兼容 Cherry Studio 等客户端）
+// 这些路由不带 v1beta/ 或 v1/ 前缀
+// ============================================================================
+
+/**
+ * POST /models/:modelName:generateContent
+ */
+router.post(
+  '/models/:modelName\\:generateContent',
+  authenticateApiKey,
+  ensureGeminiPermissionMiddleware,
+  handleStandardGenerateContent
+)
+
+/**
+ * POST /models/:modelName:streamGenerateContent
+ */
+router.post(
+  '/models/:modelName\\:streamGenerateContent',
+  authenticateApiKey,
+  ensureGeminiPermissionMiddleware,
+  handleStandardStreamGenerateContent
+)
+
+/**
+ * POST /models/:modelName:countTokens
+ */
+router.post(
+  '/models/:modelName\\:countTokens',
+  authenticateApiKey,
+  ensureGeminiPermissionMiddleware,
+  (req, res, next) => {
+    logger.info(`Standard Gemini API request (simplified): ${req.method} ${req.originalUrl}`)
+    handleCountTokens(req, res, next)
+  }
+)
+
+/**
+ * GET /models/:modelName
+ * 获取模型详情（简化路径）
+ */
+router.get(
+  '/models/:modelName',
+  authenticateApiKey,
+  ensureGeminiPermissionMiddleware,
+  handleModelDetails
+)
+
 // ============================================================================
 // 模型详情端点
 // ============================================================================

--- a/src/services/geminiRelayService.js
+++ b/src/services/geminiRelayService.js
@@ -403,26 +403,54 @@ async function getAvailableModels(accessToken, proxy, projectId, location = 'us-
     const response = await axios(axiosConfig)
     const models = response.data.models || []
 
-    // 转换为 OpenAI 格式
-    return models
-      .filter((model) => model.supportedGenerationMethods?.includes('generateContent'))
-      .map((model) => ({
-        id: model.name.replace('models/', ''),
-        object: 'model',
-        created: Date.now() / 1000,
-        owned_by: 'google'
-      }))
+    // 返回标准 Gemini API 格式，只过滤支持 generateContent 的模型
+    return {
+      models: models.filter((model) =>
+        model.supportedGenerationMethods?.includes('generateContent')
+      ),
+      nextPageToken: response.data.nextPageToken || undefined
+    }
   } catch (error) {
     logger.error('Failed to get Gemini models:', error)
-    // 返回默认模型列表
-    return [
-      {
-        id: 'gemini-2.0-flash-exp',
-        object: 'model',
-        created: Date.now() / 1000,
-        owned_by: 'google'
-      }
-    ]
+    // 返回默认模型列表（标准 Gemini API 格式）
+    return {
+      models: [
+        {
+          name: 'models/gemini-3-pro-preview',
+          displayName: 'Gemini 3 Pro Preview',
+          description: 'Most capable Gemini 3 model for complex reasoning tasks',
+          inputTokenLimit: 1048576,
+          outputTokenLimit: 65536,
+          supportedGenerationMethods: ['generateContent', 'countTokens']
+        },
+        {
+          name: 'models/gemini-3-flash-preview',
+          displayName: 'Gemini 3 Flash Preview',
+          description: 'Fast and efficient Gemini 3 model with thinking capabilities',
+          inputTokenLimit: 1048576,
+          outputTokenLimit: 65536,
+          supportedGenerationMethods: ['generateContent', 'countTokens']
+        },
+        {
+          name: 'models/gemini-2.5-pro',
+          displayName: 'Gemini 2.5 Pro',
+          description:
+            'Our state-of-the-art thinking model, capable of reasoning over complex problems',
+          inputTokenLimit: 1048576,
+          outputTokenLimit: 65536,
+          supportedGenerationMethods: ['generateContent', 'countTokens']
+        },
+        {
+          name: 'models/gemini-2.5-flash',
+          displayName: 'Gemini 2.5 Flash',
+          description:
+            'Our best model in terms of price-performance, offering well-rounded capabilities',
+          inputTokenLimit: 1048576,
+          outputTokenLimit: 65536,
+          supportedGenerationMethods: ['generateContent', 'countTokens']
+        }
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- 修复 `handleModels` 函数返回标准 Gemini API 格式 `{ models: [...] }`
- 修复 `getAvailableModels` 函数返回原生 Google 格式而非 OpenAI 格式
- 添加 `/models/...` 正式版路由支持（Google 已将 v1beta 转为 v1 正式版）
- 更新默认模型列表包含 Gemini 3 和 Gemini 2.5 系列

### 修复前后对比

| 修复前 (OpenAI 格式) | 修复后 (Gemini 格式) |
|---------------------|---------------------|
| `{ object: 'list', data: [{ id, object, created, owned_by }] }` | `{ models: [{ name, displayName, description, ... }], nextPageToken }` |

### 新增路由（v1 正式版）

Google Gemini API 已有 v1 稳定版，项目现在支持：

| 版本 | 路由示例 |
|-----|---------|
| v1beta (测试版) | `/gemini/v1beta/models/{model}:generateContent` |
| v1 (稳定版) | `/gemini/v1/models/{model}:generateContent` |
| 正式版 | `/gemini/models/{model}:generateContent` |

### 默认模型列表

- `gemini-3-pro-preview`
- `gemini-3-flash-preview`
- `gemini-2.5-pro`
- `gemini-2.5-flash`

## Test plan

- [x] 测试 `/gemini/v1beta/models` 返回标准 Gemini 格式
- [x] 测试 `/gemini/v1/models` 返回标准 Gemini 格式
- [x] 测试 `/gemini/models` 正式版路径返回正确格式
- [x] 测试 `/gemini/models/:model:generateContent` 能正常调用
- [x] 测试 Cherry Studio 等客户端能正确获取模型列表并调用

🤖 Generated with [Claude Code](https://claude.com/claude-code)