### PR TITLE
fix: increase stream watchdog timeout from 45s to 90s

### DIFF
--- a/src/services/anthropicGeminiBridgeService.js
+++ b/src/services/anthropicGeminiBridgeService.js
@@ -2326,7 +2326,7 @@ async function handleAnthropicMessagesToGemini(req, res, { vendor, baseModel }) 
     // [大东的 2.0 补丁 - 修复版] 活跃度看门狗 (Watchdog)
     // ========================================================================
     let activityTimeout = null
-    const STREAM_ACTIVITY_TIMEOUT_MS = 45000 // 45秒无数据视为卡死
+    const STREAM_ACTIVITY_TIMEOUT_MS = 90000 // 90秒无数据视为卡死
 
     const resetActivityTimeout = () => {
       if (activityTimeout) {


### PR DESCRIPTION
Google upstream (Antigravity) thinking models can take >45s during the thinking phase before producing any output, especially under heavy load. The 45s watchdog was incorrectly treating these as zombie connections and terminating the stream, causing clients to receive overloaded_error and retry repeatedly.

Increased STREAM_ACTIVITY_TIMEOUT_MS from 45000ms to 90000ms to accommodate longer thinking phases.