### PR TITLE
fix: handle custom models not in pricing table

### DIFF
--- a/src/utils/costCalculator.js
+++ b/src/utils/costCalculator.js
@@ -179,6 +179,11 @@ class CostCalculator {
       pricing = MODEL_PRICING[model] || MODEL_PRICING['unknown']
     }
 
+    // 安全兜底：确保 pricing 始终有值（防止自定义模型不在价格表中导致 undefined）
+    if (!pricing) {
+      pricing = MODEL_PRICING['unknown']
+    }
+
     // 计算各类型token的费用 (USD)
     const inputCost = (inputTokens / 1000000) * pricing.input
     const outputCost = (outputTokens / 1000000) * pricing.output


### PR DESCRIPTION
- Add safety fallback in CostCalculator.calculateCost() to prevent 'Cannot read properties of undefined (reading input)' error when custom models are not found in the pricing table
- Falls back to MODEL_PRICING['unknown'] when both dynamic pricing service and static MODEL_PRICING lookup return null/undefined