### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/auto-release-pipeline.yml
+++ b/.github/workflows/auto-release-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event.pusher.name != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip ci]')
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
     # 构建前端并推送到 web-dist 分支
     - name: Setup Node.js
       if: steps.check.outputs.needs_bump == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '18'
         cache: 'npm'

--- a/.github/workflows/pr-lint-check.yml
+++ b/.github/workflows/pr-lint-check.yml
@@ -29,18 +29,18 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           cache: 'npm'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -225,7 +225,7 @@ jobs:
       - name: Comment PR with results
         if: failure()
         continue-on-error: true  # 即使评论失败也继续
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           script: |
@@ -293,7 +293,7 @@ jobs:
       - name: Success comment
         if: success() && steps.changed-files.outputs.any_changed == 'true'
         continue-on-error: true  # 即使评论失败也继续
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/sync-model-pricing.yml
+++ b/.github/workflows/sync-model-pricing.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: 检出 price-mirror 分支
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: price-mirror
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v3`](https://github.com/actions/cache/releases/tag/v3) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | pr-lint-check.yml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | auto-release-pipeline.yml, pr-lint-check.yml, sync-model-pricing.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | pr-lint-check.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | auto-release-pipeline.yml, pr-lint-check.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: June 2nd, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/checkout** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/checkout/releases) for breaking changes
- **actions/setup-node** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/setup-node/releases) for breaking changes
  - ⚠️ Input `always-auth` was **removed** — if your workflow uses it, the step may fail
- **actions/cache** (v3 → v5):
  - ⚠️ v4 uses a new caching backend - existing caches may not be reused on first run
- **actions/github-script** (v7 → v8): Major version upgrade — review the [release notes](https://github.com/actions/github-script/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
