### PR TITLE
feat: support ecosystem.config.js for pm2 startup

### DIFF
--- a/scripts/manage.sh
+++ b/scripts/manage.sh
@@ -868,11 +868,16 @@ start_service() {
     
     # 检查pm2是否可用并且不是从package.json脚本调用的
     if command_exists pm2 && [ "$1" != "--no-pm2" ]; then
-        print_info "使用 pm2 启动服务..."
-        # 直接使用pm2启动，避免循环调用
-        pm2 start "$APP_DIR/src/app.js" --name "claude-relay" --log "$APP_DIR/logs/pm2.log" 2>/dev/null
+        # 优先使用 ecosystem.config.js 配置文件启动
+        if [ -f "$APP_DIR/ecosystem.config.js" ]; then
+            print_info "使用 pm2 + ecosystem.config.js 启动服务..."
+            cd "$APP_DIR" && pm2 start ecosystem.config.js 2>/dev/null
+        else
+            print_info "使用 pm2 启动服务..."
+            pm2 start "$APP_DIR/src/app.js" --name "claude-relay" --log "$APP_DIR/logs/pm2.log" 2>/dev/null
+        fi
         sleep 2
-        
+
         # 检查是否启动成功
         if pm2 list 2>/dev/null | grep -q "claude-relay"; then
             print_success "服务已通过 pm2 启动"


### PR DESCRIPTION
## Summary
   - pm2 启动时优先检测并使用 `ecosystem.config.js` 配置文件，支持用户自定义内存限制、重启策略、日志配置等
   - 配置文件不存在时保持原有命令行参数启动方式，完全向后兼容
   - `ecosystem.config.js` 已在 `.gitignore` 中，不影响 `git pull` 升级