### PR TITLE
Sticky session: support OpenClaw prompt_cache_key fallback

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -240,11 +240,13 @@ const handleResponses = async (req, res) => {
     }
 
     // 从请求头或请求体中提取会话 ID
+    // NOTE: For some clients, prompt_cache_key is the only stable per-session key.
     const sessionId =
       req.headers['session_id'] ||
       req.headers['x-session-id'] ||
       req.body?.session_id ||
       req.body?.conversation_id ||
+      req.body?.prompt_cache_key ||
       null
 
     sessionHash = sessionId ? crypto.createHash('sha256').update(sessionId).digest('hex') : null


### PR DESCRIPTION
This change improves sticky session routing compatibility with OpenClaw clients.

- Adds a fallback to use prompt_cache_key as the session key when session_id / conversation_id are not present.
- Minimal change: 1 line code + 1 line comment. No logging.

Context:
- OpenClaw: https://github.com/openclaw/openclaw
