### PR TITLE
fix: 修复 Bedrock API Key (ABSK) Bearer Token 认证失败

### DIFF
--- a/src/services/relay/bedrockRelayService.js
+++ b/src/services/relay/bedrockRelayService.js
@@ -74,7 +74,7 @@ class BedrockRelayService {
 
     // Bedrock API Key (ABSK) 模式：注入 Bearer Token 到 Authorization header
     if (bedrockAccount?.bearerToken) {
-      const bearerToken = bedrockAccount.bearerToken
+      const { bearerToken } = bedrockAccount
       client.middlewareStack.add(
         (next) => async (args) => {
           // 清除 SigV4 签名产生的所有 authorization header（大小写均删除）


### PR DESCRIPTION
## Summary
- **修复 Bedrock API Key (ABSK) Bearer Token 认证**：`BedrockRuntimeClient` 默认使用 SigV4 签名，`token` 配置属性不生效，导致 "Could not load credentials from any providers" 错误
- **通过 SDK middleware 注入 Bearer Token**：在 `finalizeRequest` 阶段清除 SigV4 签名的 Authorization header，替换为 `Bearer <ABSK token>`
- **新增 `claude-sonnet-4-6` 模型映射**：Bedrock 暂未上线 Sonnet 4.6，回退映射到 Sonnet 4.5

## Changes
- `src/services/relay/bedrockRelayService.js`
  - `_getBedrockClient()`: 使用占位凭证 + middleware 方式替代无效的 `token` 配置
  - `_mapToBedrockModel()`: 添加 `claude-sonnet-4-6` 映射

## Test plan
- [x] 本地验证 ABSK token 通过 middleware 认证成功（InvokeModelCommand）
- [x] 管理后台 Bedrock 账户测试连接成功
- [x] 实际 API 中转请求通过 Bedrock 账户正常工作
- [x] 验证 `global.anthropic.claude-opus-4-6-v1` 模型 ID 可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)