### PR TITLE
fix: OpenAI调度器添加quotaExceeded和完整状态检查

### DIFF
--- a/src/services/unifiedOpenAIScheduler.js
+++ b/src/services/unifiedOpenAIScheduler.js
@@ -452,6 +452,8 @@ class UnifiedOpenAIScheduler {
         (account.isActive === true || account.isActive === 'true') &&
         account.status !== 'error' &&
         account.status !== 'rateLimited' &&
+        account.status !== 'quotaExceeded' &&
+        account.status !== 'unauthorized' &&
         (account.accountType === 'shared' || !account.accountType)
       ) {
         const hasRateLimitFlag = this._hasRateLimitFlag(account.rateLimitStatus)
@@ -539,7 +541,9 @@ class UnifiedOpenAIScheduler {
           !account ||
           (account.isActive !== true && account.isActive !== 'true') ||
           account.status === 'error' ||
-          account.status === 'unauthorized'
+          account.status === 'unauthorized' ||
+          account.status === 'rateLimited' ||
+          account.status === 'quotaExceeded'
         ) {
           return false
         }
@@ -845,7 +849,10 @@ class UnifiedOpenAIScheduler {
         if (
           account &&
           (account.isActive === true || account.isActive === 'true') &&
-          account.status !== 'error'
+          account.status !== 'error' &&
+          account.status !== 'rateLimited' &&
+          account.status !== 'quotaExceeded' &&
+          account.status !== 'unauthorized'
         ) {
           const readiness = await this._ensureAccountReadyForScheduling(account, account.id, {
             sanitized: false


### PR DESCRIPTION
修复OpenAI账户调度时未正确过滤异常状态账户的问题：

问题根因：
- 分组调度(selectAccountFromGroup)只检查status!=='error'
- 共享池调度(_getAllAvailableAccounts)缺少quotaExceeded检查
- 账户可用性检查(_isAccountAvailable)缺少rateLimited和quotaExceeded检查
- 导致额度用尽或被限流的账户仍被选中，无法故障转移到其他账户

修复内容：
1. _getAllAvailableAccounts(): 添加quotaExceeded和unauthorized状态排除
2. selectAccountFromGroup(): 添加rateLimited/quotaExceeded/unauthorized状态排除
3. _isAccountAvailable(): 添加rateLimited和quotaExceeded状态检查

与Claude调度器(unifiedClaudeScheduler)保持一致的状态检查逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)