### PR TITLE
fix: prevent SSE stream corruption by requesting identity encoding

### DIFF
--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -1494,11 +1494,16 @@ class ClaudeRelayService {
     const contentLength = Buffer.byteLength(bodyString, 'utf8')
 
     // 构建最终请求头（包含认证、版本、User-Agent、Beta 等）
+    // Force identity encoding to prevent upstream (Cloudflare) from returning
+    // gzip-compressed responses without a Content-Encoding header, which causes
+    // binary data to be silently corrupted by UTF-8 text decoding in the stream
+    // handler. See: https://github.com/Wei-Shaw/claude-relay-service/issues/1030
     const headers = {
       host: 'api.anthropic.com',
       connection: 'keep-alive',
       'content-type': 'application/json',
       'content-length': String(contentLength),
+      'accept-encoding': 'identity',
       authorization: `Bearer ${accessToken}`,
       'anthropic-version': this.apiVersion,
       ...finalHeaders


### PR DESCRIPTION
## Problem

Streaming SSE responses (`stream: true`) are silently corrupted when the upstream Anthropic API (via Cloudflare) returns gzip-compressed data. The gzip magic byte `0x8b` gets replaced with `U+FFFD` (`ef bf bd`), destroying the binary stream.

**Root cause:** The `_prepareRequestHeadersAndPayload()` method does not set an `Accept-Encoding` header. Some Cloudflare edge nodes return gzip-compressed responses even without a `Content-Encoding` response header. When this happens, the existing gzip detection (`res.headers['content-encoding'] === 'gzip'`) is bypassed, and the raw gzip bytes flow into `chunk.toString()` which performs UTF-8 decoding on binary data.

The corruption pattern from the bug report confirms this: `1f 8b` (gzip magic) becomes `1f ef bf bd` because `0x8b` is an invalid UTF-8 lead byte and gets replaced with the Unicode replacement character.

Reported in #1030.

## Solution

Add `'accept-encoding': 'identity'` to upstream request headers. This tells the CDN to **not compress the response**, eliminating the issue at the source.

This is simpler and more reliable than trying to detect unlabeled gzip at the response level (magic byte sniffing, stream buffering, etc.).

## Changes

- `src/services/relay/claudeRelayService.js`: +1 header in `_prepareRequestHeadersAndPayload()`

## Why this works

- `identity` is the HTTP standard way to request no content coding
- Prevents Cloudflare from applying compression regardless of edge behavior
- The existing gzip/deflate decompression code remains as a safety net for any edge cases
- Non-streaming requests are unaffected (they already work correctly)

Closes #1030