### PR TITLE
fix: preserve responses continuity and cache hints

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -15,6 +15,11 @@ const ProxyHelper = require('../utils/proxyHelper')
 const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
 const { IncrementalSSEParser } = require('../utils/sseParser')
 const { getSafeMessage } = require('../utils/errorSanitizer')
+const {
+  applyOpenAIStorePolicy,
+  ensureOpenAISessionHeader,
+  getOpenAIContinuity
+} = require('../utils/openaiContinuity')
 
 // Codex CLI 系统提示词（非 Codex CLI 客户端请求时注入，统一端点也使用）
 const CODEX_CLI_INSTRUCTIONS =
@@ -251,17 +256,9 @@ const handleResponses = async (req, res) => {
       })
     }
 
-    // 从请求头或请求体中提取会话 ID
-    // NOTE: For some clients, prompt_cache_key is the only stable per-session key.
-    const sessionId =
-      req.headers['session_id'] ||
-      req.headers['x-session-id'] ||
-      req.body?.session_id ||
-      req.body?.conversation_id ||
-      req.body?.prompt_cache_key ||
-      null
+    const { continuityKey: sessionId, sessionHash: derivedSessionHash } = getOpenAIContinuity(req)
 
-    sessionHash = sessionId ? crypto.createHash('sha256').update(sessionId).digest('hex') : null
+    sessionHash = derivedSessionHash
 
     // 从请求体中提取模型和流式标志
     let requestedModel = req.body?.model || null
