### PR TITLE
fix: resolve concurrency count leak on client disconnect

### DIFF
--- a/src/services/relay/ccrRelayService.js
+++ b/src/services/relay/ccrRelayService.js
@@ -854,11 +854,13 @@ class CcrRelayService {
             if (response.data && typeof response.data.destroy === 'function') {
               response.data.destroy()
             }
+            reject(new Error('Client disconnected'))
           })
 
           responseStream.on('error', (err) => {
             logger.error('❌ Response stream error:', err)
             aborted = true
+            reject(err)
           })
         })
         .catch((error) => {

--- a/src/services/relay/claudeConsoleRelayService.js
+++ b/src/services/relay/claudeConsoleRelayService.js
@@ -1281,6 +1281,7 @@ class ClaudeConsoleRelayService {
         })
         .catch((error) => {
           if (aborted) {
+            reject(error)
             return
           }
 
@@ -1363,6 +1364,7 @@ class ClaudeConsoleRelayService {
       responseStream.on('close', () => {
         logger.debug('🔌 Client disconnected, cleaning up Claude Console stream')
         aborted = true
+        reject(new Error('Client disconnected'))
       })
     })
   }


### PR DESCRIPTION
## 问题描述                                                                                                                            
  - 修复 `claudeConsoleRelayService.js` 和 `ccrRelayService.js` 中并发计数泄漏的问题                                                     
  - 客户端在流式请求期间断开连接时，`_makeClaudeConsoleStreamRequest()` 中的 Promise 永远不会 resolve/reject，导致 `finally`             
  块无法执行，`decrConcurrency()` 永远不会被调用                                                                                         
  - 并发计数只增不减，最终超过 `maxConcurrentTasks` 限制，账户被永久排除在调度之外                                                       

  ## 修改内容
  - `claudeConsoleRelayService.js`：在 `responseStream.on('close')` 处理器中添加 `reject()`，在 `.catch()` 中 `aborted=true` 时也添加
  `reject()`
  - `ccrRelayService.js`：在 `responseStream.on('close')` 和 `responseStream.on('error')` 处理器中添加 `reject()`

  ## 根因分析
  `responseStream.on('close')` 处理器仅设置了 `aborted = true`，但没有调用 `reject()`，导致 Promise 永远处于挂起状态。外层 `finally`
  块（负责调用 `redis.decrConcurrency()` 释放并发槽位）永远不会执行。


Related: #744
