### PR TITLE
Fix bedrock sse stream event

### DIFF
--- a/src/services/bedrockRelayService.js
+++ b/src/services/bedrockRelayService.js
@@ -343,8 +343,8 @@ class BedrockRelayService {
             res.write(`event: ${claudeEvent.type}\n`)
             res.write(`data: ${JSON.stringify(claudeEvent.data)}\n\n`)
 
-            // 提取使用统计
-            if (claudeEvent.type === 'message_stop' && claudeEvent.data.usage) {
+            // 提取使用统计 (usage is reported in message_delta per Claude API spec)
+            if (claudeEvent.type === 'message_delta' && claudeEvent.data.usage) {
               totalUsage = claudeEvent.data.usage
             }
 
@@ -576,14 +576,17 @@ class BedrockRelayService {
       return {
         type: 'message_start',
         data: {
-          type: 'message',
-          id: `msg_${Date.now()}_bedrock`,
-          role: 'assistant',
-          content: [],
-          model: this.defaultModel,
-          stop_reason: null,
-          stop_sequence: null,
-          usage: bedrockChunk.message?.usage || { input_tokens: 0, output_tokens: 0 }
+          type: 'message_start',
+          message: {
+            id: `msg_${Date.now()}_bedrock`,
+            type: 'message',
+            role: 'assistant',
+            content: [],
+            model: this.defaultModel,
+            stop_reason: null,
+            stop_sequence: null,
+            usage: bedrockChunk.message?.usage || { input_tokens: 0, output_tokens: 0 }
+          }
         }
       }
     }
@@ -603,6 +606,7 @@ class BedrockRelayService {
       return {
         type: 'content_block_delta',
         data: {
+          type: 'content_block_delta',
           index: bedrockChunk.index || 0,
           delta: bedrockChunk.delta || {}
         }
@@ -623,6 +627,7 @@ class BedrockRelayService {
       return {
         type: 'message_delta',
         data: {
+          type: 'message_delta',
           delta: bedrockChunk.delta || {},
           usage: bedrockChunk.usage || {}
         }
@@ -633,7 +638,7 @@ class BedrockRelayService {
       return {
         type: 'message_stop',
         data: {
-          usage: bedrockChunk.usage || {}
+          type: 'message_stop'
         }
       }
     }


### PR DESCRIPTION

## 问题： 

- sse stream 中的 events 和 https://platform.claude.com/docs/en/build-with-claude/streaming 不一致，导致
  - 1. 部分第三方 anthropic 兼容的客户端不能正确使用 sse stream events (如 opencode)
  - 2. claude code 不能正常使用，会在每次对话中发起两次请求。在 calude code 使用中没有报错，因为 claude code 会启动一个非 streaming 的请求。 
- 配置 aws bedrock 后，sse stream 下没有返回 tool use 的信息

---

## 修复：

### 修复 sse stream 中的 events 和官方要求不一致的问题

- claude code 中可以正常使用
<img width="1856" height="1592" alt="image" src="https://github.com/user-attachments/assets/89b259a2-5f83-40a2-b290-0a8d445c1cb0" />
<img width="1832" height="1108" alt="image" src="https://github.com/user-attachments/assets/dc9e57d4-5406-4eb6-b330-0b4f40a418ee" />

- opencode 中可以正常使用
<img width="1826" height="1978" alt="image" src="https://github.com/user-attachments/assets/e7de35ac-c11f-4c49-9427-a1e8ef18a409" />




### 修复配置 aws bedrock 后，sse stream 下没有返回 tool use 的信息
在 text/event-stream 模式下， aws bedrock 是通过 content_block_start 来返回 tool use 数据的。

https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlockStart.html

```
Tool blocks:    contentBlockStart → contentBlockDelta → contentBlockStop

```

```
event: content_block_start
data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_bdrk_01SHJ5PizFeo8DLU9KrtCsfE","name":"webfetch","input":{}}}
```

<img width="1824" height="1492" alt="image" src="https://github.com/user-attachments/assets/dceec70a-0fb9-439c-bc8f-557f6b17c188" />
