### PR TITLE
feat: 优化 Console 账户限流自动解除机制

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -235,7 +235,8 @@ const config = {
     serverErrorTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_5XX_TTL_SECONDS) || 300, // 5xx错误暂停秒数
     overloadTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_OVERLOAD_TTL_SECONDS) || 600, // 529过载暂停秒数
     authErrorTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_AUTH_TTL_SECONDS) || 1800, // 401/403认证错误暂停秒数
-    timeoutTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_TIMEOUT_TTL_SECONDS) || 300 // 504超时暂停秒数
+    timeoutTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_TIMEOUT_TTL_SECONDS) || 300, // 504超时暂停秒数
+    rateLimitTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_RATE_LIMIT_TTL_SECONDS) || 300 // 限流错误暂停秒数（优先使用响应头解析值）
   }
 }
 

--- a/src/utils/upstreamErrorHelper.js
+++ b/src/utils/upstreamErrorHelper.js
@@ -2,6 +2,9 @@ const logger = require('./logger')
 
 const TEMP_UNAVAILABLE_PREFIX = 'temp_unavailable'
 
+// 默认限流错误码列表（用于非 Claude Console 账户）
+const DEFAULT_RATE_LIMIT_STATUS_CODES = [429]
+
 // 默认 TTL（秒）
 const DEFAULT_TTL = {
   server_error: 300, // 5xx: 5分钟
@@ -31,8 +34,13 @@ const getTtlConfig = () => {
     overload: config.upstreamError?.overloadTtlSeconds ?? DEFAULT_TTL.overload,
     auth_error: config.upstreamError?.authErrorTtlSeconds ?? DEFAULT_TTL.auth_error,
     timeout: config.upstreamError?.timeoutTtlSeconds ?? DEFAULT_TTL.timeout,
-    rate_limit: DEFAULT_TTL.rate_limit
+    rate_limit: config.upstreamError?.rateLimitTtlSeconds ?? DEFAULT_TTL.rate_limit
   }
+}
+
+// 获取默认的限流错误码列表（用于非 Claude Console 账户）
+const getDefaultRateLimitStatusCodes = () => {
+  return DEFAULT_RATE_LIMIT_STATUS_CODES
 }
 
 // 延迟加载 redis，避免循环依赖
@@ -45,7 +53,13 @@ const getRedis = () => {
 }
 
 // 根据 HTTP 状态码分类错误类型
