### PR TITLE
fix: remove unused heapdump dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "google-auth-library": "^10.1.0",
-    "heapdump": "^0.3.15",
     "helmet": "^7.1.0",
     "https-proxy-agent": "^7.0.2",
     "inquirer": "^8.2.6",


### PR DESCRIPTION
## Summary

Remove the `heapdump` dependency that was added in v1.1.257 but is never used in the codebase.

## Problem

The `heapdump` package requires native compilation via `node-gyp`, which needs Python installed. This causes build failures on platforms that don't have Python in their build environment (e.g., Zeabur, some Docker images).

**Error example:**
```
gyp ERR! find Python
Could not find any Python installation to use
npm ci --only=production exit code: 1 → Build Failed
```

## Solution

Simply remove the unused dependency. Verified via grep that `heapdump` is not imported or used anywhere in `src/`.

## Test plan

- [x] Verified `heapdump` is not used in codebase (`grep -r heapdump src/` returns nothing)
- [x] Build succeeds without the dependency

🤖 Generated with [Claude Code](https://claude.ai/code)