### PR TITLE
fix: errorSanitizer 无法识别 Anthropic 错误格式导致 400 误映射为 E015/500

### DIFF
--- a/src/utils/errorSanitizer.js
+++ b/src/utils/errorSanitizer.js
@@ -56,7 +56,7 @@ const ERROR_MATCHERS = [
   { pattern: /model.*not.*found|model.*unavailable|unsupported.*model/i, code: 'E006' },
 
   // 请求错误
-  { pattern: /bad.*request|invalid.*request|malformed/i, code: 'E005' },
+  { pattern: /bad.*request|invalid.*request|invalid.*argument|malformed/i, code: 'E005' },
   { pattern: /not.*found|404/i, code: 'E010' },
 
   // 上游错误
@@ -157,6 +157,9 @@ function extractOriginalMessage(error) {
   }
   if (error.message) {
     return error.message
+  }
+  if (error.error?.message) {
+    return error.error.message
   }
   if (error.response?.data?.error?.message) {
     return error.response.data.error.message


### PR DESCRIPTION
## Summary

- `extractOriginalMessage` 新增 `error.error?.message` 路径检查，支持 Anthropic 标准错误格式 `{"error":{"message":"..."}}`
- `ERROR_MATCHERS` 增加 `invalid.*argument` 模式匹配 Antigravity 返回的 `INVALID_ARGUMENT` 类型错误

## Problem

上游返回 400 错误时（如 `prompt is too long`、`tool_use.id` 格式不合法、Antigravity 的 `INVALID_ARGUMENT`），`extractOriginalMessage` 无法从 `{"error":{"message":"..."}}` 格式中提取消息，导致所有 400 错误回退为默认的 E015 (Internal server error, 500)。

**根因**：`extractOriginalMessage` 只检查 `error.message`（标准 Error 对象）和 `error.response.data.error.message`（axios 错误），未覆盖 `error.error.message`（Anthropic API 响应体格式）。

**Antigravity 错误格式**：
```json
{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"Request contains an invalid argument"}}
```
此格式中消息在 `error.error.message`，且 `"Request contains an invalid argument"` 不匹配原有的 `invalid.*request` 模式（`invalid` 后跟的是 `argument` 而非 `request`），需要增加 `invalid.*argument` 匹配规则。

## Test plan

- [ ] 验证 `prompt is too long` 错误映射到 E005 (400)
- [ ] 验证 `tool_use.id` 格式错误映射到 E005 (400)
- [ ] 验证 Antigravity `INVALID_ARGUMENT` 错误映射到 E005 (400)
- [ ] 验证现有错误映射不受影响（E001-E014）