### PR TITLE
fix: 拦截 1M 上下文窗口请求，避免账户被误标记为限流

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -189,6 +189,17 @@ async function handleMessagesRequest(req, res) {
       }
     }
 
+    // 拦截 1M 上下文窗口请求（anthropic-beta 包含 context-1m）
+    const betaHeader = (req.headers['anthropic-beta'] || '').toLowerCase()
+    if (betaHeader.includes('context-1m')) {
+      return res.status(403).json({
+        error: {
+          type: 'forbidden',
+          message: '暂不支持 1M 上下文窗口，请切换为非 [1m] 模型'
+        }
+      })
+    }
+
     logger.api('📥 /v1/messages request received', {
       model: req.body.model || null,
       forcedVendor,


### PR DESCRIPTION
## 问题描述

当用户在 Claude Code 中选择 `[1m]` 模型（如 `claude-opus-4-6[1m]`）时，客户端会在请求头中携带 `anthropic-beta: context-1m-2025-08-07` 来启用 1M 上下文窗口。

部分账户订阅类型（如 Max）不支持 1M 上下文窗口，上游 API 会返回 429 错误。系统收到 429 后会将账户标记为限流状态，导致该账户后续的**所有请求**（包括正常的非 1M 请求）都被拦截，直到限流恢复时间结束。

## 修复方案

在 `src/routes/api.js` 的路由层统一拦截：检测请求的 `anthropic-beta` header 是否包含 `context-1m`，如果包含则直接返回 403 错误，提示用户切换为非 `[1m]` 模型。

这样做的好处：
- **不转发请求**：避免触发上游 429 错误
- **不标记限流**：账户状态不受影响，后续正常请求不受干扰
- **客户端收到明确提示**：用户知道需要切换模型，而非看到含糊的限流错误

## 修改文件

| 文件 | 修改说明 |
|------|----------|
| `src/routes/api.js` | 在模型黑名单校验之后、请求转发之前，新增 `context-1m` beta header 检测，匹配则返回 403 |

## 测试计划

- [ ] 使用 Claude Code 选择 `[1m]` 模型发送请求，验证收到 403 和明确的错误提示
- [ ] 使用非 `[1m]` 模型发送请求，验证不受影响，正常转发
- [ ] 验证触发 403 后账户不会被标记为限流状态