### PR TITLE
fix: 修复 Claude 周额度统计范围，从仅 Opus 扩展到全部 Claude 模型

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -9,7 +9,7 @@ const ClientValidator = require('../validators/clientValidator')
 const ClaudeCodeValidator = require('../validators/clients/claudeCodeValidator')
 const claudeRelayConfigService = require('../services/claudeRelayConfigService')
 const { calculateWaitTimeStats } = require('../utils/statsHelper')
-const { isOpusModel } = require('../utils/modelHelper')
+const { isClaudeFamilyModel } = require('../utils/modelHelper')
 
 // 工具函数
 function sleep(ms) {
@@ -1256,7 +1256,7 @@ const authenticateApiKey = async (req, res, next) => {
       const model = requestBody.model || ''
 
       // 判断是否为 Claude 模型
-      if (isOpusModel(model)) {
+      if (isClaudeFamilyModel(model)) {
         const weeklyOpusCost = validation.keyData.weeklyOpusCost || 0
 
         if (weeklyOpusCost >= weeklyOpusCostLimit) {
@@ -1278,7 +1278,7 @@ const authenticateApiKey = async (req, res, next) => {
           return res.status(402).json({
             error: {
               type: 'insufficient_quota',
-              message: `已达到 Opus 模型周费用限制 ($${weeklyOpusCostLimit})`,
+              message: `已达到 Claude 模型周费用限制 ($${weeklyOpusCostLimit})`,
               code: 'weekly_opus_cost_limit_exceeded'
             },
             currentCost: weeklyOpusCost,

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -4,7 +4,7 @@ const config = require('../../config/config')
 const redis = require('../models/redis')
 const logger = require('../utils/logger')
 const serviceRatesService = require('./serviceRatesService')
-const { isOpusModel } = require('../utils/modelHelper')
+const { isClaudeFamilyModel } = require('../utils/modelHelper')
 
 const ACCOUNT_TYPE_CONFIG = {
   claude: { prefix: 'claude:account:' },
@@ -1649,7 +1649,7 @@ class ApiKeyService {
   async recordOpusCost(keyId, ratedCost, realCost, model, accountType) {
     try {
       // 判断是否为 Claude 系列模型（包含 Bedrock 格式等）
-      if (!isOpusModel(model)) {
+      if (!isClaudeFamilyModel(model)) {
         return
       }
 

--- a/src/services/weeklyClaudeCostInitService.js
+++ b/src/services/weeklyClaudeCostInitService.js
@@ -2,7 +2,7 @@ const redis = require('../models/redis')
 const logger = require('../utils/logger')
 const pricingService = require('./pricingService')
 const serviceRatesService = require('./serviceRatesService')
-const { isOpusModel } = require('../utils/modelHelper')
+const { isClaudeFamilyModel } = require('../utils/modelHelper')
 
 function pad2(n) {
   return String(n).padStart(2, '0')
@@ -151,7 +151,7 @@ class WeeklyClaudeCostInitService {
             }
             const keyId = match[1]
             const model = match[2]
-            if (!isOpusModel(model)) {
+            if (!isClaudeFamilyModel(model)) {
               continue
             }
             matchedClaudeKeys++

--- a/web/admin-spa/src/views/ApiKeysView.vue
+++ b/web/admin-spa/src/views/ApiKeysView.vue
@@ -646,7 +646,8 @@
                           <template
                             v-if="
                               isStatsLoading(key.id) &&
-                              (key.dailyCostLimit > 0 ||
+                              (key.weeklyOpusCostLimit > 0 ||
+                                key.dailyCostLimit > 0 ||
                                 key.totalCostLimit > 0 ||
                                 (key.rateLimitWindow > 0 && key.rateLimitCost > 0))
                             "
@@ -662,6 +663,16 @@
                           </template>
                           <!-- 已加载状态 -->
                           <template v-else>
+                            <!-- Claude 周额度限制 - 独立显示 -->
+                            <LimitProgressBar
+                              v-if="key.weeklyOpusCostLimit > 0"
+                              :current="getCachedStats(key.id)?.weeklyOpusCost || 0"
+                              label="Claude 周限制"
+                              :limit="key.weeklyOpusCostLimit"
+                              type="opus"
+                              variant="compact"
+                            />
+
                             <!-- 每日费用限制进度条 -->
                             <LimitProgressBar
                               v-if="key.dailyCostLimit > 0"
@@ -727,7 +738,12 @@
 
                             <!-- 如果没有任何限制 -->
                             <div
-                              v-else
+                              v-if="
+                                !(key.weeklyOpusCostLimit > 0) &&
+                                !(key.dailyCostLimit > 0) &&
+                                !(key.totalCostLimit > 0) &&
+                                !(key.rateLimitWindow > 0 && key.rateLimitCost > 0)
+                              "
                               class="flex items-center justify-center gap-1.5 py-2 text-gray-500 dark:text-gray-400"
                             >
                               <i class="fas fa-infinity text-base" />


### PR DESCRIPTION
## 问题描述

当前 Claude 周额度统计（`weeklyOpusCostLimit`）仅统计 Opus 模型的费用，使用 `isOpusModel()` 进行判断。这导致其他 Claude 系列模型（如 Sonnet、Haiku）的费用不会被计入周额度，用户可以通过切换非 Opus 模型来绕过周费用限制。

## 修复方案

将所有 `isOpusModel()` 调用替换为 `isClaudeFamilyModel()`，使周额度限制覆盖全部 Claude 系列模型。同时修复前端 API Key 管理页面中周限制进度条缺失的问题。

## 修改内容

### 后端

| 文件 | 修改说明 |
|------|----------|
| `src/middleware/auth.js` | 认证中间件的周额度检查从 `isOpusModel` 改为 `isClaudeFamilyModel`，错误提示从「Opus 模型周费用限制」改为「Claude 模型周费用限制」 |
| `src/services/apiKeyService.js` | `recordOpusCost` 方法中的模型判断从 `isOpusModel` 改为 `isClaudeFamilyModel`，确保所有 Claude 模型费用都被记录 |
| `src/services/weeklyClaudeCostInitService.js` | 周费用初始化统计服务中的模型过滤从 `isOpusModel` 改为 `isClaudeFamilyModel`，确保历史数据统计范围一致 |

### 前端

| 文件 | 修改说明 |
|------|----------|
| `web/admin-spa/src/views/ApiKeysView.vue` | 新增 Claude 周限制进度条（`LimitProgressBar`），在 API Key 列表中独立展示周额度使用情况 |
| `web/admin-spa/src/views/ApiKeysView.vue` | 修复「无任何限制」提示的条件判断：当设置了 `weeklyOpusCostLimit` 时不再错误显示该提示 |

## 测试计划

- [ ] 验证 Sonnet、Haiku 等非 Opus 的 Claude 模型费用被正确计入周额度
- [ ] 验证 Opus 模型费用仍然被正确计入周额度（向后兼容）
- [ ] 验证非 Claude 模型（如 Gemini、GPT）不受影响
- [ ] 验证前端 API Key 列表中设置了周限制的 Key 能正确显示进度条
- [ ] 验证未设置任何限制的 Key 仍然显示「无任何限制」提示