-const classifyError = (statusCode) => {
+// accountRateLimitCodes: 账户级别的限流错误码配置（可选），如果提供则优先使用
+const classifyError = (statusCode, accountRateLimitCodes = null) => {
+  // 优先判断限流错误（优先级最高）
+  const rateLimitCodes = accountRateLimitCodes || getDefaultRateLimitStatusCodes()
+  if (rateLimitCodes.includes(statusCode)) {
+    return 'rate_limit'
+  }
   if (statusCode === 529) {
     return 'overload'
   }
@@ -55,13 +69,17 @@ const classifyError = (statusCode) => {
   if (statusCode === 401 || statusCode === 403) {
     return 'auth_error'
   }
-  if (statusCode === 429) {
-    return 'rate_limit'
-  }
   if (statusCode >= 500) {
     return 'server_error'
   }
   return null
+}
+
+// 判断状态码是否为限流错误（用于替代硬编码的 402/429 判断）
+// accountRateLimitCodes: 账户级别的限流错误码配置（可选），如果提供则优先使用
+const isRateLimitError = (statusCode, accountRateLimitCodes = null) => {
+  const rateLimitCodes = accountRateLimitCodes || getDefaultRateLimitStatusCodes()
+  return rateLimitCodes.includes(statusCode)
 }
 
 // 解析 429 响应头中的重置时间（返回秒数）
@@ -111,9 +129,16 @@ const parseRetryAfter = (headers) => {
 }
 
 // 标记账户为临时不可用
-const markTempUnavailable = async (accountId, accountType, statusCode, customTtl = null) => {
+// accountRateLimitCodes: 账户级别的限流错误码配置（可选），如果提供则优先使用
+const markTempUnavailable = async (
+  accountId,
+  accountType,
+  statusCode,
+  customTtl = null,
+  accountRateLimitCodes = null
+) => {
   try {
-    const errorType = classifyError(statusCode)
+    const errorType = classifyError(statusCode, accountRateLimitCodes)
     if (!errorType) {
       return { success: false, reason: 'not_a_pausable_error' }
     }
@@ -251,5 +276,6 @@ module.exports = {
   classifyError,
   parseRetryAfter,
   sanitizeErrorForClient,
+  isRateLimitError,
   TEMP_UNAVAILABLE_PREFIX
 }

--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -1254,20 +1254,22 @@
                   </p>
                 </div>
 
-                <div v-if="form.enableRateLimit">
-                  <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
-                    >限流时间 (分钟)</label
-                  >
-                  <input
-                    v-model.number="form.rateLimitDuration"
-                    class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
-                    min="1"
-                    placeholder="默认60分钟"
-                    type="number"
-                  />
-                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    账号被限流后暂停调度的时间（分钟）
-                  </p>
+                <div v-if="form.enableRateLimit" class="space-y-4">
+                  <div>
+                    <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                      >限流时间 (分钟)</label
+                    >
+                    <input
+                      v-model.number="form.rateLimitDuration"
+                      class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                      min="1"
+                      placeholder="默认60分钟"
+                      type="number"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      账号被限流后暂停调度的时间（分钟）
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1596,20 +1598,37 @@
                   </p>
                 </div>
 
-                <div v-if="form.enableRateLimit">
-                  <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
-                    >限流时间 (分钟)</label
-                  >
-                  <input
-                    v-model.number="form.rateLimitDuration"
-                    class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
-                    min="1"
-                    placeholder="默认60分钟"
-                    type="number"
-                  />
-                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    账号被限流后暂停调度的时间（分钟）
-                  </p>
+                <div v-if="form.enableRateLimit" class="space-y-4">
+                  <div>
+                    <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                      >限流时间 (分钟)</label
+                    >
+                    <input
+                      v-model.number="form.rateLimitDuration"
+                      class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                      min="1"
+                      placeholder="默认60分钟"
+                      type="number"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      账号被限流后暂停调度的时间（分钟）
+                    </p>
+                  </div>
+
+                  <div v-if="form.platform === 'claude-console'">
+                    <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                      >限流错误码</label
+                    >
+                    <input
+                      v-model="form.rateLimitStatusCodesInput"
+                      class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                      placeholder="429"
+                      type="text"
+                    />
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      配置哪些 HTTP 状态码会触发限流保护，多个状态码用逗号分隔（如 402,429,503）
+                    </p>
+                  </div>
                 </div>
               </div>
 
@@ -3360,17 +3379,34 @@
                 </p>
               </div>
 
-              <div v-if="form.enableRateLimit">
-                <label class="mb-3 block text-sm font-semibold text-gray-700"
-                  >限流时间 (分钟)</label
-                >
-                <input
-                  v-model.number="form.rateLimitDuration"
-                  class="form-input w-full"
-                  min="1"
-                  type="number"
-                />
-                <p class="mt-1 text-xs text-gray-500">账号被限流后暂停调度的时间（分钟）</p>
+              <div v-if="form.enableRateLimit" class="space-y-4">
+                <div>
+                  <label class="mb-3 block text-sm font-semibold text-gray-700"
+                    >限流时间 (分钟)</label
+                  >
+                  <input
+                    v-model.number="form.rateLimitDuration"
+                    class="form-input w-full"
+                    min="1"
+                    type="number"
+                  />
+                  <p class="mt-1 text-xs text-gray-500">账号被限流后暂停调度的时间（分钟）</p>
+                </div>
+
+                <div v-if="form.platform === 'claude-console'">
+                  <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                    >限流错误码</label
+                  >
+                  <input
+                    v-model="form.rateLimitStatusCodesInput"
+                    class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                    placeholder="429"
+                    type="text"
+                  />
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    配置哪些 HTTP 状态码会触发限流保护，多个状态码用逗号分隔（如 402,429,503）
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -4293,6 +4329,25 @@ const form = ref({
   disableAutoProtection:
     props.account?.disableAutoProtection === true ||
     props.account?.disableAutoProtection === 'true',
+  // Claude Console 限流配置
+  rateLimitStatusCodesInput: (() => {
+    if (props.account?.rateLimitStatusCodes) {
+      let codes = props.account.rateLimitStatusCodes
+      // 兼容处理：后端可能返回数组或 JSON 字符串
+      if (typeof codes === 'string') {
+        try {
+          codes = JSON.parse(codes)
+        } catch {
+          // 如果解析失败，返回默认值
+          return '429'
+        }
+      }
+      if (Array.isArray(codes) && codes.length > 0) {
+        return codes.join(',')
+      }
+    }
+    return '429'
+  })(),
   // 额度管理字段
   dailyQuota: props.account?.dailyQuota || 0,
   dailyUsage: props.account?.dailyUsage || 0,
@@ -5421,6 +5476,16 @@ const createAccount = async () => {
       data.userAgent = form.value.userAgent || null
       // 如果不启用限流，传递 0 表示不限流
       data.rateLimitDuration = form.value.enableRateLimit ? form.value.rateLimitDuration || 60 : 0
+      // 解析限流错误码
+      if (form.value.platform === 'claude-console' && form.value.rateLimitStatusCodesInput) {
+        const codes = form.value.rateLimitStatusCodesInput
+          .split(',')
+          .map((code) => parseInt(code.trim()))
+          .filter((code) => !isNaN(code) && code >= 400 && code <= 599)
+        data.rateLimitStatusCodes = codes.length > 0 ? codes : [429]
+      } else if (form.value.platform === 'claude-console') {
+        data.rateLimitStatusCodes = [429]
+      }
       if (form.value.platform === 'claude-console') {
         data.interceptWarmup = !!form.value.interceptWarmup
       }
@@ -5489,6 +5554,13 @@ const createAccount = async () => {
     // 支持 disableAutoProtection 的平台才写入
     if (autoProtectionPlatforms.includes(form.value.platform)) {
       data.disableAutoProtection = !!form.value.disableAutoProtection
+    }
+
+    // Claude Console 限流配置
+    if (form.value.platform === 'claude-console') {
+      if (form.value.rateLimitStatusCodes && form.value.rateLimitStatusCodes.length > 0) {
+        data.rateLimitStatusCodes = form.value.rateLimitStatusCodes
+      }
     }
 
     let result
@@ -5768,6 +5840,16 @@ const updateAccount = async () => {
       data.userAgent = form.value.userAgent || null
       // 如果不启用限流，传递 0 表示不限流
       data.rateLimitDuration = form.value.enableRateLimit ? form.value.rateLimitDuration || 60 : 0
+      // 解析限流错误码
+      if (form.value.rateLimitStatusCodesInput) {
+        const codes = form.value.rateLimitStatusCodesInput
+          .split(',')
+          .map((code) => parseInt(code.trim()))
+          .filter((code) => !isNaN(code) && code >= 400 && code <= 599)
+        data.rateLimitStatusCodes = codes.length > 0 ? codes : [429]
+      } else {
+        data.rateLimitStatusCodes = [429]
+      }
       // 拦截预热请求
       data.interceptWarmup = !!form.value.interceptWarmup
       // 额度管理字段
@@ -6393,6 +6475,23 @@ watch(
         enableRateLimit:
           newAccount.rateLimitDuration && newAccount.rateLimitDuration > 0 ? true : false,
         rateLimitDuration: newAccount.rateLimitDuration || 60,
+        rateLimitStatusCodesInput: (() => {
+          if (newAccount.rateLimitStatusCodes) {
+            let codes = newAccount.rateLimitStatusCodes
+            // 兼容处理：后端可能返回数组或 JSON 字符串
+            if (typeof codes === 'string') {
+              try {
+                codes = JSON.parse(codes)
+              } catch {
+                return '429'
+              }
+            }
+            if (Array.isArray(codes) && codes.length > 0) {
+              return codes.join(',')
+            }
+          }
+          return '429'
+        })(),
         // Bedrock 特定字段
         accessKeyId: '', // 编辑模式不显示现有的访问密钥
         secretAccessKey: '', // 编辑模式不显示现有的秘密密钥


### PR DESCRIPTION
## 功能概述

优化 Console 账户的限流处理机制，支持账户级别的限流错误码配置，并实现智能的限流自动解除功能。

## 主要改进

### 1. 账户级别限流错误码配置

**新增字段**: `rateLimitStatusCodes`
- 支持为每个 Console 账户配置自定义的限流 HTTP 状态码列表
- 默认值为 `null`，表示使用全局默认配置 `[429]`
- 可配置多个状态码，如 `[402, 429]`，满足不同上游 API 的限流响应

**优先级机制**:
1. 账户级别配置（`account.rateLimitStatusCodes`）
2. 全局默认配置（`[429]`）

**涉及文件**:
- `src/services/account/claudeConsoleAccountService.js`: 添加字段存储和解析
- `src/utils/upstreamErrorHelper.js`: 新增 `isRateLimitError()` 方法，支持账户级配置
- `src/services/relay/claudeConsoleRelayService.js`: 使用账户配置判断限流错误
- `web/admin-spa/src/components/accounts/AccountForm.vue`: 前端表单支持配置

### 2. 智能限流自动解除

**核心逻辑**: 在 `isAccountRateLimited()` 检查时自动解除到期的限流状态

**新增方法**:
- `_getResetTimeOnDate(account, date)`: 获取指定日期当天的配额重置时间点
- `_getNextResetTimeAfter(account, afterDate)`: 获取指定时间之后的第一个配额重置时间点

**解除条件**（按优先级）:
1. **配额重置时间到达**: 如果当前时间已过限流触发后的第一个配额重置时间点，立即解除限流
2. **限流时长到期**: 如果距离限流触发时间已超过配置的 `rateLimitDuration`，解除限流

**实现细节**:
```javascript
// 获取限流触发之后的第一个配额重置时间点
const nextResetTime = this._getNextResetTimeAfter(account, rateLimitedAt)

// 如果当前时间已经过了配额重置时间点，立即解除限流
if (now >= nextResetTime) {
  logger.info(`🔄 Auto-clearing rate limit for account ${accountId} (quota reset time reached)`)
  await this.removeAccountRateLimit(accountId)
  return false
}
```

### 3. 错误判断优先级优化

**调整前**: 按 HTTP 状态码顺序判断（401 → 403 → 429 → 529 → 5xx）

**调整后**: 限流错误优先级最高
1. **限流错误** (使用账户配置或默认 `[429]`)
2. 过载错误 (529)
3. 认证错误 (401/403)
4. 超时错误 (504)
5. 服务器错误 (5xx)

**原因**: 确保账户级别的限流配置能够正确生效，避免被其他错误类型误判

### 4. 代码优化

**移除重复逻辑**: 删除 `resetDailyUsage()` 中的限流清除代码
- 原逻辑: 在配额重置时无条件清除限流状态
- 优化后: 统一由 `isAccountRateLimited()` 在检查时自动处理
- 好处: 避免逻辑重复，提升代码可维护性

### 5. 全局配置支持

**新增配置项**: `UPSTREAM_ERROR_RATE_LIMIT_TTL_SECONDS`
- 默认值: 300 秒（5 分钟）
- 用途: 限流错误的默认暂停时长（优先使用响应头解析值或账户配置）

## 技术细节

### 限流错误处理流程

```
请求失败 → 判断状态码是否为限流错误（使用账户配置）
  ↓ 是
检查配额使用情况 → 标记账户为 rate_limited
  ↓
计算暂停时长（优先级：账户配置 > 响应头 > 全局配置）
  ↓
标记账户临时不可用
```

### 限流自动解除流程

```
调度器选择账户 → isAccountRateLimited() 检查
  ↓
计算限流触发后的第一个配额重置时间点
  ↓
当前时间 >= 重置时间点？
  ↓ 是                    ↓ 否
解除限流，返回 false    检查限流时长是否到期
                          ↓ 是        ↓ 否
                    解除限流      保持限流状态
```

## 测试建议

1. **账户级配置测试**
   - 配置 `rateLimitStatusCodes: [402, 429]`
   - 验证 402 和 429 状态码都能触发限流

2. **自动解除测试**
   - 触发限流后，等待配额重置时间到达
   - 验证账户自动恢复可用

3. **优先级测试**
   - 同时满足多种错误条件
   - 验证限流错误优先级最高

4. **兼容性测试**
   - 未配置 `rateLimitStatusCodes` 的账户
   - 验证使用默认 `[429]` 配置