### PR TITLE
fix: set SSE response headers before streaming to prevent gzip corruption

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -197,11 +197,16 @@ class Application {
       this.app.use(
         compression({
           filter: (req, res) => {
-            // 不压缩 Server-Sent Events
+            // Respect client's Accept-Encoding: identity (no compression desired)
+            const acceptEncoding = req.headers['accept-encoding']
+            if (acceptEncoding && acceptEncoding.trim() === 'identity') {
+              return false
+            }
+            // Don't compress Server-Sent Events
             if (res.getHeader('Content-Type') === 'text/event-stream') {
               return false
             }
-            // 使用默认的压缩判断
+            // Use default compression heuristics
             return compression.filter(req, res)
           }
         })

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -2494,6 +2494,21 @@ class ClaudeRelayService {
           }
         }
 
+        // Set SSE response headers before forwarding data.
+        // This ensures the compression middleware sees Content-Type: text/event-stream
+        // and skips gzip compression for the stream.
+        if (!responseStream.headersSent) {
+          const existingConnection = responseStream.getHeader
+            ? responseStream.getHeader('Connection')
+            : null
+          responseStream.writeHead(200, {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            Connection: existingConnection || 'keep-alive',
+            'X-Accel-Buffering': 'no'
+          })
+        }
+
         let buffer = ''
         const allUsageData = [] // 收集所有的usage事件
         let currentUsageData = {} // 当前正在收集的usage数据


### PR DESCRIPTION
## Summary

- **Root cause**: `claudeRelayService._makeClaudeStreamRequestWithUsageCapture()` never sets `Content-Type: text/event-stream` on successful 200 streaming responses, causing the `compression` middleware to mistakenly apply gzip to the SSE stream. Clients then receive corrupted binary data instead of readable event streams.
- Add `writeHead()` with proper SSE headers (`Content-Type: text/event-stream`, `Cache-Control: no-cache`, `X-Accel-Buffering: no`) in the 200 success path, **before** any data is forwarded — consistent with error paths and other relay services (`openaiResponsesRelayService`, `droidRelayService`, `azureOpenaiRelayService`).
- Respect `Accept-Encoding: identity` in the compression middleware filter, so clients that explicitly request no compression are honored.

## Bug chain (before fix)

```
1. claudeRelayService receives 200 from upstream Claude API
2. Starts forwarding SSE data via responseStream.write() — no headers set yet
3. compression middleware checks res Content-Type → finds nothing → decides to compress
4. SSE stream gets gzip-compressed, but Content-Encoding header is missing
5. Client receives binary gzip data, expects UTF-8 text → parse failure
```

## Test plan

- [ ] Verify streaming responses return `Content-Type: text/event-stream` header
- [ ] Verify SSE data is **not** gzip-compressed when received by client
- [ ] Verify `Accept-Encoding: identity` requests bypass compression
- [ ] Verify non-streaming (regular JSON) responses still get compressed normally
- [ ] Verify error responses (4xx/5xx) still work correctly with existing `writeHead()` calls