### PR TITLE
fix: Bedrock compatibility — 修复了 bedrock 不能用的问题. cache_control sanitization, Opus 4.6 mapping, [1m] suffix stripping

### DIFF
--- a/src/services/relay/bedrockRelayService.js
+++ b/src/services/relay/bedrockRelayService.js
@@ -525,7 +525,9 @@ class BedrockRelayService {
   // Bedrock only supports { type: "ephemeral" } — extra fields like "scope"
   // (added in Claude Code v2.1.38+) cause ValidationException.
   _sanitizeCacheControl(obj) {
-    if (obj == null || typeof obj !== 'object') return obj
+    if (obj === null || obj === undefined || typeof obj !== 'object') {
+      return obj
+    }
 
     if (Array.isArray(obj)) {
       obj.forEach((item) => this._sanitizeCacheControl(item))


### PR DESCRIPTION
## Problems

### 1. cache_control.scope breaks Bedrock (Claude Code v2.1.38+)
Claude Code v2.1.38+ sends cache_control with a scope field: `{"type": "ephemeral", "scope": "global"}`. Bedrock only accepts `{"type": "ephemeral"}` — the extra scope field causes `ValidationException`.

### 2. Missing Opus 4.6 model mapping
Claude Code sends `claude-opus-4-6` but the Bedrock relay has no mapping, causing lookup failures.

### 3. `[1m]` suffix not handled
Claude Code sends e.g. `claude-opus-4-6[1m]` for the 1M context variant. The suffix isn't stripped before model lookup, so the mapping fails.

## Fixes

- **`_sanitizeCacheControl()`** — recursively strips unsupported fields from `cache_control` objects in system, messages, and tools before forwarding to Bedrock. Only the `type` field is preserved.
- **Opus 4.6 model mapping** — `claude-opus-4-6` → `global.anthropic.claude-opus-4-6-v1` (cross-region inference profile)
- **`[1m]` suffix stripping** — stripped before model lookup in `_mapToBedrockModel()` so mapping works correctly for long-context variants