### PR TITLE
fix: route novita-compatible models in unified openai endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,16 @@ gpt-5                      # Codex使用固定模型ID
 - API Key填入：后台创建的API密钥（cr_开头）
 - **重要**：Codex只支持Openai-Response标准
 
+**4. Novita（OpenAI 兼容）接入：**
+
+如果你希望通过 Novita 使用 DeepSeek / Qwen 等 OpenAI 兼容模型：
+
+- 在后台新增 `OpenAI-Responses` 账号
+- `Base API` 填入：`https://api.novita.ai/openai`
+- `API Key` 填入你的 Novita Key
+- 通过统一 OpenAI 入口调用：`http://你的服务器:3000/openai/v1/chat/completions`
+- 模型示例：`deepseek/deepseek-v3`、`qwen/qwen3-32b`
+
 
 **Cherry Studio 地址格式重要说明：**
 

--- a/src/routes/unified.js
+++ b/src/routes/unified.js
@@ -12,35 +12,9 @@ const { CODEX_CLI_INSTRUCTIONS } = require('./openaiRoutes')
 const apiKeyService = require('../services/apiKeyService')
 const GeminiToOpenAIConverter = require('../services/geminiToOpenAI')
 const CodexToOpenAIConverter = require('../services/codexToOpenAI')
+const { detectBackendFromModel } = require('../utils/modelBackendDetector')
 
 const router = express.Router()
-
-// 🔍 根据模型名称检测后端类型
-function detectBackendFromModel(modelName) {
-  if (!modelName) {
-    return 'claude' // 默认 Claude
-  }
-
-  const model = modelName.toLowerCase()
-
-  // Claude 模型
-  if (model.startsWith('claude-')) {
-    return 'claude'
-  }
-
-  // Gemini 模型
-  if (model.startsWith('gemini-')) {
-    return 'gemini'
-  }
-
-  // OpenAI 模型
-  if (model.startsWith('gpt-')) {
-    return 'openai'
-  }
-
-  // 默认使用 Claude
-  return 'claude'
-}
 
 // 🚀 智能后端路由处理器
 async function routeToBackend(req, res, requestedModel) {

--- a/src/utils/modelBackendDetector.js
+++ b/src/utils/modelBackendDetector.js
@@ -1,0 +1,45 @@
+function detectBackendFromModel(modelName) {
+  if (!modelName) {
+    return 'claude'
+  }
+
+  const model = String(modelName).toLowerCase()
+
+  if (model.startsWith('claude-')) {
+    return 'claude'
+  }
+
+  if (model.startsWith('gemini-')) {
+    return 'gemini'
+  }
+
+  if (
+    model.startsWith('gpt-') ||
+    model.startsWith('o1') ||
+    model.startsWith('o3') ||
+    model.startsWith('o4') ||
+    model.startsWith('codex') ||
+    model.startsWith('deepseek') ||
+    model.startsWith('qwen') ||
+    model.startsWith('kimi') ||
+    model.startsWith('glm')
+  ) {
+    return 'openai'
+  }
+
+  if (
+    model.includes('/deepseek') ||
+    model.includes('/qwen') ||
+    model.includes('/kimi') ||
+    model.includes('/glm') ||
+    model.includes('/gpt')
+  ) {
+    return 'openai'
+  }
+
+  return 'claude'
+}
+
+module.exports = {
+  detectBackendFromModel
+}

--- a/tests/modelBackendDetector.test.js
+++ b/tests/modelBackendDetector.test.js
@@ -1,0 +1,22 @@
+const { detectBackendFromModel } = require('../src/utils/modelBackendDetector')
+
+describe('modelBackendDetector', () => {
+  it('routes codex models to openai backend', () => {
+    expect(detectBackendFromModel('codex-mini')).toBe('openai')
+  })
+
+  it('routes DeepSeek models to openai backend', () => {
+    expect(detectBackendFromModel('deepseek-chat')).toBe('openai')
+    expect(detectBackendFromModel('deepseek/deepseek-v3')).toBe('openai')
+  })
+
+  it('routes Qwen models to openai backend', () => {
+    expect(detectBackendFromModel('qwen-plus')).toBe('openai')
+    expect(detectBackendFromModel('qwen/qwen3-32b')).toBe('openai')
+  })
+
+  it('keeps existing claude and gemini routing behavior', () => {
+    expect(detectBackendFromModel('claude-sonnet-4-5-20250929')).toBe('claude')
+    expect(detectBackendFromModel('gemini-2.5-pro')).toBe('gemini')
+  })
+})


### PR DESCRIPTION
## Summary
- extract model backend detection into a dedicated utility
- route Novita/OpenAI-compatible model names (e.g. codex/deepseek/qwen/kimi/glm/o1/o3/o4) to the OpenAI backend instead of defaulting to Claude
- add tests for backend detection behavior
- document Novita endpoint setup (`https://api.novita.ai/openai`) in README

## Validation
- npm test -- tests/modelBackendDetector.test.js
- npm run lint:check