### PR TITLE
fix: 实现 Gemini/Droid ensureValidToken 并修复 Gemini 账户连通性测试

### DIFF
--- a/src/services/account/droidAccountService.js
+++ b/src/services/account/droidAccountService.js
@@ -1369,6 +1369,18 @@ class DroidAccountService {
   }
 
   /**
+   * 确保账户 token 有效（未过期直接返回，过期则刷新）
+   */
+  async ensureValidToken(accountId) {
+    try {
+      const accessToken = await this.getValidAccessToken(accountId)
+      return { success: true, accessToken }
+    } catch (error) {
+      return { success: false, error: error.message }
+    }
+  }
+
+  /**
    * 获取可调度的 Droid 账户列表
    */
   async getSchedulableAccounts(endpointType = null) {


### PR DESCRIPTION
## Summary

修复管理后台 Gemini/Droid 账户连通性测试失败的问题。

**根因：** PR #859 在路由层调用了 `ensureValidToken()`，但从未在 service 中实现。此外 Gemini 测试路由使用了错误的 API 端点和请求格式。

### 修复内容
- 补齐 `geminiAccountService.ensureValidToken()`（快速路径 + token 刷新）
- 补齐 `droidAccountService.ensureValidToken()`（封装 `getValidAccessToken`）
- 修正 Gemini 测试端点：`generativelanguage.googleapis.com` → `cloudcode-pa.googleapis.com/v1internal`
- 修正请求体结构：`{ model, project, request: { contents, generationConfig } }`
- 补齐必要 Headers：User-Agent、X-Goog-Api-Client、Client-Metadata、Accept
- 兼容嵌套响应结构解析

### 变更文件
| 文件 | 改动 |
|------|------|
| `src/services/account/geminiAccountService.js` | +32 新增 `ensureValidToken` |
| `src/services/account/droidAccountService.js` | +12 新增 `ensureValidToken` |
| `src/routes/admin/geminiAccounts.js` | 修正测试路由端点/请求体/headers |

## Test plan
- [x] Gemini OAuth 账户连通性测试通过（gemini-2.5-pro，延迟 2873ms，响应 "Hello"）
- [x] Droid 账户连通性测试通过

Closes #1018