### PR TITLE
fix: resolve timezone bugs in date-based statistics queries

### DIFF
--- a/src/routes/apiStats.js
+++ b/src/routes/apiStats.js
@@ -811,7 +811,7 @@ router.post('/api/batch-model-stats', async (req, res) => {
     const _client = redis.getClientSafe()
     const tzDate = redis.getDateInTimezone()
     const today = redis.getDateStringInTimezone()
-    const currentMonth = `${tzDate.getFullYear()}-${String(tzDate.getMonth() + 1).padStart(2, '0')}`
+    const currentMonth = `${tzDate.getUTCFullYear()}-${String(tzDate.getUTCMonth() + 1).padStart(2, '0')}`
 
     const modelUsageMap = new Map()
 
@@ -1399,7 +1399,7 @@ router.post('/api/user-model-stats', async (req, res) => {
     // 使用与管理页面相同的时区处理逻辑
     const tzDate = redis.getDateInTimezone()
     const today = redis.getDateStringInTimezone()
-    const currentMonth = `${tzDate.getFullYear()}-${String(tzDate.getMonth() + 1).padStart(2, '0')}`
+    const currentMonth = `${tzDate.getUTCFullYear()}-${String(tzDate.getUTCMonth() + 1).padStart(2, '0')}`
 
     let pattern
     let matchRegex

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -1451,8 +1451,9 @@ class ApiKeyService {
       }
 
       // 删除所有相关的使用统计数据
-      const today = new Date().toISOString().split('T')[0]
-      const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0]
+      const today = redis.getDateStringInTimezone()
+      const yesterdayDate = new Date(Date.now() - 86400000)
+      const yesterday = redis.getDateStringInTimezone(yesterdayDate)
 
       // 删除每日统计
       await redis.client.del(`usage:daily:${today}:${keyId}`)

--- a/web/admin-spa/src/stores/dashboard.js
+++ b/web/admin-spa/src/stores/dashboard.js
@@ -529,8 +529,14 @@ export const useDashboardStore = defineStore('dashboard', () => {
       return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
     }
 
-    dateFilter.value.customStart = startDate ? startDate.toISOString().split('T')[0] : ''
-    dateFilter.value.customEnd = endDate ? endDate.toISOString().split('T')[0] : ''
+    const formatLocalDate = (d) =>
+      d.getFullYear() +
+      '-' +
+      String(d.getMonth() + 1).padStart(2, '0') +
+      '-' +
+      String(d.getDate()).padStart(2, '0')
+    dateFilter.value.customStart = startDate ? formatLocalDate(startDate) : ''
+    dateFilter.value.customEnd = endDate ? formatLocalDate(endDate) : ''
     dateFilter.value.customRange =
       startDate && endDate ? [formatDateForDisplay(startDate), formatDateForDisplay(endDate)] : null
 

--- a/web/admin-spa/src/views/ApiKeysView.vue
+++ b/web/admin-spa/src/views/ApiKeysView.vue
@@ -3614,8 +3614,8 @@ const setGlobalDateFilterPreset = (preset) => {
       }
 
       globalDateFilter.customRange = [formatDate(startDate), formatDate(today)]
-      globalDateFilter.customStart = startDate.toISOString().split('T')[0]
-      globalDateFilter.customEnd = today.toISOString().split('T')[0]
+      globalDateFilter.customStart = formatLocalDate(startDate)
+      globalDateFilter.customEnd = formatLocalDate(today)
     }
   } else if (preset === 'all') {
     // 全部时间选项
@@ -3637,8 +3637,8 @@ const setGlobalDateFilterPreset = (preset) => {
       startDate.setDate(today.getDate() - 29)
     }
 
-    globalDateFilter.customStart = startDate.toISOString().split('T')[0]
-    globalDateFilter.customEnd = today.toISOString().split('T')[0]
+    globalDateFilter.customStart = formatLocalDate(startDate)
+    globalDateFilter.customEnd = formatLocalDate(today)
   }
 
   loadApiKeys()
@@ -3668,8 +3668,8 @@ const initApiKeyDateFilter = (keyId) => {
   apiKeyDateFilters.value[keyId] = {
     type: 'preset',
     preset: 'today',
-    customStart: today.toISOString().split('T')[0],
-    customEnd: today.toISOString().split('T')[0],
+    customStart: formatLocalDate(today),
+    customEnd: formatLocalDate(today),
     customRange: null,
     presetOptions: [
       { value: 'today', label: '今日', days: 1 },
@@ -3717,8 +3717,8 @@ const setApiKeyDateFilterPreset = (preset, keyId) => {
         }
 
         filter.customRange = [formatDate(startDate), formatDate(today)]
-        filter.customStart = startDate.toISOString().split('T')[0]
-        filter.customEnd = today.toISOString().split('T')[0]
+        filter.customStart = formatLocalDate(startDate)
+        filter.customEnd = formatLocalDate(today)
       }
     } else {
       // 预设选项
@@ -3726,8 +3726,8 @@ const setApiKeyDateFilterPreset = (preset, keyId) => {
       const startDate = new Date(today)
       startDate.setDate(today.getDate() - (option.days - 1))
 
-      filter.customStart = startDate.toISOString().split('T')[0]
-      filter.customEnd = today.toISOString().split('T')[0]
+      filter.customStart = formatLocalDate(startDate)
+      filter.customEnd = formatLocalDate(today)
 
       const formatDate = (date) => {
         return (
@@ -3766,6 +3766,16 @@ const onApiKeyCustomDateRangeChange = (keyId, value) => {
 }
 
 // 禁用未来日期
+const formatLocalDate = (date) => {
+  return (
+    date.getFullYear() +
+    '-' +
+    String(date.getMonth() + 1).padStart(2, '0') +
+    '-' +
+    String(date.getDate()).padStart(2, '0')
+  )
+}
+
 const disabledDate = (date) => {
   return date > new Date()
 }
@@ -3782,8 +3792,8 @@ const resetApiKeyDateFilter = (keyId) => {
   const startDate = new Date(today)
   startDate.setHours(0, 0, 0, 0) // 今日从0点开始
 
-  filter.customStart = today.toISOString().split('T')[0]
-  filter.customEnd = today.toISOString().split('T')[0]
+  filter.customStart = formatLocalDate(today)
+  filter.customEnd = formatLocalDate(today)
   filter.customRange = null
 
   // 重新加载数据


### PR DESCRIPTION
## Summary
- Replace `toISOString().split('T')[0]` (returns UTC date) with `formatLocalDate()` (returns local date) across frontend date filters, fixing "Today" stats showing previous day's data for non-UTC users before 8AM
- Fix `getFullYear()/getMonth()` to `getUTCFullYear()/getUTCMonth()` on timezone-offset `Date` objects in backend `apiStats.js`, preventing wrong monthly key at month boundaries
- Use `redis.getDateStringInTimezone()` for API key cleanup in `apiKeyService.js` to match data recording timezone

## Affected files
- `web/admin-spa/src/views/ApiKeysView.vue` — 10 occurrences fixed (model usage distribution filters)
- `web/admin-spa/src/stores/dashboard.js` — 2 occurrences fixed (custom date range)
- `src/routes/apiStats.js` — 2 occurrences fixed (monthly pattern generation)
- `src/services/apiKeyService.js` — 2 occurrences fixed (daily stats cleanup)

## Test plan
- [ ] Verify "Today" model usage stats show correct data in UTC+8 timezone before 8AM
- [ ] Verify 7-day and 30-day date ranges query correct Redis keys
- [ ] Verify monthly stats pattern is correct at month boundaries (e.g., March 31 → April 1)
- [ ] Verify API key hard delete cleans up correct daily stats keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)