### PR TITLE
fix: 切换 /v1/chat/completions Gemini 处理器为 standard 版本，支持 API Key 账户

### DIFF
--- a/src/routes/unified.js
+++ b/src/routes/unified.js
@@ -2,10 +2,10 @@ const express = require('express')
 const { authenticateApiKey } = require('../middleware/auth')
 const logger = require('../utils/logger')
 const { handleChatCompletion } = require('./openaiClaudeRoutes')
-// 从 handlers/geminiHandlers.js 导入处理函数
+// 从 handlers/geminiHandlers.js 导入 standard 处理函数（支持 OAuth + API Key 双账户类型）
 const {
-  handleGenerateContent: geminiHandleGenerateContent,
-  handleStreamGenerateContent: geminiHandleStreamGenerateContent
+  handleStandardGenerateContent: geminiHandleGenerateContent,
+  handleStandardStreamGenerateContent: geminiHandleStreamGenerateContent
 } = require('../handlers/geminiHandlers')
 const openaiRoutes = require('./openaiRoutes')
 const apiKeyService = require('../services/apiKeyService')


### PR DESCRIPTION
## Summary

- 将 `/v1/chat/completions` 端点的 Gemini 处理器从 v1internal 版本切换为 standard 版本
- standard 版本同时兼容 OAuth 和 API Key 两种认证方式

Closes #1012