### PR TITLE
fix: allow new session binding after /clear command

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -370,19 +370,13 @@ async function handleMessagesRequest(req, res) {
         accountId &&
         accountType === 'claude-official'
       ) {
-        // 🚫 检测旧会话（污染的会话）
-        if (isOldSession(req.body)) {
-          const cfg = await claudeRelayConfigService.getConfig()
-          logger.warn(
-            `🚫 Old session rejected: sessionId=${originalSessionIdForBinding}, messages.length=${req.body?.messages?.length}, tools.length=${req.body?.tools?.length || 0}, isOldSession=true`
-          )
-          return res.status(400).json({
-            error: {
-              type: 'session_binding_error',
-              message: cfg.sessionBindingErrorMessage || '你的本地session已污染，请清理后使用。'
-            }
-          })
-        }
+        // 🆕 允许新 session ID 创建绑定（支持 Claude Code /clear 等场景）
+        // 信任客户端的 session ID 作为新会话的标识，不再检查请求内容
+        logger.info(
+          `🔗 Creating new session binding: sessionId=${originalSessionIdForBinding}, ` +
+            `messages.length=${req.body?.messages?.length}, tools.length=${req.body?.tools?.length || 0}, ` +
+            `accountId=${accountId}, accountType=${accountType}`
+        )
 
         // 创建绑定
         try {
@@ -928,19 +922,13 @@ async function handleMessagesRequest(req, res) {
         accountId &&
         accountType === 'claude-official'
       ) {
-        // 🚫 检测旧会话（污染的会话）
-        if (isOldSession(req.body)) {
-          const cfg = await claudeRelayConfigService.getConfig()
-          logger.warn(
-            `🚫 Old session rejected (non-stream): sessionId=${originalSessionIdForBindingNonStream}, messages.length=${req.body?.messages?.length}, tools.length=${req.body?.tools?.length || 0}, isOldSession=true`
-          )
-          return res.status(400).json({
-            error: {
-              type: 'session_binding_error',
-              message: cfg.sessionBindingErrorMessage || '你的本地session已污染，请清理后使用。'
-            }
-          })
-        }
+        // 🆕 允许新 session ID 创建绑定（支持 Claude Code /clear 等场景）
+        // 信任客户端的 session ID 作为新会话的标识，不再检查请求内容
+        logger.info(
+          `🔗 Creating new session binding (non-stream): sessionId=${originalSessionIdForBindingNonStream}, ` +
+            `messages.length=${req.body?.messages?.length}, tools.length=${req.body?.tools?.length || 0}, ` +
+            `accountId=${accountId}, accountType=${accountType}`
+        )
 
         // 创建绑定
         try {

--- a/src/services/claudeRelayConfigService.js
+++ b/src/services/claudeRelayConfigService.js
@@ -14,7 +14,7 @@ const DEFAULT_CONFIG = {
   claudeCodeOnlyEnabled: false,
   globalSessionBindingEnabled: false,
   sessionBindingErrorMessage: '你的本地session已污染，请清理后使用。',
-  sessionBindingTtlDays: 30, // 会话绑定 TTL（天），默认30天
+  sessionBindingTtlDays: 1, // 会话绑定 TTL（天），默认1天（支持 /clear 场景，避免 Redis 累积）
   // 用户消息队列配置
   userMessageQueueEnabled: false, // 是否启用用户消息队列（默认关闭）
   userMessageQueueDelayMs: 200, // 请求间隔（毫秒）

--- a/web/admin-spa/src/views/SettingsView.vue
+++ b/web/admin-spa/src/views/SettingsView.vue
@@ -1676,7 +1676,7 @@ const claudeConfig = ref({
   claudeCodeOnlyEnabled: false,
   globalSessionBindingEnabled: false,
   sessionBindingErrorMessage: '你的本地session已污染，请清理后使用。',
-  sessionBindingTtlDays: 30,
+  sessionBindingTtlDays: 1,
   userMessageQueueEnabled: false, // 与后端默认值保持一致
   userMessageQueueDelayMs: 200,
   userMessageQueueTimeoutMs: 5000, // 与后端默认值保持一致（优化后锁持有时间短无需长等待）
@@ -1952,7 +1952,7 @@ const loadClaudeConfig = async () => {
         globalSessionBindingEnabled: response.config?.globalSessionBindingEnabled ?? false,
         sessionBindingErrorMessage:
           response.config?.sessionBindingErrorMessage || '你的本地session已污染，请清理后使用。',
-        sessionBindingTtlDays: response.config?.sessionBindingTtlDays ?? 30,
+        sessionBindingTtlDays: response.config?.sessionBindingTtlDays ?? 1,
         userMessageQueueEnabled: response.config?.userMessageQueueEnabled ?? false, // 与后端默认值保持一致
         userMessageQueueDelayMs: response.config?.userMessageQueueDelayMs ?? 200,
         userMessageQueueTimeoutMs: response.config?.userMessageQueueTimeoutMs ?? 5000, // 与后端默认值保持一致


### PR DESCRIPTION
## 🐛 问题描述

  当用户在 Claude Code 中执行 `/clear` 命令后，会生成新的 session ID，但系统会检查请求内容，判定为"旧会话"，导致返回错误：

  你的本地session已污染，请清理后使用。

  ### 🔍 根本原因

  1. Claude Code 执行 `/clear` 后，`metadata.user_id` 中的 session ID 变成新的 UUID
  2. `isOldSession()` 函数检查请求内容（messages 数量、tools 等），判定为"旧会话"
  3. 系统拒绝为新 session ID 创建绑定，返回 400 错误

  ### ✅ 解决方案

  采用**方案2（放宽新会话检测）+ TTL 优化**：

  1. **移除 `isOldSession` 检查**：信任客户端的 session ID 作为新会话标识
  2. **优化 TTL 配置**：将 `sessionBindingTtlDays` 从 30 天改为 1 天，避免 Redis 内存累积
  3. **添加监控日志**：详细记录新会话绑定信息，便于追踪

  ### 📋 修改内容

  #### 1. `src/routes/api.js`（流式 + 非流式两处）

  **修改前**：
  ```javascript
  // 🚫 检测旧会话（污染的会话）
  if (isOldSession(req.body)) {
    // 拒绝请求，返回错误
  }

  修改后：
  // 🆕 允许新 session ID 创建绑定（支持 Claude Code /clear 等场景）
  // 信任客户端的 session ID 作为新会话的标识，不再检查请求内容
  logger.info(
    `🔗 Creating new session binding: sessionId=${originalSessionIdForBinding}, ` +
      `messages.length=${req.body?.messages?.length}, tools.length=${req.body?.tools?.length || 0}, ` +
      `accountId=${accountId}, accountType=${accountType}`
  )

  2. src/services/claudeRelayConfigService.js

  // 默认配置
  sessionBindingTtlDays: 1, // 从 30 天改为 1 天（支持 /clear 场景，避免 Redis 累积）

  3. web/admin-spa/src/views/SettingsView.vue（两处）

  sessionBindingTtlDays: 1, // 同步更新前端默认值

  🎯 效果

  ✅ 用户执行 /clear 后不再报错"本地session已污染"
  ✅ 自动支持 Claude Code 的新会话场景
  ✅ 1 天 TTL 自动清理过期绑定，避免内存累积
  ✅ 监控日志帮助追踪会话绑定行为

  ⚠️ 潜在风险评估
  ┌───────────────────────────┬──────────┬────────────────────────────────────────┐
  │          风险项           │ 风险等级 │                缓解措施                │
  ├───────────────────────────┼──────────┼────────────────────────────────────────┤
  │ 用户可能伪造新 session ID │ 🟡 中等  │ 大多数用户不会修改客户端，实际影响有限 │
  ├───────────────────────────┼──────────┼────────────────────────────────────────┤
  │ Redis 内存累积            │ 🟢 低    │ TTL 从 30 天缩短到 1 天，自动清理      │
  ├───────────────────────────┼──────────┼────────────────────────────────────────┤
  │ 设计意图冲突              │ 🟢 低    │ 实用主义优先，用户体验 > 理论安全      │
  └───────────────────────────┴──────────┴────────────────────────────────────────┘
  📊 测试建议

  1. 正常场景：用户在 Claude Code 中执行 /clear，新会话应正常工作
  2. 会话绑定：新 session ID 应成功创建绑定到账户
  3. TTL 验证：Redis 中的绑定记录应在 1 天后自动过期
  4. 日志检查：查看日志中的 🔗 Creating new session binding 信息

  🔗 相关讨论

  - 分支：fix/allow-new-session-after-clear
  - Commit：16e2bcf

  📝 Checklist

  - 代码已使用 Prettier 格式化
  - 同步更新前后端配置
  - 添加详细的代码注释
  - 添加监控日志
  - 风险评估完成