### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/auto-release-pipeline.yml
+++ b/.github/workflows/auto-release-pipeline.yml
@@ -284,7 +284,7 @@ jobs:
 
     - name: Create GitHub Release
       if: steps.check.outputs.needs_bump == 'true'
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.next_version.outputs.new_tag }}
         name: Release ${{ steps.next_version.outputs.new_version }}

--- a/.github/workflows/pr-lint-check.yml
+++ b/.github/workflows/pr-lint-check.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             **/*.js


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `softprops/action-gh-release` | [`v1`](https://github.com/softprops/action-gh-release/releases/tag/v1) | [`v2`](https://github.com/softprops/action-gh-release/releases/tag/v2) | [Release](https://github.com/softprops/action-gh-release/releases/tag/v2) | auto-release-pipeline.yml |
| `tj-actions/changed-files` | [`v41`](https://github.com/tj-actions/changed-files/releases/tag/v41) | [`v47`](https://github.com/tj-actions/changed-files/releases/tag/v47) | [Release](https://github.com/tj-actions/changed-files/releases/tag/v47) | pr-lint-check.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **softprops/action-gh-release** (v1 → v2): Major version upgrade — review the [release notes](https://github.com/softprops/action-gh-release/releases) for breaking changes
- **tj-actions/changed-files** (v41 → v47): Major version upgrade — review the [release notes](https://github.com/tj-actions/changed-files/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
