### PR TITLE
feat: add gemini-3.1-pro-preview model support

### DIFF
--- a/config/models.js
+++ b/config/models.js
@@ -18,7 +18,8 @@ const GEMINI_MODELS = [
   { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
   { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
   { value: 'gemini-3-pro-preview', label: 'Gemini 3 Pro Preview' },
-  { value: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview' }
+  { value: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview' },
+  { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview' }
 ]
 
 const OPENAI_MODELS = [

--- a/src/services/modelService.js
+++ b/src/services/modelService.js
@@ -58,7 +58,12 @@ class ModelService {
       gemini: {
         provider: 'google',
         description: 'Google Gemini models',
-        models: ['gemini-2.5-pro', 'gemini-3-pro-preview', 'gemini-2.5-flash']
+        models: [
+          'gemini-2.5-pro',
+          'gemini-3-pro-preview',
+          'gemini-3.1-pro-preview',
+          'gemini-2.5-flash'
+        ]
       }
     }
   }

--- a/src/utils/antigravityModel.js
+++ b/src/utils/antigravityModel.js
@@ -4,6 +4,7 @@ const UPSTREAM_TO_ALIAS = {
   'rev19-uic3-1p': 'gemini-2.5-computer-use-preview-10-2025',
   'gemini-3-pro-image': 'gemini-3-pro-image-preview',
   'gemini-3-pro-high': 'gemini-3-pro-preview',
+  'gemini-3.1-pro-high': 'gemini-3.1-pro-preview',
   'gemini-3-flash': 'gemini-3-flash-preview',
   'claude-sonnet-4-5': 'gemini-claude-sonnet-4-5',
   'claude-sonnet-4-5-thinking': 'gemini-claude-sonnet-4-5-thinking',
@@ -13,6 +14,7 @@ const UPSTREAM_TO_ALIAS = {
   chat_23310: '',
   'gemini-2.5-flash-thinking': '',
   'gemini-3-pro-low': '',
+  'gemini-3.1-pro-low': '',
   'gemini-2.5-pro': ''
 }
 
@@ -20,6 +22,7 @@ const ALIAS_TO_UPSTREAM = {
   'gemini-2.5-computer-use-preview-10-2025': 'rev19-uic3-1p',
   'gemini-3-pro-image-preview': 'gemini-3-pro-image',
   'gemini-3-pro-preview': 'gemini-3-pro-high',
+  'gemini-3.1-pro-preview': 'gemini-3.1-pro-high',
   'gemini-3-flash-preview': 'gemini-3-flash',
   'gemini-claude-sonnet-4-5': 'claude-sonnet-4-5',
   'gemini-claude-sonnet-4-5-thinking': 'claude-sonnet-4-5-thinking',
@@ -58,6 +61,16 @@ const ANTIGRAVITY_MODEL_METADATA = {
       levels: ['low', 'high']
     },
     name: 'models/gemini-3-pro-image-preview'
+  },
+  'gemini-3.1-pro-preview': {
+    thinking: {
+      min: 128,
+      max: 32768,
+      zeroAllowed: false,
+      dynamicAllowed: true,
+      levels: ['low', 'high']
+    },
+    name: 'models/gemini-3.1-pro-preview'
   },
   'gemini-3-flash-preview': {
     thinking: {


### PR DESCRIPTION
## Summary
- Add `gemini-3.1-pro-preview` to frontend model list, core model registry, and Antigravity mappings
- Upstream mapping: `gemini-3.1-pro-high` ↔ `gemini-3.1-pro-preview`
- Thinking config: min 128, max 32768, levels: low/high (same as gemini-3-pro-preview)

## Test plan
- [ ] Verify model appears in admin UI model selector
- [ ] Verify Antigravity relay correctly maps upstream/alias
- [ ] Test API call with `gemini-3.1-pro-preview` model name

🤖 Generated with [Claude Code](https://claude.com/claude-code)