### PR TITLE
feat: add configurable rate limit error handling for Console accounts

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -235,7 +235,8 @@ const config = {
     serverErrorTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_5XX_TTL_SECONDS) || 300, // 5xx错误暂停秒数
     overloadTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_OVERLOAD_TTL_SECONDS) || 600, // 529过载暂停秒数
     authErrorTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_AUTH_TTL_SECONDS) || 1800, // 401/403认证错误暂停秒数
-    timeoutTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_TIMEOUT_TTL_SECONDS) || 300 // 504超时暂停秒数
+    timeoutTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_TIMEOUT_TTL_SECONDS) || 300, // 504超时暂停秒数
+    rateLimitTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_RATE_LIMIT_TTL_SECONDS) || 300 // 限流错误暂停秒数（优先使用响应头解析值）
   }
 }
 

--- a/src/services/account/claudeConsoleAccountService.js
+++ b/src/services/account/claudeConsoleAccountService.js
@@ -62,6 +62,7 @@ class ClaudeConsoleAccountService {
       supportedModels = [], // 支持的模型列表或映射表，空数组/对象表示支持所有
       userAgent = 'claude-cli/1.0.69 (external, cli)',
       rateLimitDuration = 60, // 限流时间（分钟）
+      rateLimitStatusCodes = null, // 限流触发的HTTP状态码列表，null表示使用全局配置
       proxy = null,
       isActive = true,
       accountType = 'shared', // 'dedicated' or 'shared'
@@ -94,6 +95,7 @@ class ClaudeConsoleAccountService {
       supportedModels: JSON.stringify(processedModels),
       userAgent,
       rateLimitDuration: rateLimitDuration.toString(),
+      rateLimitStatusCodes: rateLimitStatusCodes ? JSON.stringify(rateLimitStatusCodes) : '', // 账户级别的限流错误码配置
       proxy: proxy ? JSON.stringify(proxy) : '',
       isActive: isActive.toString(),
       accountType,
@@ -206,6 +208,9 @@ class ClaudeConsoleAccountService {
             rateLimitDuration: Number.isNaN(parseInt(accountData.rateLimitDuration))
               ? 60
               : parseInt(accountData.rateLimitDuration),
+            rateLimitStatusCodes: accountData.rateLimitStatusCodes
+              ? JSON.parse(accountData.rateLimitStatusCodes)
+              : null,
             isActive: accountData.isActive === 'true',
             proxy: accountData.proxy ? JSON.parse(accountData.proxy) : null,
             accountType: accountData.accountType || 'shared',
@@ -275,6 +280,9 @@ class ClaudeConsoleAccountService {
       const _parsedDuration = parseInt(accountData.rateLimitDuration)
       accountData.rateLimitDuration = Number.isNaN(_parsedDuration) ? 60 : _parsedDuration
     }
+    accountData.rateLimitStatusCodes = accountData.rateLimitStatusCodes
+      ? JSON.parse(accountData.rateLimitStatusCodes)
+      : null
     accountData.isActive = accountData.isActive === 'true'
     accountData.schedulable = accountData.schedulable !== 'false' // 默认为true
     accountData.disableAutoProtection = accountData.disableAutoProtection === 'true'
@@ -340,6 +348,11 @@ class ClaudeConsoleAccountService {
       }
       if (updates.rateLimitDuration !== undefined) {
         updatedData.rateLimitDuration = updates.rateLimitDuration.toString()
+      }
+      if (updates.rateLimitStatusCodes !== undefined) {
+        updatedData.rateLimitStatusCodes = updates.rateLimitStatusCodes
+          ? JSON.stringify(updates.rateLimitStatusCodes)
+          : ''
       }
       if (updates.proxy !== undefined) {
         updatedData.proxy = updates.proxy ? JSON.stringify(updates.proxy) : ''

--- a/src/services/relay/claudeConsoleRelayService.js
+++ b/src/services/relay/claudeConsoleRelayService.js
@@ -103,6 +103,11 @@ class ClaudeConsoleRelayService {
 
       const autoProtectionDisabled = account.disableAutoProtection === true
 
+      // 解析账户级别的限流错误码配置（优先使用账户配置，否则使用全局配置）
+      const accountRateLimitCodes = account.rateLimitStatusCodes
+        ? account.rateLimitStatusCodes
+        : [429]
+
       logger.info(
         `📤 Processing Claude Console API request for key: ${apiKeyData.name || apiKeyData.id}, account: ${account.name} (${accountId}), request: ${requestId}`
       )
@@ -349,24 +354,23 @@ class ClaudeConsoleRelayService {
         if (!autoProtectionDisabled) {
           await claudeConsoleAccountService.markConsoleAccountBlocked(accountId, errorDetails)
         }
-      } else if (response.status === 429) {
+      } else if (upstreamErrorHelper.isRateLimitError(response.status, accountRateLimitCodes)) {
         logger.warn(
-          `🚫 Rate limit detected for Claude Console account ${accountId}${autoProtectionDisabled ? ' (auto-protection disabled, skipping status change)' : ''}`
+          `🚫 Rate limit error (${response.status}) detected for Claude Console account ${accountId}${autoProtectionDisabled ? ' (auto-protection disabled, skipping status change)' : ''}`
         )
-        // 收到429先检查是否因为超过了手动配置的每日额度
+        // 收到限流错误先检查是否因为超过了手动配置的每日额度
         await claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
-          logger.error('❌ Failed to check quota after 429 error:', err)
+          logger.error('❌ Failed to check quota after rate limit error:', err)
         })
 
         if (!autoProtectionDisabled) {
           await claudeConsoleAccountService.markAccountRateLimited(accountId)
+          // 使用账户配置的限流时长（分钟转秒），如果没有配置则尝试从响应头解析
+          const accountTtl = account.rateLimitDuration ? account.rateLimitDuration * 60 : null
+          const headerTtl = upstreamErrorHelper.parseRetryAfter(response.headers)
+          const customTtl = accountTtl || headerTtl
           await upstreamErrorHelper
-            .markTempUnavailable(
-              accountId,
-              'claude-console',
-              429,
-              upstreamErrorHelper.parseRetryAfter(response.headers)
-            )
+            .markTempUnavailable(accountId, 'claude-console', response.status, customTtl)
             .catch(() => {})
         }
       } else if (response.status === 529) {
@@ -756,6 +760,12 @@ class ClaudeConsoleRelayService {
     return new Promise((resolve, reject) => {
       let aborted = false
 
+      // 解析账户级别的配置
+      const accountRateLimitCodes = account.rateLimitStatusCodes
+        ? account.rateLimitStatusCodes
+        : [429]
+      const autoProtectionDisabled = account.disableAutoProtection === true
+
       // 构建完整的API URL
       const cleanUrl = account.apiUrl.replace(/\/$/, '') // 移除末尾斜杠
       const apiEndpoint = cleanUrl.endsWith('/v1/messages') ? cleanUrl : `${cleanUrl}/v1/messages`
@@ -837,7 +847,6 @@ class ClaudeConsoleRelayService {
             })
 
             response.data.on('end', async () => {
-              const autoProtectionDisabled = account.disableAutoProtection === true
               // 记录原始错误消息到日志（方便调试，包含供应商信息）
               logger.error(
                 `📝 [Stream] Upstream error response from ${account?.name || accountId}: ${errorDataForCheck.substring(0, 500)}`
@@ -869,23 +878,26 @@ class ClaudeConsoleRelayService {
                     errorDataForCheck
                   )
                 }
-              } else if (response.status === 429) {
+              } else if (
+                upstreamErrorHelper.isRateLimitError(response.status, accountRateLimitCodes)
+              ) {
                 logger.warn(
-                  `🚫 [Stream] Rate limit detected for Claude Console account ${accountId}${autoProtectionDisabled ? ' (auto-protection disabled, skipping status change)' : ''}`
+                  `🚫 [Stream] Rate limit error (${response.status}) detected for Claude Console account ${accountId}${autoProtectionDisabled ? ' (auto-protection disabled, skipping status change)' : ''}`
                 )
                 // 检查是否因为超过每日额度
                 claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
-                  logger.error('❌ Failed to check quota after 429 error:', err)
+                  logger.error('❌ Failed to check quota after rate limit error:', err)
                 })
                 if (!autoProtectionDisabled) {
                   await claudeConsoleAccountService.markAccountRateLimited(accountId)
+                  // 使用账户配置的限流时长（分钟转秒），如果没有配置则尝试从响应头解析
+                  const accountTtl = account.rateLimitDuration
+                    ? account.rateLimitDuration * 60
+                    : null
+                  const headerTtl = upstreamErrorHelper.parseRetryAfter(response.headers)
+                  const customTtl = accountTtl || headerTtl
                   await upstreamErrorHelper
-                    .markTempUnavailable(
-                      accountId,
-                      'claude-console',
-                      429,
-                      upstreamErrorHelper.parseRetryAfter(response.headers)
-                    )
+                    .markTempUnavailable(accountId, 'claude-console', response.status, customTtl)
                     .catch(() => {})
                 }
               } else if (response.status === 529) {
@@ -1291,32 +1303,36 @@ class ClaudeConsoleRelayService {
 
           // 检查错误状态
           if (error.response) {
-            const catchAutoProtectionDisabled =
-              account?.disableAutoProtection === true || account?.disableAutoProtection === 'true'
             if (error.response.status === 401) {
-              if (!catchAutoProtectionDisabled) {
+              if (!autoProtectionDisabled) {
                 upstreamErrorHelper
                   .markTempUnavailable(accountId, 'claude-console', 401)
                   .catch(() => {})
               }
-            } else if (error.response.status === 429) {
-              if (!catchAutoProtectionDisabled) {
+            } else if (
+              upstreamErrorHelper.isRateLimitError(error.response.status, accountRateLimitCodes)
+            ) {
+              if (!autoProtectionDisabled) {
                 claudeConsoleAccountService.markAccountRateLimited(accountId)
                 // 检查是否因为超过每日额度
                 claudeConsoleAccountService.checkQuotaUsage(accountId).catch((err) => {
-                  logger.error('❌ Failed to check quota after 429 error:', err)
+                  logger.error('❌ Failed to check quota after rate limit error:', err)
                 })
+                // 使用账户配置的限流时长（分钟转秒），如果没有配置则尝试从响应头解析
+                const accountTtl = account.rateLimitDuration ? account.rateLimitDuration * 60 : null
+                const headerTtl = upstreamErrorHelper.parseRetryAfter(error.response.headers)
+                const customTtl = accountTtl || headerTtl
                 upstreamErrorHelper
                   .markTempUnavailable(
                     accountId,
                     'claude-console',
-                    429,
-                    upstreamErrorHelper.parseRetryAfter(error.response.headers)
+                    error.response.status,
+                    customTtl
                   )
                   .catch(() => {})
               }
             } else if (error.response.status === 529) {
-              if (!catchAutoProtectionDisabled) {
+              if (!autoProtectionDisabled) {
                 claudeConsoleAccountService.markAccountOverloaded(accountId)
                 upstreamErrorHelper
                   .markTempUnavailable(accountId, 'claude-console', 529)

--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -1254,20 +1254,22 @@
                   </p>
                 </div>
 
-                <div v-if="form.enableRateLimit">
-                  <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
-                    >限流时间 (分钟)</label
-                  >
-                  <input
-                    v-model.number="form.rateLimitDuration"
-                    class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
-                    min="1"
-                    placeholder="默认60分钟"
-                    type="number"
-                  />
-                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    账号被限流后暂停调度的时间（分钟）
-                  </p>
+                <div v-if="form.enableRateLimit" class="space-y-4">
+                  <div>
+                    <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                      >限流时间 (分钟)</label
+                    >
+                    <input
+                      v-model.number="form.rateLimitDuration"
+                      class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                      min="1"
+                      placeholder="默认60分钟"
+                      type="number"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      账号被限流后暂停调度的时间（分钟）
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1596,20 +1598,37 @@
                   </p>
                 </div>
 
-                <div v-if="form.enableRateLimit">
-                  <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
-                    >限流时间 (分钟)</label
-                  >
-                  <input
-                    v-model.number="form.rateLimitDuration"
-                    class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
-                    min="1"
-                    placeholder="默认60分钟"
-                    type="number"
-                  />
-                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    账号被限流后暂停调度的时间（分钟）
-                  </p>
+                <div v-if="form.enableRateLimit" class="space-y-4">
+                  <div>
+                    <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                      >限流时间 (分钟)</label
+                    >
+                    <input
+                      v-model.number="form.rateLimitDuration"
+                      class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                      min="1"
+                      placeholder="默认60分钟"
+                      type="number"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      账号被限流后暂停调度的时间（分钟）
+                    </p>
+                  </div>
+
+                  <div v-if="form.platform === 'claude-console'">
+                    <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                      >限流错误码</label
+                    >
+                    <input
+                      v-model="form.rateLimitStatusCodesInput"
+                      class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                      placeholder="429"
+                      type="text"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      配置哪些 HTTP 状态码会触发限流保护，多个状态码用逗号分隔（如 402,429,503）
+                    </p>
+                  </div>
                 </div>
               </div>
 
@@ -3360,17 +3379,34 @@
                 </p>
               </div>
 
-              <div v-if="form.enableRateLimit">
-                <label class="mb-3 block text-sm font-semibold text-gray-700"
-                  >限流时间 (分钟)</label
-                >
-                <input
-                  v-model.number="form.rateLimitDuration"
-                  class="form-input w-full"
-                  min="1"
-                  type="number"
-                />
-                <p class="mt-1 text-xs text-gray-500">账号被限流后暂停调度的时间（分钟）</p>
+              <div v-if="form.enableRateLimit" class="space-y-4">
+                <div>
+                  <label class="mb-3 block text-sm font-semibold text-gray-700"
+                    >限流时间 (分钟)</label
+                  >
+                  <input
+                    v-model.number="form.rateLimitDuration"
+                    class="form-input w-full"
+                    min="1"
+                    type="number"
+                  />
+                  <p class="mt-1 text-xs text-gray-500">账号被限流后暂停调度的时间（分钟）</p>
+                </div>
+
+                <div v-if="form.platform === 'claude-console'">
+                  <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                    >限流错误码</label
+                  >
+                  <input
+                    v-model="form.rateLimitStatusCodesInput"
+                    class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                    placeholder="429"
+                    type="text"
+                  />
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    配置哪些 HTTP 状态码会触发限流保护，多个状态码用逗号分隔（如 402,429,503）
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -4293,6 +4329,25 @@ const form = ref({
   disableAutoProtection:
     props.account?.disableAutoProtection === true ||
     props.account?.disableAutoProtection === 'true',
+  // Claude Console 限流配置
+  rateLimitStatusCodesInput: (() => {
+    if (props.account?.rateLimitStatusCodes) {
+      let codes = props.account.rateLimitStatusCodes
+      // 兼容处理：后端可能返回数组或 JSON 字符串
+      if (typeof codes === 'string') {
+        try {
+          codes = JSON.parse(codes)
+        } catch {
+          // 如果解析失败，返回默认值
+          return '429'
+        }
+      }
+      if (Array.isArray(codes) && codes.length > 0) {
+        return codes.join(',')
+      }
+    }
+    return '429'
+  })(),
   // 额度管理字段
   dailyQuota: props.account?.dailyQuota || 0,
   dailyUsage: props.account?.dailyUsage || 0,
@@ -5421,6 +5476,16 @@ const createAccount = async () => {
       data.userAgent = form.value.userAgent || null
       // 如果不启用限流，传递 0 表示不限流
       data.rateLimitDuration = form.value.enableRateLimit ? form.value.rateLimitDuration || 60 : 0
+      // 解析限流错误码
+      if (form.value.platform === 'claude-console' && form.value.rateLimitStatusCodesInput) {
+        const codes = form.value.rateLimitStatusCodesInput
+          .split(',')
+          .map((code) => parseInt(code.trim()))
+          .filter((code) => !isNaN(code) && code >= 400 && code <= 599)
+        data.rateLimitStatusCodes = codes.length > 0 ? codes : [429]
+      } else if (form.value.platform === 'claude-console') {
+        data.rateLimitStatusCodes = [429]
+      }
       if (form.value.platform === 'claude-console') {
         data.interceptWarmup = !!form.value.interceptWarmup
       }
@@ -5489,6 +5554,13 @@ const createAccount = async () => {
     // 支持 disableAutoProtection 的平台才写入
     if (autoProtectionPlatforms.includes(form.value.platform)) {
       data.disableAutoProtection = !!form.value.disableAutoProtection
+    }
+
+    // Claude Console 限流配置
+    if (form.value.platform === 'claude-console') {
+      if (form.value.rateLimitStatusCodes && form.value.rateLimitStatusCodes.length > 0) {
+        data.rateLimitStatusCodes = form.value.rateLimitStatusCodes
+      }
     }
 
     let result
@@ -5768,6 +5840,16 @@ const updateAccount = async () => {
       data.userAgent = form.value.userAgent || null
       // 如果不启用限流，传递 0 表示不限流
       data.rateLimitDuration = form.value.enableRateLimit ? form.value.rateLimitDuration || 60 : 0
+      // 解析限流错误码
+      if (form.value.rateLimitStatusCodesInput) {
+        const codes = form.value.rateLimitStatusCodesInput
+          .split(',')
+          .map((code) => parseInt(code.trim()))
+          .filter((code) => !isNaN(code) && code >= 400 && code <= 599)
+        data.rateLimitStatusCodes = codes.length > 0 ? codes : [429]
+      } else {
+        data.rateLimitStatusCodes = [429]
+      }
       // 拦截预热请求
       data.interceptWarmup = !!form.value.interceptWarmup
       // 额度管理字段
@@ -6393,6 +6475,23 @@ watch(
         enableRateLimit:
           newAccount.rateLimitDuration && newAccount.rateLimitDuration > 0 ? true : false,
         rateLimitDuration: newAccount.rateLimitDuration || 60,
+        rateLimitStatusCodesInput: (() => {
+          if (newAccount.rateLimitStatusCodes) {
+            let codes = newAccount.rateLimitStatusCodes
+            // 兼容处理：后端可能返回数组或 JSON 字符串
+            if (typeof codes === 'string') {
+              try {
+                codes = JSON.parse(codes)
+              } catch {
+                return '429'
+              }
+            }
+            if (Array.isArray(codes) && codes.length > 0) {
+              return codes.join(',')
+            }
+          }
+          return '429'
+        })(),
         // Bedrock 特定字段
         accessKeyId: '', // 编辑模式不显示现有的访问密钥
         secretAccessKey: '', // 编辑模式不显示现有的秘密密钥


### PR DESCRIPTION
- Add rateLimitStatusCodes configuration field for Claude Console accounts
- Support custom HTTP status codes (e.g., 402, 429, 503) to trigger rate limiting
- Add input field in account form for comma-separated status codes
- Handle both string and array formats from backend for compatibility
- Add proper parsing and validation in create/update account functions
- Remove dead code in bedrock section that incorrectly checks for claude-console
- Fix bug in update function that accessed non-existent form field

