### PR TITLE
Fix Claude Enterprise account type detection from OAuth profile

### DIFF
--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -2119,7 +2119,9 @@ class ClaudeAccountService {
           organizationType: profileData.organization?.organization_type
         })
 
-        const organizationType = String(profileData.organization?.organization_type || '').toLowerCase()
+        const organizationType = String(
+          profileData.organization?.organization_type || ''
+        ).toLowerCase()
         const isEnterpriseOrg = organizationType === 'claude_enterprise'
         const hasClaudeMax = profileData.account?.has_claude_max === true || isEnterpriseOrg
         const hasClaudePro = profileData.account?.has_claude_pro === true && !hasClaudeMax


### PR DESCRIPTION
## Summary
- treat `organization.organization_type == claude_enterprise` as Max-capable during profile sync
- keep existing Max/Pro detection behavior for non-enterprise organizations
- normalize Opus filtering to also recognize `accountType: free` (in addition to legacy `claude_free`)

## Why
Some OAuth profiles can return `has_claude_max=false` and `has_claude_pro=false` while still belonging to a Claude Enterprise organization. The previous mapping downgraded such accounts to `free`, causing Opus scheduling rejection.

## Scope
- `src/services/claudeAccountService.js`
- `src/services/unifiedClaudeScheduler.js`

## Validation
- `node --check src/services/claudeAccountService.js`
- `node --check src/services/unifiedClaudeScheduler.js`
