### PR TITLE
feat(codex): 添加 codex_exec 用户代理支持

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -264,8 +264,9 @@ const handleResponses = async (req, res) => {
     const isStream = req.body?.stream !== false // 默认为流式（兼容现有行为）
 
     // 判断是否为 Codex CLI 的请求（基于 User-Agent）
+    // 支持: codex_vscode, codex_cli_rs, codex_exec (非交互式/脚本模式)
     const userAgent = req.headers['user-agent'] || ''
-    const codexCliPattern = /^(codex_vscode|codex_cli_rs)\/[\d.]+/i
+    const codexCliPattern = /^(codex_vscode|codex_cli_rs|codex_exec)\/[\d.]+/i
     const isCodexCLI = codexCliPattern.test(userAgent)
 
     // 如果不是 Codex CLI 请求，则进行适配

--- a/src/validators/clients/codexCliValidator.js
+++ b/src/validators/clients/codexCliValidator.js
@@ -42,7 +42,8 @@ class CodexCliValidator {
       // Codex CLI 的 UA 格式:
       // - codex_vscode/0.35.0 (Windows 10.0.26100; x86_64) unknown (Cursor; 0.4.10)
       // - codex_cli_rs/0.38.0 (Ubuntu 22.4.0; x86_64) WindowsTerminal
-      const codexCliPattern = /^(codex_vscode|codex_cli_rs)\/[\d.]+/i
+      // - codex_exec/0.89.0 (Mac OS 26.2.0; arm64) xterm-256color (非交互式/脚本模式)
+      const codexCliPattern = /^(codex_vscode|codex_cli_rs|codex_exec)\/[\d.]+/i
       const uaMatch = userAgent.match(codexCliPattern)
 
       if (!uaMatch) {


### PR DESCRIPTION
支持 Codex CLI 的非交互式/脚本模式（codex exec），使其与 codex_vscode 和 codex_cli_rs 共享相同的验证逻辑和权限配置。修复 codex exec 0.89.0 版本因客户端限制导致的 403 错误。