### PR TITLE
feat: add Claude 4.6 and GPT-5.2/5.3 model support

### DIFF
--- a/config/models.js
+++ b/config/models.js
@@ -5,6 +5,7 @@
 
 const CLAUDE_MODELS = [
   { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   { value: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5' },
   { value: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5' },
   { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
@@ -37,6 +38,7 @@ const OPENAI_MODELS = [
 
 const BEDROCK_MODELS = [
   { value: 'us.anthropic.claude-opus-4-6-20250610-v1:0', label: 'Claude Opus 4.6' },
+  { value: 'us.anthropic.claude-sonnet-4-6-v1:0', label: 'Claude Sonnet 4.6' },
   { value: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', label: 'Claude Sonnet 4.5' },
   { value: 'us.anthropic.claude-sonnet-4-20250514-v1:0', label: 'Claude Sonnet 4' },
   { value: 'us.anthropic.claude-3-5-haiku-20241022-v1:0', label: 'Claude 3.5 Haiku' }

--- a/resources/model-pricing/model_prices_and_context_window.json
+++ b/resources/model-pricing/model_prices_and_context_window.json
@@ -4765,7 +4765,59 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
+    "anthropic/claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
     "claude-sonnet-4-5-20250929": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
+    "claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -19696,6 +19748,32 @@
         "tool_use_system_prompt_tokens": 159
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
+    "us.anthropic.claude-sonnet-4-6-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,

--- a/src/services/modelService.js
+++ b/src/services/modelService.js
@@ -30,6 +30,8 @@ class ModelService {
         provider: 'anthropic',
         description: 'Claude models from Anthropic',
         models: [
+          'claude-opus-4-6',
+          'claude-sonnet-4-6',
           'claude-opus-4-5-20251101',
           'claude-haiku-4-5-20251001',
           'claude-sonnet-4-5-20250929',
@@ -47,6 +49,9 @@ class ModelService {
         provider: 'openai',
         description: 'OpenAI GPT models',
         models: [
+          'gpt-5.3-codex',
+          'gpt-5.2',
+          'gpt-5.2-codex',
           'gpt-5.1-2025-11-13',
           'gpt-5.1-codex-mini',
           'gpt-5.1-codex',

--- a/src/services/pricingService.js
+++ b/src/services/pricingService.js
@@ -53,6 +53,9 @@ class PricingService {
       'claude-sonnet-3-7': 0.000006,
       'claude-sonnet-4': 0.000006,
       'claude-sonnet-4-20250514': 0.000006,
+      'claude-sonnet-4-5': 0.000006,
+      'claude-sonnet-4-5-20250929': 0.000006,
+      'claude-sonnet-4-6': 0.000006,
 
       // Haiku 系列: $1.6/MTok
       'claude-3-5-haiku': 0.0000016,
@@ -71,8 +74,12 @@ class PricingService {
       'claude-sonnet-4-20250514[1m]': {
         input: 0.000006, // $6/MTok
         output: 0.0000225 // $22.50/MTok
+      },
+      // claude-sonnet-4-6[1m] 模型的 1M 上下文价格
+      'claude-sonnet-4-6[1m]': {
+        input: 0.000006, // $6/MTok
+        output: 0.0000225 // $22.50/MTok
       }
-      // 未来可以添加更多 1M 模型的价格
     }
   }
 

--- a/src/services/relay/bedrockRelayService.js
+++ b/src/services/relay/bedrockRelayService.js
@@ -438,6 +438,9 @@ class BedrockRelayService {
   _mapToBedrockModel(modelName) {
     // 标准Claude模型名到Bedrock模型名的映射表
     const modelMapping = {
+      // Claude 4.6 Sonnet
+      'claude-sonnet-4-6': 'us.anthropic.claude-sonnet-4-6-v1:0',
+
       // Claude 4.5 Opus
       'claude-opus-4-5': 'us.anthropic.claude-opus-4-5-20251101-v1:0',
       'claude-opus-4-5-20251101': 'us.anthropic.claude-opus-4-5-20251101-v1:0',
@@ -697,6 +700,12 @@ class BedrockRelayService {
 
       // Bedrock暂不支持列出推理配置文件的API，返回预定义的模型列表
       const models = [
+        {
+          id: 'us.anthropic.claude-sonnet-4-6-v1:0',
+          name: 'Claude Sonnet 4.6',
+          provider: 'anthropic',
+          type: 'bedrock'
+        },
         {
           id: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
           name: 'Claude Sonnet 4',


### PR DESCRIPTION
Add claude-opus-4-6, claude-sonnet-4-6 (Anthropic latest), gpt-5.3-codex, gpt-5.2, gpt-5.2-codex (OpenAI latest) to supported models list in modelService.

补充 /v1/models 中支持的模型