@@ -327,12 +324,13 @@ const handleResponses = async (req, res) => {
 
     const allowedKeys = ['version', 'openai-beta', 'session_id']
 
-    const headers = {}
+    let headers = {}
     for (const key of allowedKeys) {
       if (incoming[key] !== undefined) {
         headers[key] = incoming[key]
       }
     }
+    headers = ensureOpenAISessionHeader(headers, sessionId)
 
     // 判断是否访问 compact 端点
     const isCompactRoute =
@@ -346,11 +344,10 @@ const handleResponses = async (req, res) => {
     headers['host'] = 'chatgpt.com'
     headers['accept'] = isStream ? 'text/event-stream' : 'application/json'
     headers['content-type'] = 'application/json'
-    if (!isCompactRoute) {
-      req.body['store'] = false
-    } else if (req.body && Object.prototype.hasOwnProperty.call(req.body, 'store')) {
-      delete req.body['store']
-    }
+    applyOpenAIStorePolicy(req.body, {
+      isCompactRoute,
+      continuityKey: sessionId
+    })
 
     // 创建代理 agent
     const proxyAgent = createProxyAgent(proxy)

--- a/src/services/codexToOpenAI.js
+++ b/src/services/codexToOpenAI.js
@@ -470,7 +470,9 @@ class CodexToOpenAIConverter {
     // 固定值
     result.parallel_tool_calls = true
     result.include = ['reasoning.encrypted_content']
-    result.store = false
+    if (chatBody.store !== undefined) {
+      result.store = chatBody.store
+    }
 
     // 收集所有工具名（tools + assistant.tool_calls），统一构建缩短映射
     const allToolNames = new Set()
@@ -527,6 +529,9 @@ class CodexToOpenAIConverter {
     }
     if (chatBody.prompt_cache_key) {
       result.prompt_cache_key = chatBody.prompt_cache_key
+    }
+    if (chatBody.previous_response_id !== undefined) {
+      result.previous_response_id = chatBody.previous_response_id
     }
 
     return result

--- a/src/services/relay/openaiResponsesRelayService.js
+++ b/src/services/relay/openaiResponsesRelayService.js
@@ -6,8 +6,12 @@ const openaiResponsesAccountService = require('../account/openaiResponsesAccount
 const apiKeyService = require('../apiKeyService')
 const unifiedOpenAIScheduler = require('../scheduler/unifiedOpenAIScheduler')
 const config = require('../../../config/config')
-const crypto = require('crypto')
 const LRUCache = require('../../utils/lruCache')
+const {
+  ensureOpenAISessionHeader,
+  ensureResponsesPromptCacheKey,
+  getOpenAIContinuity
+} = require('../../utils/openaiContinuity')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
 
 // lastUsedAt 更新节流（每账户 60 秒内最多更新一次，使用 LRU 防止内存泄漏）
@@ -63,11 +67,7 @@ class OpenAIResponsesRelayService {
   // 处理请求转发
   async handleRequest(req, res, account, apiKeyData) {
     let abortController = null
-    // 获取会话哈希（如果有的话）
-    const sessionId = req.headers['session_id'] || req.body?.session_id
-    const sessionHash = sessionId
-      ? crypto.createHash('sha256').update(sessionId).digest('hex')
-      : null
+    const { continuityKey, sessionHash, source: continuitySource } = getOpenAIContinuity(req)
 
     try {
       // 获取完整的账户信息（包含解密的 API Key）
@@ -117,12 +117,17 @@ class OpenAIResponsesRelayService {
       const targetUrl = `${baseApi}${targetPath}`
       logger.info(`🎯 Forwarding to: ${targetUrl}`)
 
+      req.body = ensureResponsesPromptCacheKey(req.body, continuityKey)
+
       // 构建请求头 - 使用统一的 headerFilter 移除 CDN headers
-      const headers = {
-        ...filterForOpenAI(req.headers),
-        Authorization: `Bearer ${fullAccount.apiKey}`,
-        'Content-Type': 'application/json'
-      }
+      const headers = ensureOpenAISessionHeader(
+        {
+          ...filterForOpenAI(req.headers),
+          Authorization: `Bearer ${fullAccount.apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        continuityKey
+      )
 
       // 处理 User-Agent
       if (fullAccount.userAgent) {
@@ -168,7 +173,11 @@ class OpenAIResponsesRelayService {
         method: req.method,
         stream: req.body?.stream || false,
         model: req.body?.model || 'unknown',
-        userAgent: headers['User-Agent'] || 'not set'
+        userAgent: headers['User-Agent'] || 'not set',
+        continuitySource: continuitySource || 'none',
+        continuityKeyPresent: !!continuityKey,
+        promptCacheKeyPresent: !!req.body?.prompt_cache_key,
+        previousResponseIdPresent: !!req.body?.previous_response_id
       })
 
       // 发送请求
@@ -344,7 +353,8 @@ class OpenAIResponsesRelayService {
           apiKeyData,
           req.body?.model,
           handleClientDisconnect,
-          req
+          req,
+          sessionHash
         )
       }
 
@@ -476,7 +486,8 @@ class OpenAIResponsesRelayService {
     apiKeyData,
     requestedModel,
     handleClientDisconnect,
-    req
+    req,
+    sessionHash = null
   ) {
     // 设置 SSE 响应头
     res.setHeader('Content-Type', 'text/event-stream')
@@ -643,11 +654,6 @@ class OpenAIResponsesRelayService {
       // 如果在流式响应中检测到限流
       if (rateLimitDetected) {
         // 使用统一调度器处理限流（与非流式响应保持一致）
-        const sessionId = req.headers['session_id'] || req.body?.session_id
-        const sessionHash = sessionId
-          ? crypto.createHash('sha256').update(sessionId).digest('hex')
-          : null
-
         await unifiedOpenAIScheduler.markAccountRateLimited(
           account.id,
           'openai-responses',

--- a/src/utils/openaiContinuity.js
+++ b/src/utils/openaiContinuity.js
@@ -1,0 +1,107 @@
+const crypto = require('crypto')
+
+function normalizeHeaders(headers = {}) {
+  if (!headers || typeof headers !== 'object') {
+    return {}
+  }
+
+  const normalized = {}
+  for (const [key, value] of Object.entries(headers)) {
+    if (!key) {
+      continue
+    }
+    normalized[key.toLowerCase()] = value
+  }
+  return normalized
+}
+
+function getOpenAIContinuity(reqLike = {}) {
+  const headers = normalizeHeaders(reqLike.headers || reqLike)
+  const body = reqLike.body || {}
+  const candidates = [
+    ['headers.session_id', headers['session_id']],
+    ['headers.x-session-id', headers['x-session-id']],
+    ['body.session_id', body?.session_id],
+    ['body.conversation_id', body?.conversation_id],
+    ['body.prompt_cache_key', body?.prompt_cache_key]
+  ]
+
+  const match = candidates.find(
+    ([, value]) => value !== undefined && value !== null && value !== ''
+  )
+  const continuityKey = match ? String(match[1]) : null
+
+  return {
+    continuityKey,
+    source: match ? match[0] : null,
+    sessionHash: continuityKey
+      ? crypto.createHash('sha256').update(continuityKey).digest('hex')
+      : null
+  }
+}
+
+function ensureOpenAISessionHeader(headers = {}, continuityKey = null) {
+  const nextHeaders = { ...(headers || {}) }
+  const normalized = normalizeHeaders(nextHeaders)
+
+  if (!continuityKey || normalized.session_id) {
+    return nextHeaders
+  }
+
+  nextHeaders.session_id = continuityKey
+  return nextHeaders
+}
+
+function hasExplicitStore(body = {}) {
+  return !!body && typeof body === 'object' && Object.prototype.hasOwnProperty.call(body, 'store')
+}
+
+function hasContinuityHint(body = {}, continuityKey = null) {
+  return Boolean(
+    continuityKey || body?.conversation_id || body?.prompt_cache_key || body?.previous_response_id
+  )
+}
+
+function applyOpenAIStorePolicy(body = {}, { isCompactRoute = false, continuityKey = null } = {}) {
+  if (!body || typeof body !== 'object') {
+    return body
+  }
+
+  if (isCompactRoute) {
+    if (hasExplicitStore(body)) {
+      delete body.store
+    }
+    return body
+  }
+
+  if (!hasExplicitStore(body) && !hasContinuityHint(body, continuityKey)) {
+    body.store = false
+  }
+
+  return body
+}
+
+function ensureResponsesPromptCacheKey(body = {}, continuityKey = null) {
+  if (!body || typeof body !== 'object' || !continuityKey) {
+    return body
+  }
+
+  const existing = body.prompt_cache_key
+  if (existing !== undefined && existing !== null && existing !== '') {
+    return body
+  }
+
+  if (!Array.isArray(body.input)) {
+    return body
+  }
+
+  body.prompt_cache_key = continuityKey
+  return body
+}
+
+module.exports = {
+  applyOpenAIStorePolicy,
+  ensureOpenAISessionHeader,
+  ensureResponsesPromptCacheKey,
+  getOpenAIContinuity
+}

--- a/tests/codexToOpenAI.test.js
+++ b/tests/codexToOpenAI.test.js
@@ -1,0 +1,32 @@
+const CodexToOpenAIConverter = require('../src/services/codexToOpenAI')
+
+describe('CodexToOpenAIConverter', () => {
+  it('preserves store and previous_response_id when building responses payload', () => {
+    const converter = new CodexToOpenAIConverter()
+    const body = converter.buildRequestFromOpenAI({
+      model: 'gpt-5.4',
+      stream: false,
+      store: true,
+      previous_response_id: 'resp_prev_123',
+      session_id: 'sess_1',
+      prompt_cache_key: 'pck_1',
+      messages: [{ role: 'user', content: 'hi' }]
+    })
+
+    expect(body.store).toBe(true)
+    expect(body.previous_response_id).toBe('resp_prev_123')
+    expect(body.session_id).toBe('sess_1')
+    expect(body.prompt_cache_key).toBe('pck_1')
+  })
+
+  it('omits store when caller did not specify it', () => {
+    const converter = new CodexToOpenAIConverter()
+    const body = converter.buildRequestFromOpenAI({
+      model: 'gpt-5.4',
+      stream: false,
+      messages: [{ role: 'user', content: 'hi' }]
+    })
+
+    expect(Object.prototype.hasOwnProperty.call(body, 'store')).toBe(false)
+  })
+})

--- a/tests/openaiContinuity.test.js
+++ b/tests/openaiContinuity.test.js
@@ -1,0 +1,59 @@
+const {
+  applyOpenAIStorePolicy,
+  ensureOpenAISessionHeader,
+  ensureResponsesPromptCacheKey,
+  getOpenAIContinuity
+} = require('../src/utils/openaiContinuity')
+
+describe('openaiContinuity utils', () => {
+  it('prefers prompt_cache_key after session/conversation fallbacks', () => {
+    const result = getOpenAIContinuity({
+      headers: {},
+      body: { conversation_id: 'conv_1', prompt_cache_key: 'pck_1' }
+    })
+
+    expect(result.continuityKey).toBe('conv_1')
+    expect(result.source).toBe('body.conversation_id')
+    expect(result.sessionHash).toHaveLength(64)
+  })
+
+  it('uses prompt_cache_key when it is the only stable continuity key', () => {
+    const result = getOpenAIContinuity({
+      headers: {},
+      body: { prompt_cache_key: 'pck_only' }
+    })
+
+    expect(result.continuityKey).toBe('pck_only')
+    expect(result.source).toBe('body.prompt_cache_key')
+  })
+
+  it('adds canonical session_id header when only fallback continuity key exists', () => {
+    const headers = ensureOpenAISessionHeader({ 'x-session-id': 'sid_alt' }, 'pck_only')
+    expect(headers.session_id).toBe('pck_only')
+    expect(headers['x-session-id']).toBe('sid_alt')
+  })
+
+  it('preserves explicit store=true for continuity-aware requests', () => {
+    const body = { store: true, prompt_cache_key: 'pck_1' }
+    applyOpenAIStorePolicy(body, { isCompactRoute: false, continuityKey: 'pck_1' })
+    expect(body.store).toBe(true)
+  })
+
+  it('does not default store=false when continuity hints already exist', () => {
+    const body = { prompt_cache_key: 'pck_1' }
+    applyOpenAIStorePolicy(body, { isCompactRoute: false, continuityKey: 'pck_1' })
+    expect(Object.prototype.hasOwnProperty.call(body, 'store')).toBe(false)
+  })
+
+  it('defaults store=false only for requests without continuity hints', () => {
+    const body = {}
+    applyOpenAIStorePolicy(body, { isCompactRoute: false, continuityKey: null })
+    expect(body.store).toBe(false)
+  })
+
+  it('injects prompt_cache_key for responses payloads when missing', () => {
+    const body = { input: [{ role: 'user', content: 'hi' }] }
+    ensureResponsesPromptCacheKey(body, 'sid_123')
+    expect(body.prompt_cache_key).toBe('sid_123')
+  })
+})


### PR DESCRIPTION
## Summary
- preserve caller-provided `store` semantics during relay conversion instead of forcing a fixed value
- forward `previous_response_id` so multi-turn `responses` flows keep upstream continuity
- centralize continuity key derivation across session, conversation, and cache-related hints
- backfill `prompt_cache_key` when a stable continuity key already exists but the field is missing
- keep canonical `session_id` and related headers aligned across relay hops
- add focused tests for continuity helpers and request conversion behavior

## Validation
- ran an identical local 4-turn multi-turn A/B against a baseline relay build and the patched build
- used two variants: an implicit continuity path (no explicit `prompt_cache_key`) and an explicit `prompt_cache_key` control path
- compared turn-by-turn `cached_input_tokens` behavior and continuity-related request fields instead of relying on a single aggregate result
- the baseline build showed degraded cache reuse when continuity depended on relay-preserved state, while the patched build restored stable multi-turn reuse behavior
- the explicit `prompt_cache_key` control path behaved consistently across both runs, which points to relay continuity handling rather than upstream cache availability
- validation focused on `previous_response_id`, `store`, `session_id`, and `prompt_cache_key` parity across turns
- added focused unit coverage for continuity key derivation / backfill and for preserving `store` plus forwarding `previous_response_id`
- `npm test -- --runTestsByPath tests/openaiContinuity.test.js tests/codexToOpenAI.test.js`
- `npx eslint src/utils/openaiContinuity.js src/routes/openaiRoutes.js src/services/relay/openaiResponsesRelayService.js src/services/codexToOpenAI.js tests/openaiContinuity.test.js tests/codexToOpenAI.test.js`