### PR TITLE
Fix sliding API key quota enforcement

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -10,6 +10,7 @@ const ClaudeCodeValidator = require('../validators/clients/claudeCodeValidator')
 const claudeRelayConfigService = require('../services/claudeRelayConfigService')
 const { calculateWaitTimeStats } = require('../utils/statsHelper')
 const { isClaudeFamilyModel } = require('../utils/modelHelper')
+const slidingWindowRateLimit = require('../utils/slidingWindowRateLimit')
 
 // 工具函数
 function sleep(ms) {
@@ -1065,47 +1066,22 @@ const authenticateApiKey = async (req, res, next) => {
       (rateLimitRequests > 0 || validation.keyData.tokenLimit > 0 || rateLimitCost > 0)
 
     if (hasRateLimits) {
-      const windowStartKey = `rate_limit:window_start:${validation.keyData.id}`
-      const requestCountKey = `rate_limit:requests:${validation.keyData.id}`
-      const tokenCountKey = `rate_limit:tokens:${validation.keyData.id}`
-      const costCountKey = `rate_limit:cost:${validation.keyData.id}` // 新增：费用计数器
-
       const now = Date.now()
-      const windowDuration = rateLimitWindow * 60 * 1000 // 转换为毫秒
-
-      // 获取窗口开始时间
-      let windowStart = await redis.getClient().get(windowStartKey)
-
-      if (!windowStart) {
-        // 第一次请求，设置窗口开始时间
-        await redis.getClient().set(windowStartKey, now, 'PX', windowDuration)
-        await redis.getClient().set(requestCountKey, 0, 'PX', windowDuration)
-        await redis.getClient().set(tokenCountKey, 0, 'PX', windowDuration)
-        await redis.getClient().set(costCountKey, 0, 'PX', windowDuration) // 新增：重置费用
-        windowStart = now
-      } else {
-        windowStart = parseInt(windowStart)
-
-        // 检查窗口是否已过期
-        if (now - windowStart >= windowDuration) {
-          // 窗口已过期，重置
-          await redis.getClient().set(windowStartKey, now, 'PX', windowDuration)
-          await redis.getClient().set(requestCountKey, 0, 'PX', windowDuration)
-          await redis.getClient().set(tokenCountKey, 0, 'PX', windowDuration)
-          await redis.getClient().set(costCountKey, 0, 'PX', windowDuration) // 新增：重置费用
-          windowStart = now
-        }
-      }
-
-      // 获取当前计数
-      const currentRequests = parseInt((await redis.getClient().get(requestCountKey)) || '0')
-      const currentTokens = parseInt((await redis.getClient().get(tokenCountKey)) || '0')
-      const currentCost = parseFloat((await redis.getClient().get(costCountKey)) || '0') // 新增：当前费用
+      const windowStats = await slidingWindowRateLimit.getWindowSnapshot(
+        validation.keyData.id,
+        rateLimitWindow,
+        { now }
+      )
+      const currentRequests = windowStats.requests || 0
+      const currentTokens = windowStats.tokens || 0
+      const currentCost = windowStats.cost || 0
+      const windowStart = windowStats.windowStartTime || now
+      const windowEnd = windowStats.windowEndTime || now
+      const remainingMinutes = Math.max(1, Math.ceil((windowEnd - now) / 60000))
 
       // 检查请求次数限制
       if (rateLimitRequests > 0 && currentRequests >= rateLimitRequests) {
-        const resetTime = new Date(windowStart + windowDuration)
-        const remainingMinutes = Math.ceil((resetTime - now) / 60000)
+        const resetTime = new Date(windowEnd)
 
         logger.security(
           `🚦 Rate limit exceeded (requests) for key: ${validation.keyData.id} (${validation.keyData.name}), requests: ${currentRequests}/${rateLimitRequests}`
@@ -1126,8 +1102,7 @@ const authenticateApiKey = async (req, res, next) => {
       if (tokenLimit > 0) {
         // 使用Token限制（向后兼容）
         if (currentTokens >= tokenLimit) {
-          const resetTime = new Date(windowStart + windowDuration)
-          const remainingMinutes = Math.ceil((resetTime - now) / 60000)
+          const resetTime = new Date(windowEnd)
 
           logger.security(
             `🚦 Rate limit exceeded (tokens) for key: ${validation.keyData.id} (${validation.keyData.name}), tokens: ${currentTokens}/${tokenLimit}`
@@ -1145,8 +1120,7 @@ const authenticateApiKey = async (req, res, next) => {
       } else if (rateLimitCost > 0) {
         // 使用费用限制（新功能）
         if (currentCost >= rateLimitCost) {
-          const resetTime = new Date(windowStart + windowDuration)
-          const remainingMinutes = Math.ceil((resetTime - now) / 60000)
+          const resetTime = new Date(windowEnd)
 
           logger.security(
             `💰 Rate limit exceeded (cost) for key: ${validation.keyData.id} (${
@@ -1165,16 +1139,22 @@ const authenticateApiKey = async (req, res, next) => {
         }
       }
 
-      // 增加请求计数
-      await redis.getClient().incr(requestCountKey)
+      // 请求进入系统时立即记一次，用于请求数限制；费用/Token 在响应结束后补记。
+      await slidingWindowRateLimit.incrementRequestCount(
+        validation.keyData.id,
+        rateLimitWindow,
+        1,
+        {
+          now
+        }
+      )
 
       // 存储限流信息到请求对象
       req.rateLimitInfo = {
-        windowStart,
-        windowDuration,
-        requestCountKey,
-        tokenCountKey,
-        costCountKey, // 新增：费用计数器
+        apiKeyId: validation.keyData.id,
+        windowMinutes: rateLimitWindow,
+        windowStartTime: windowStart,
+        windowEndTime: windowEnd,
         currentRequests: currentRequests + 1,
         currentTokens,
         currentCost, // 新增：当前费用

--- a/src/routes/admin/apiKeys.js
+++ b/src/routes/admin/apiKeys.js
@@ -4,6 +4,7 @@ const redis = require('../../models/redis')
 const { authenticateAdmin } = require('../../middleware/auth')
 const logger = require('../../utils/logger')
 const CostCalculator = require('../../utils/costCalculator')
+const slidingWindowRateLimit = require('../../utils/slidingWindowRateLimit')
 const config = require('../../../config/config')
 
 const router = express.Router()
@@ -1147,34 +1148,24 @@ async function calculateKeyStats(keyId, timeRange, startDate, endDate) {
 
     // 只在启用了窗口限制时查询窗口数据
     if (rateLimitWindow > 0) {
-      const requestCountKey = `rate_limit:requests:${keyId}`
-      const tokenCountKey = `rate_limit:tokens:${keyId}`
-      const costCountKey = `rate_limit:cost:${keyId}`
-      const windowStartKey = `rate_limit:window_start:${keyId}`
+      const windowStats = await slidingWindowRateLimit.getWindowSnapshot(keyId, rateLimitWindow, {
+        client
+      })
+      const {
+        requests = 0,
+        tokens = 0,
+        cost = 0,
+        windowRemainingSeconds: remainingSeconds = null,
+        windowStartTime: startTime = null,
+        windowEndTime: endTime = null
+      } = windowStats
 
-      currentWindowRequests = parseInt((await client.get(requestCountKey)) || '0')
-      currentWindowTokens = parseInt((await client.get(tokenCountKey)) || '0')
-      currentWindowCost = parseFloat((await client.get(costCountKey)) || '0')
-
-      // 获取窗口开始时间和计算剩余时间
-      const windowStart = await client.get(windowStartKey)
-      if (windowStart) {
-        const now = Date.now()
-        windowStartTime = parseInt(windowStart)
-        const windowDuration = rateLimitWindow * 60 * 1000 // 转换为毫秒
-        windowEndTime = windowStartTime + windowDuration
-
-        // 如果窗口还有效
-        if (now < windowEndTime) {
-          windowRemainingSeconds = Math.max(0, Math.floor((windowEndTime - now) / 1000))
-        } else {
-          // 窗口已过期
-          windowRemainingSeconds = 0
-          currentWindowRequests = 0
-          currentWindowTokens = 0
-          currentWindowCost = 0
-        }
-      }
+      currentWindowRequests = requests
+      currentWindowTokens = tokens
+      currentWindowCost = cost
+      windowRemainingSeconds = remainingSeconds
+      windowStartTime = startTime
+      windowEndTime = endTime
     }
   } catch (error) {
     logger.warn(`⚠️ 获取实时限制数据失败 (key: ${keyId}):`, error.message)

--- a/src/routes/apiStats.js
+++ b/src/routes/apiStats.js
@@ -6,6 +6,7 @@ const CostCalculator = require('../utils/costCalculator')
 const claudeAccountService = require('../services/account/claudeAccountService')
 const openaiAccountService = require('../services/account/openaiAccountService')
 const serviceRatesService = require('../services/serviceRatesService')
+const slidingWindowRateLimit = require('../utils/slidingWindowRateLimit')
 const {
   createClaudeTestPayload,
   extractErrorMessage,
@@ -389,37 +390,26 @@ router.post('/api/user-stats', async (req, res) => {
       // 获取当前时间窗口的请求次数、Token使用量和费用
       if (fullKeyData.rateLimitWindow > 0) {
         const client = redis.getClientSafe()
-        const requestCountKey = `rate_limit:requests:${keyId}`
-        const tokenCountKey = `rate_limit:tokens:${keyId}`
-        const costCountKey = `rate_limit:cost:${keyId}` // 新增：费用计数key
-        const windowStartKey = `rate_limit:window_start:${keyId}`
+        const windowStats = await slidingWindowRateLimit.getWindowSnapshot(
+          keyId,
+          fullKeyData.rateLimitWindow,
+          { client }
+        )
+        const {
+          requests = 0,
+          tokens = 0,
+          cost = 0,
+          windowStartTime: startTime = null,
+          windowEndTime: endTime = null,
+          windowRemainingSeconds: remainingSeconds = null
+        } = windowStats
 
-        currentWindowRequests = parseInt((await client.get(requestCountKey)) || '0')
-        currentWindowTokens = parseInt((await client.get(tokenCountKey)) || '0')
-        currentWindowCost = parseFloat((await client.get(costCountKey)) || '0') // 新增：获取当前窗口费用
-
-        // 获取窗口开始时间和计算剩余时间
-        const windowStart = await client.get(windowStartKey)
-        if (windowStart) {
-          const now = Date.now()
-          windowStartTime = parseInt(windowStart)
-          const windowDuration = fullKeyData.rateLimitWindow * 60 * 1000 // 转换为毫秒
-          windowEndTime = windowStartTime + windowDuration
-
-          // 如果窗口还有效
-          if (now < windowEndTime) {
-            windowRemainingSeconds = Math.max(0, Math.floor((windowEndTime - now) / 1000))
-          } else {
-            // 窗口已过期，下次请求会重置
-            windowStartTime = null
-            windowEndTime = null
-            windowRemainingSeconds = 0
-            // 重置计数为0，因为窗口已过期
-            currentWindowRequests = 0
-            currentWindowTokens = 0
-            currentWindowCost = 0 // 新增：重置窗口费用
-          }
-        }
+        currentWindowRequests = requests
+        currentWindowTokens = tokens
+        currentWindowCost = cost
+        windowStartTime = startTime
+        windowEndTime = endTime
+        windowRemainingSeconds = remainingSeconds
       }
 
       // 获取当日费用

--- a/src/routes/openaiGeminiRoutes.js
+++ b/src/routes/openaiGeminiRoutes.js
@@ -7,6 +7,7 @@ const unifiedGeminiScheduler = require('../services/scheduler/unifiedGeminiSched
 const { getAvailableModels } = require('../services/relay/geminiRelayService')
 const crypto = require('crypto')
 const apiKeyService = require('../services/apiKeyService')
+const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
 
 // 生成会话哈希
 function generateSessionHash(req) {
@@ -33,6 +34,40 @@ function ensureAntigravityProjectId(account) {
 // 检查 API Key 权限
 function checkPermissions(apiKeyData, requiredPermission = 'gemini') {
   return apiKeyService.hasPermission(apiKeyData?.permissions, requiredPermission)
+}
+
+async function applyRateLimitTracking(
+  req,
+  usageSummary,
+  model,
+  context = '',
+  preCalculatedCost = null
+) {
+  if (!req.rateLimitInfo) {
+    return
+  }
+
+  const label = context ? ` (${context})` : ''
+
+  try {
+    const { totalTokens, totalCost } = await updateRateLimitCounters(
+      req.rateLimitInfo,
+      usageSummary,
+      model,
+      req.apiKey?.id,
+      'gemini',
+      preCalculatedCost
+    )
+
+    if (totalTokens > 0) {
+      logger.api(`📊 Updated rate limit token count${label}: +${totalTokens} tokens`)
+    }
+    if (typeof totalCost === 'number' && totalCost > 0) {
+      logger.api(`💰 Updated rate limit cost count${label}: +$${totalCost.toFixed(6)}`)
+    }
+  } catch (error) {
+    logger.error(`❌ Failed to update rate limit counters${label}:`, error)
+  }
 }
 
 // 转换 OpenAI 消息格式到 Gemini 格式
@@ -532,7 +567,7 @@ router.post('/v1/chat/completions', authenticateApiKey, async (req, res) => {
         // 记录使用统计
         if (!usageReported && totalUsage.totalTokenCount > 0) {
           try {
-            await apiKeyService.recordUsage(
+            const recordedCosts = await apiKeyService.recordUsage(
               apiKeyData.id,
               totalUsage.promptTokenCount || 0,
               totalUsage.candidatesTokenCount || 0,
@@ -544,6 +579,19 @@ router.post('/v1/chat/completions', authenticateApiKey, async (req, res) => {
             )
             logger.info(
               `📊 Recorded Gemini stream usage - Input: ${totalUsage.promptTokenCount}, Output: ${totalUsage.candidatesTokenCount}, Total: ${totalUsage.totalTokenCount}`
+            )
+
+            await applyRateLimitTracking(
+              req,
+              {
+                inputTokens: totalUsage.promptTokenCount || 0,
+                outputTokens: totalUsage.candidatesTokenCount || 0,
+                cacheCreateTokens: 0,
+                cacheReadTokens: 0
+              },
+              model,
+              'openai-gemini-stream',
+              recordedCosts
             )
 
             // 修复：标记 usage 已上报，避免重复上报
@@ -634,7 +682,7 @@ router.post('/v1/chat/completions', authenticateApiKey, async (req, res) => {
       // 记录使用统计
       if (openaiResponse.usage) {
         try {
-          await apiKeyService.recordUsage(
+          const recordedCosts = await apiKeyService.recordUsage(
             apiKeyData.id,
             openaiResponse.usage.prompt_tokens || 0,
             openaiResponse.usage.completion_tokens || 0,
@@ -646,6 +694,19 @@ router.post('/v1/chat/completions', authenticateApiKey, async (req, res) => {
           )
           logger.info(
             `📊 Recorded Gemini usage - Input: ${openaiResponse.usage.prompt_tokens}, Output: ${openaiResponse.usage.completion_tokens}, Total: ${openaiResponse.usage.total_tokens}`
+          )
+
+          await applyRateLimitTracking(
+            req,
+            {
+              inputTokens: openaiResponse.usage.prompt_tokens || 0,
+              outputTokens: openaiResponse.usage.completion_tokens || 0,
+              cacheCreateTokens: 0,
+              cacheReadTokens: 0
+            },
+            model,
+            'openai-gemini-non-stream',
+            recordedCosts
           )
         } catch (error) {
           logger.error('Failed to record Gemini usage:', error)

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -3,6 +3,7 @@ const { v4: uuidv4 } = require('uuid')
 const config = require('../../config/config')
 const redis = require('../models/redis')
 const logger = require('../utils/logger')
+const slidingWindowRateLimit = require('../utils/slidingWindowRateLimit')
 const serviceRatesService = require('./serviceRatesService')
 const { isClaudeFamilyModel } = require('../utils/modelHelper')
 
@@ -812,44 +813,18 @@ class ApiKeyService {
 
         // 获取当前时间窗口的请求次数、Token使用量和费用
         if (key.rateLimitWindow > 0) {
-          const requestCountKey = `rate_limit:requests:${key.id}`
-          const tokenCountKey = `rate_limit:tokens:${key.id}`
-          const costCountKey = `rate_limit:cost:${key.id}` // 新增：费用计数器
-          const windowStartKey = `rate_limit:window_start:${key.id}`
+          const windowStats = await slidingWindowRateLimit.getWindowSnapshot(
+            key.id,
+            key.rateLimitWindow,
+            { client }
+          )
 
-          key.currentWindowRequests = parseInt((await client.get(requestCountKey)) || '0')
-          key.currentWindowTokens = parseInt((await client.get(tokenCountKey)) || '0')
-          key.currentWindowCost = parseFloat((await client.get(costCountKey)) || '0') // 新增：当前窗口费用
-
-          // 获取窗口开始时间和计算剩余时间
-          const windowStart = await client.get(windowStartKey)
-          if (windowStart) {
-            const now = Date.now()
-            const windowStartTime = parseInt(windowStart)
-            const windowDuration = key.rateLimitWindow * 60 * 1000 // 转换为毫秒
-            const windowEndTime = windowStartTime + windowDuration
-
-            // 如果窗口还有效
-            if (now < windowEndTime) {
-              key.windowStartTime = windowStartTime
-              key.windowEndTime = windowEndTime
-              key.windowRemainingSeconds = Math.max(0, Math.floor((windowEndTime - now) / 1000))
-            } else {
-              // 窗口已过期，下次请求会重置
-              key.windowStartTime = null
-              key.windowEndTime = null
-              key.windowRemainingSeconds = 0
-              // 重置计数为0，因为窗口已过期
-              key.currentWindowRequests = 0
-              key.currentWindowTokens = 0
-              key.currentWindowCost = 0 // 新增：重置费用
-            }
-          } else {
-            // 窗口还未开始（没有任何请求）
-            key.windowStartTime = null
-            key.windowEndTime = null
-            key.windowRemainingSeconds = null
-          }
+          key.currentWindowRequests = windowStats.requests || 0
+          key.currentWindowTokens = windowStats.tokens || 0
+          key.currentWindowCost = windowStats.cost || 0
+          key.windowStartTime = windowStats.windowStartTime
+          key.windowEndTime = windowStats.windowEndTime
+          key.windowRemainingSeconds = windowStats.windowRemainingSeconds
         } else {
           key.currentWindowRequests = 0
           key.currentWindowTokens = 0
@@ -956,6 +931,20 @@ class ApiKeyService {
       const activeKeyIds = apiKeys.map((k) => k.id)
       const statsMap = await redis.batchGetApiKeyStats(activeKeyIds)
 
+      const windowConfigs = apiKeys
+        .map((key) => ({
+          keyId: key.id,
+          windowMinutes: parseInt(key.rateLimitWindow || 0)
+        }))
+        .filter((item) => item.windowMinutes > 0)
+
+      const windowStatsMap = await slidingWindowRateLimit.getWindowSnapshotsByConfig(
+        windowConfigs,
+        {
+          legacyFallback: true
+        }
+      )
+
       // 5. 合并数据
       for (const key of apiKeys) {
         const stats = statsMap.get(key.id) || {}
@@ -1054,33 +1043,16 @@ class ApiKeyService {
 
         // Rate limit 窗口数据
         if (key.rateLimitWindow > 0) {
-          const rl = stats.rateLimit || {}
-          key.currentWindowRequests = rl.requests || 0
-          key.currentWindowTokens = rl.tokens || 0
-          key.currentWindowCost = rl.cost || 0
-
-          if (rl.windowStart) {
-            const now = Date.now()
-            const windowDuration = key.rateLimitWindow * 60 * 1000
-            const windowEndTime = rl.windowStart + windowDuration
-
-            if (now < windowEndTime) {
-              key.windowStartTime = rl.windowStart
-              key.windowEndTime = windowEndTime
-              key.windowRemainingSeconds = Math.max(0, Math.floor((windowEndTime - now) / 1000))
-            } else {
-              key.windowStartTime = null
-              key.windowEndTime = null
-              key.windowRemainingSeconds = 0
-              key.currentWindowRequests = 0
-              key.currentWindowTokens = 0
-              key.currentWindowCost = 0
-            }
-          } else {
-            key.windowStartTime = null
-            key.windowEndTime = null
-            key.windowRemainingSeconds = null
-          }
+          const windowStats = windowStatsMap.get(key.id) || {}
+          key.currentWindowRequests = windowStats.requests || 0
+          key.currentWindowTokens = windowStats.tokens || 0
+          key.currentWindowCost = windowStats.cost || 0
+          key.windowStartTime = windowStats.windowStartTime || null
+          key.windowEndTime = windowStats.windowEndTime || null
+          key.windowRemainingSeconds =
+            windowStats.windowRemainingSeconds !== undefined
+              ? windowStats.windowRemainingSeconds
+              : null
         } else {
           key.currentWindowRequests = 0
           key.currentWindowTokens = 0

--- a/src/services/relay/openaiResponsesRelayService.js
+++ b/src/services/relay/openaiResponsesRelayService.js
@@ -9,6 +9,7 @@ const config = require('../../../config/config')
 const crypto = require('crypto')
 const LRUCache = require('../../utils/lruCache')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
+const { updateRateLimitCounters } = require('../../utils/rateLimitHelper')
 
 // lastUsedAt 更新节流（每账户 60 秒内最多更新一次，使用 LRU 防止内存泄漏）
 const lastUsedAtThrottle = new LRUCache(1000) // 最多缓存 1000 个账户
@@ -43,6 +44,34 @@ function extractCacheCreationTokens(usageData) {
 class OpenAIResponsesRelayService {
   constructor() {
     this.defaultTimeout = config.requestTimeout || 600000
+  }
+
+  async _applyRateLimitTracking(req, usageSummary, model, context = '', preCalculatedCost = null) {
+    if (!req?.rateLimitInfo) {
+      return
+    }
+
+    const label = context ? ` (${context})` : ''
+
+    try {
+      const { totalTokens, totalCost } = await updateRateLimitCounters(
+        req.rateLimitInfo,
+        usageSummary,
+        model,
+        req.apiKey?.id,
+        'openai-responses',
+        preCalculatedCost
+      )
+
+      if (totalTokens > 0) {
+        logger.api(`📊 Updated rate limit token count${label}: +${totalTokens} tokens`)
+      }
+      if (typeof totalCost === 'number' && totalCost > 0) {
+        logger.api(`💰 Updated rate limit cost count${label}: +$${totalCost.toFixed(6)}`)
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to update rate limit counters${label}:`, error)
+    }
   }
 
   // 节流更新 lastUsedAt
@@ -349,7 +378,7 @@ class OpenAIResponsesRelayService {
       }
 
       // 处理非流式响应
-      return this._handleNormalResponse(response, res, account, apiKeyData, req.body?.model)
+      return this._handleNormalResponse(response, res, account, apiKeyData, req.body?.model, req)
     } catch (error) {
       // 清理 AbortController
       if (abortController && !abortController.signal.aborted) {
@@ -603,7 +632,7 @@ class OpenAIResponsesRelayService {
           const modelToRecord = actualModel || requestedModel || 'gpt-4'
 
           const serviceTier = req._serviceTier || null
-          await apiKeyService.recordUsage(
+          const recordedCosts = await apiKeyService.recordUsage(
             apiKeyData.id,
             actualInputTokens, // 传递实际输入（不含缓存）
             outputTokens,
@@ -617,6 +646,19 @@ class OpenAIResponsesRelayService {
 
           logger.info(
             `📊 Recorded usage - Input: ${totalInputTokens}(actual:${actualInputTokens}+cached:${cacheReadTokens}), CacheCreate: ${cacheCreateTokens}, Output: ${outputTokens}, Total: ${totalTokens}, Model: ${modelToRecord}`
+          )
+
+          await this._applyRateLimitTracking(
+            req,
+            {
+              inputTokens: actualInputTokens,
+              outputTokens,
+              cacheCreateTokens,
+              cacheReadTokens
+            },
+            modelToRecord,
+            'openai-responses-stream',
+            recordedCosts
           )
 
           // 更新账户的 token 使用统计
@@ -709,7 +751,7 @@ class OpenAIResponsesRelayService {
   }
 
   // 处理非流式响应
-  async _handleNormalResponse(response, res, account, apiKeyData, requestedModel) {
+  async _handleNormalResponse(response, res, account, apiKeyData, requestedModel, req) {
     const responseData = response.data
 
     // 提取 usage 数据和实际 model
@@ -735,7 +777,7 @@ class OpenAIResponsesRelayService {
           usageData.total_tokens || totalInputTokens + outputTokens + cacheCreateTokens
 
         const serviceTier = req._serviceTier || null
-        await apiKeyService.recordUsage(
+        const recordedCosts = await apiKeyService.recordUsage(
           apiKeyData.id,
           actualInputTokens, // 传递实际输入（不含缓存）
           outputTokens,
@@ -749,6 +791,19 @@ class OpenAIResponsesRelayService {
 
         logger.info(
           `📊 Recorded non-stream usage - Input: ${totalInputTokens}(actual:${actualInputTokens}+cached:${cacheReadTokens}), CacheCreate: ${cacheCreateTokens}, Output: ${outputTokens}, Total: ${totalTokens}, Model: ${actualModel}`
+        )
+
+        await this._applyRateLimitTracking(
+          req,
+          {
+            inputTokens: actualInputTokens,
+            outputTokens,
+            cacheCreateTokens,
+            cacheReadTokens
+          },
+          actualModel,
+          'openai-responses-non-stream',
+          recordedCosts
         )
 
         // 更新账户的 token 使用统计

--- a/src/utils/rateLimitHelper.js
+++ b/src/utils/rateLimitHelper.js
@@ -1,6 +1,7 @@
 const redis = require('../models/redis')
 const pricingService = require('../services/pricingService')
 const CostCalculator = require('./costCalculator')
+const slidingWindowRateLimit = require('./slidingWindowRateLimit')
 
 function toNumber(value) {
   const num = Number(value)
@@ -32,10 +33,6 @@ async function updateRateLimitCounters(
   const cacheReadTokens = toNumber(usageSummary.cacheReadTokens)
 
   const totalTokens = inputTokens + outputTokens + cacheCreateTokens + cacheReadTokens
-
-  if (totalTokens > 0 && rateLimitInfo.tokenCountKey) {
-    await client.incrby(rateLimitInfo.tokenCountKey, Math.round(totalTokens))
-  }
 
   let totalCost = 0
   let ratedCost = 0
@@ -103,8 +100,23 @@ async function updateRateLimitCounters(
     }
   }
 
-  if (ratedCost > 0 && rateLimitInfo.costCountKey) {
-    await client.incrbyfloat(rateLimitInfo.costCountKey, ratedCost)
+  if (rateLimitInfo.apiKeyId && rateLimitInfo.windowMinutes > 0) {
+    await slidingWindowRateLimit.incrementWindowUsage(
+      rateLimitInfo.apiKeyId,
+      rateLimitInfo.windowMinutes,
+      {
+        tokens: Math.round(totalTokens),
+        cost: ratedCost
+      }
+    )
+  } else {
+    if (totalTokens > 0 && rateLimitInfo.tokenCountKey) {
+      await client.incrby(rateLimitInfo.tokenCountKey, Math.round(totalTokens))
+    }
+
+    if (ratedCost > 0 && rateLimitInfo.costCountKey) {
+      await client.incrbyfloat(rateLimitInfo.costCountKey, ratedCost)
+    }
   }
 
   return { totalTokens, totalCost, ratedCost }

--- a/src/utils/slidingWindowRateLimit.js
+++ b/src/utils/slidingWindowRateLimit.js
@@ -1,0 +1,397 @@
+const redis = require('../models/redis')
+const logger = require('./logger')
+
+const MINUTE_MS = 60 * 1000
+const FALLBACK_RETENTION_BUFFER_SECONDS = 24 * 60 * 60
+const SLIDING_BUCKET_KEY_PREFIX = 'rate_limit:sliding:buckets:'
+
+function toInt(value) {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function toNumber(value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function roundCost(value) {
+  return Math.round(toNumber(value) * 1e6) / 1e6
+}
+
+function getWindowDurationMs(windowMinutes) {
+  return Math.max(0, toInt(windowMinutes)) * MINUTE_MS
+}
+
+function getBucketKey(keyId) {
+  return `${SLIDING_BUCKET_KEY_PREFIX}${keyId}`
+}
+
+function getLegacyKeys(keyId) {
+  return {
+    requestCountKey: `rate_limit:requests:${keyId}`,
+    tokenCountKey: `rate_limit:tokens:${keyId}`,
+    costCountKey: `rate_limit:cost:${keyId}`,
+    windowStartKey: `rate_limit:window_start:${keyId}`
+  }
+}
+
+function getBucketId(timestampMs = Date.now()) {
+  return Math.floor(toNumber(timestampMs) / MINUTE_MS)
+}
+
+function getBucketTimestamp(bucketId) {
+  return toInt(bucketId) * MINUTE_MS
+}
+
+function parseBucketValue(rawValue) {
+  if (!rawValue) {
+    return { requests: 0, tokens: 0, cost: 0 }
+  }
+
+  const [requestsRaw = '0', tokensRaw = '0', costRaw = '0'] = String(rawValue).split('|')
+
+  return {
+    requests: Math.max(0, toInt(requestsRaw)),
+    tokens: Math.max(0, toInt(tokensRaw)),
+    cost: Math.max(0, roundCost(costRaw))
+  }
+}
+
+function serializeBucketValue(bucketValue) {
+  return [
+    Math.max(0, toInt(bucketValue.requests)),
+    Math.max(0, toInt(bucketValue.tokens)),
+    Math.max(0, roundCost(bucketValue.cost))
+  ].join('|')
+}
+
+function createEmptySnapshot() {
+  return {
+    requests: 0,
+    tokens: 0,
+    cost: 0,
+    hasActiveWindow: false,
+    windowStartTime: null,
+    windowEndTime: null,
+    windowRemainingSeconds: null,
+    staleFields: []
+  }
+}
+
+function buildSnapshotFromBuckets(rawBuckets, windowMinutes, now = Date.now()) {
+  const windowDurationMs = getWindowDurationMs(windowMinutes)
+  if (windowDurationMs <= 0) {
+    return createEmptySnapshot()
+  }
+
+  const snapshot = createEmptySnapshot()
+  const normalizedNow = toNumber(now) || Date.now()
+  const minIncludedBucketId = Math.floor((normalizedNow - windowDurationMs) / MINUTE_MS)
+  let oldestActiveBucketId = null
+
+  for (const [bucketIdRaw, bucketValueRaw] of Object.entries(rawBuckets || {})) {
+    const bucketId = toInt(bucketIdRaw)
+    if (!Number.isFinite(bucketId) || bucketId <= 0) {
+      snapshot.staleFields.push(bucketIdRaw)
+      continue
+    }
+
+    if (bucketId < minIncludedBucketId) {
+      snapshot.staleFields.push(bucketIdRaw)
+      continue
+    }
+
+    const bucketValue = parseBucketValue(bucketValueRaw)
+    if (bucketValue.requests <= 0 && bucketValue.tokens <= 0 && bucketValue.cost <= 0) {
+      snapshot.staleFields.push(bucketIdRaw)
+      continue
+    }
+
+    snapshot.requests += bucketValue.requests
+    snapshot.tokens += bucketValue.tokens
+    snapshot.cost = roundCost(snapshot.cost + bucketValue.cost)
+
+    if (oldestActiveBucketId === null || bucketId < oldestActiveBucketId) {
+      oldestActiveBucketId = bucketId
+    }
+  }
+
+  if (oldestActiveBucketId === null) {
+    return snapshot
+  }
+
+  snapshot.hasActiveWindow = true
+  snapshot.windowStartTime = getBucketTimestamp(oldestActiveBucketId)
+  snapshot.windowEndTime = getBucketTimestamp(oldestActiveBucketId + 1) + windowDurationMs
+  snapshot.windowRemainingSeconds = Math.max(
+    0,
+    Math.ceil((snapshot.windowEndTime - normalizedNow) / 1000)
+  )
+
+  return snapshot
+}
+
+function getBucketRetentionSeconds(windowMinutes) {
+  const windowDurationSeconds = Math.ceil(getWindowDurationMs(windowMinutes) / 1000)
+  return Math.max(windowDurationSeconds + FALLBACK_RETENTION_BUFFER_SECONDS, 3600)
+}
+
+async function pruneBucketFields(client, bucketKey, staleFields) {
+  if (!client || !bucketKey || !Array.isArray(staleFields) || staleFields.length === 0) {
+    return
+  }
+
+  try {
+    await client.hdel(bucketKey, ...staleFields)
+  } catch (error) {
+    logger.debug(`Failed to prune stale sliding-window fields for ${bucketKey}: ${error.message}`)
+  }
+}
+
+async function getLegacyWindowSnapshot(keyId, windowMinutes, options = {}) {
+  const windowDurationMs = getWindowDurationMs(windowMinutes)
+  if (!keyId || windowDurationMs <= 0) {
+    return createEmptySnapshot()
+  }
+
+  const client = options.client || redis.getClientSafe()
+  if (!client) {
+    return createEmptySnapshot()
+  }
+
+  const now = toNumber(options.now) || Date.now()
+  const { requestCountKey, tokenCountKey, costCountKey, windowStartKey } = getLegacyKeys(keyId)
+
+  const [requestCountRaw, tokenCountRaw, costCountRaw, windowStartRaw] = await Promise.all([
+    client.get(requestCountKey),
+    client.get(tokenCountKey),
+    client.get(costCountKey),
+    client.get(windowStartKey)
+  ])
+
+  const windowStartTime = toInt(windowStartRaw)
+  if (!windowStartTime || now >= windowStartTime + windowDurationMs) {
+    return createEmptySnapshot()
+  }
+
+  const requests = Math.max(0, toInt(requestCountRaw))
+  const tokens = Math.max(0, toInt(tokenCountRaw))
+  const cost = Math.max(0, roundCost(costCountRaw))
+  if (requests <= 0 && tokens <= 0 && cost <= 0) {
+    return createEmptySnapshot()
+  }
+
+  return {
+    requests,
+    tokens,
+    cost,
+    hasActiveWindow: true,
+    windowStartTime,
+    windowEndTime: windowStartTime + windowDurationMs,
+    windowRemainingSeconds: Math.max(
+      0,
+      Math.ceil((windowStartTime + windowDurationMs - now) / 1000)
+    ),
+    staleFields: []
+  }
+}
+
+async function migrateLegacyWindowToBuckets(keyId, windowMinutes, legacySnapshot, options = {}) {
+  if (!legacySnapshot || !legacySnapshot.hasActiveWindow) {
+    return false
+  }
+
+  const client = options.client || redis.getClientSafe()
+  if (!client) {
+    return false
+  }
+
+  const bucketKey = getBucketKey(keyId)
+  const bucketId = String(getBucketId(legacySnapshot.windowStartTime))
+
+  try {
+    await client.hset(
+      bucketKey,
+      bucketId,
+      serializeBucketValue({
+        requests: legacySnapshot.requests,
+        tokens: legacySnapshot.tokens,
+        cost: legacySnapshot.cost
+      })
+    )
+    await client.expire(bucketKey, getBucketRetentionSeconds(windowMinutes))
+    logger.info(`Migrated legacy rate-limit window to sliding buckets for API key ${keyId}`)
+    return true
+  } catch (error) {
+    logger.warn(`Failed to migrate legacy rate-limit window for API key ${keyId}: ${error.message}`)
+    return false
+  }
+}
+
+async function getWindowSnapshot(keyId, windowMinutes, options = {}) {
+  if (!keyId || getWindowDurationMs(windowMinutes) <= 0) {
+    return createEmptySnapshot()
+  }
+
+  const client = options.client || redis.getClientSafe()
+  if (!client) {
+    return createEmptySnapshot()
+  }
+
+  const now = toNumber(options.now) || Date.now()
+  const bucketKey = getBucketKey(keyId)
+  const rawBuckets = (await client.hgetall(bucketKey)) || {}
+  const hasBucketData = Object.keys(rawBuckets).length > 0
+
+  if (!hasBucketData && options.legacyFallback !== false) {
+    const legacySnapshot = await getLegacyWindowSnapshot(keyId, windowMinutes, { client, now })
+    if (legacySnapshot.hasActiveWindow) {
+      if (options.migrateLegacy !== false) {
+        await migrateLegacyWindowToBuckets(keyId, windowMinutes, legacySnapshot, { client })
+      }
+      return legacySnapshot
+    }
+  }
+
+  const snapshot = buildSnapshotFromBuckets(rawBuckets, windowMinutes, now)
+
+  if (options.prune !== false && snapshot.staleFields.length > 0) {
+    await pruneBucketFields(client, bucketKey, snapshot.staleFields)
+  }
+
+  return snapshot
+}
+
+async function getWindowSnapshotsByConfig(configs, options = {}) {
+  const normalizedConfigs = Array.isArray(configs)
+    ? configs
+        .map((item) => ({
+          keyId: item?.keyId,
+          windowMinutes: toInt(item?.windowMinutes)
+        }))
+        .filter((item) => item.keyId && item.windowMinutes > 0)
+    : []
+
+  if (normalizedConfigs.length === 0) {
+    return new Map()
+  }
+
+  const client = options.client || redis.getClientSafe()
+  if (!client) {
+    return new Map()
+  }
+
+  const now = toNumber(options.now) || Date.now()
+  const pipeline = client.pipeline()
+
+  for (const config of normalizedConfigs) {
+    pipeline.hgetall(getBucketKey(config.keyId))
+  }
+
+  const results = await pipeline.exec()
+  const snapshots = new Map()
+  const prunePipeline = options.prune === false ? null : client.pipeline()
+  let pruneCommands = 0
+
+  for (let i = 0; i < normalizedConfigs.length; i += 1) {
+    const config = normalizedConfigs[i]
+    const [, rawBuckets] = results[i] || []
+    let snapshot = buildSnapshotFromBuckets(rawBuckets || {}, config.windowMinutes, now)
+
+    if (!snapshot.hasActiveWindow && options.legacyFallback) {
+      snapshot = await getLegacyWindowSnapshot(config.keyId, config.windowMinutes, {
+        client,
+        now
+      })
+    }
+
+    if (prunePipeline && snapshot.staleFields.length > 0) {
+      prunePipeline.hdel(getBucketKey(config.keyId), ...snapshot.staleFields)
+      pruneCommands += 1
+    }
+
+    snapshots.set(config.keyId, snapshot)
+  }
+
+  if (prunePipeline && pruneCommands > 0) {
+    await prunePipeline.exec()
+  }
+
+  return snapshots
+}
+
+async function incrementWindowUsage(keyId, windowMinutes, increments = {}, options = {}) {
+  if (!keyId || getWindowDurationMs(windowMinutes) <= 0) {
+    return createEmptySnapshot()
+  }
+
+  const requestsDelta = Math.max(0, toInt(increments.requests))
+  const tokensDelta = Math.max(0, toInt(increments.tokens))
+  const costDelta = Math.max(0, roundCost(increments.cost))
+
+  if (requestsDelta <= 0 && tokensDelta <= 0 && costDelta <= 0) {
+    return createEmptySnapshot()
+  }
+
+  const client = options.client || redis.getClientSafe()
+  if (!client) {
+    return createEmptySnapshot()
+  }
+
+  const now = toNumber(options.now) || Date.now()
+  const bucketKey = getBucketKey(keyId)
+  const bucketId = String(getBucketId(now))
+
+  const currentValue = parseBucketValue(await client.hget(bucketKey, bucketId))
+  const nextValue = {
+    requests: currentValue.requests + requestsDelta,
+    tokens: currentValue.tokens + tokensDelta,
+    cost: roundCost(currentValue.cost + costDelta)
+  }
+
+  const pipeline = client.pipeline()
+  pipeline.hset(bucketKey, bucketId, serializeBucketValue(nextValue))
+  pipeline.expire(bucketKey, getBucketRetentionSeconds(windowMinutes))
+  await pipeline.exec()
+
+  return {
+    requests: nextValue.requests,
+    tokens: nextValue.tokens,
+    cost: nextValue.cost,
+    hasActiveWindow: true,
+    windowStartTime: getBucketTimestamp(toInt(bucketId)),
+    windowEndTime: getBucketTimestamp(toInt(bucketId) + 1) + getWindowDurationMs(windowMinutes),
+    windowRemainingSeconds: Math.max(
+      0,
+      Math.ceil(
+        (getBucketTimestamp(toInt(bucketId) + 1) + getWindowDurationMs(windowMinutes) - now) / 1000
+      )
+    ),
+    staleFields: []
+  }
+}
+
+async function incrementRequestCount(keyId, windowMinutes, count = 1, options = {}) {
+  return incrementWindowUsage(keyId, windowMinutes, { requests: count }, options)
+}
+
+module.exports = {
+  getWindowSnapshot,
+  getWindowSnapshotsByConfig,
+  getLegacyWindowSnapshot,
+  incrementRequestCount,
+  incrementWindowUsage,
+  buildSnapshotFromBuckets,
+  parseBucketValue,
+  serializeBucketValue,
+  _private: {
+    createEmptySnapshot,
+    getBucketKey,
+    getBucketId,
+    getBucketTimestamp,
+    getBucketRetentionSeconds,
+    migrateLegacyWindowToBuckets,
+    roundCost
+  }
+}

--- a/tests/slidingWindowRateLimit.test.js
+++ b/tests/slidingWindowRateLimit.test.js
@@ -1,0 +1,188 @@
+jest.mock('../src/models/redis', () => ({
+  getClientSafe: jest.fn()
+}))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+
+const slidingWindowRateLimit = require('../src/utils/slidingWindowRateLimit')
+
+function createFakeRedisClient() {
+  const strings = new Map()
+  const hashes = new Map()
+
+  const ensureHash = (key) => {
+    if (!hashes.has(key)) {
+      hashes.set(key, {})
+    }
+    return hashes.get(key)
+  }
+
+  return {
+    strings,
+    hashes,
+    async get(key) {
+      return strings.has(key) ? strings.get(key) : null
+    },
+    async hgetall(key) {
+      return { ...(hashes.get(key) || {}) }
+    },
+    async hget(key, field) {
+      const hash = hashes.get(key) || {}
+      return Object.prototype.hasOwnProperty.call(hash, field) ? hash[field] : null
+    },
+    async hset(key, field, value) {
+      const hash = ensureHash(key)
+      hash[field] = value
+      return 1
+    },
+    async hdel(key, ...fields) {
+      const hash = hashes.get(key)
+      if (!hash) {
+        return 0
+      }
+
+      let deleted = 0
+      for (const field of fields) {
+        if (Object.prototype.hasOwnProperty.call(hash, field)) {
+          delete hash[field]
+          deleted += 1
+        }
+      }
+      return deleted
+    },
+    async expire() {
+      return 1
+    },
+    pipeline() {
+      const commands = []
+      const pipelineApi = {
+        hgetall(key) {
+          commands.push(['hgetall', key])
+          return pipelineApi
+        },
+        hset(key, field, value) {
+          commands.push(['hset', key, field, value])
+          return pipelineApi
+        },
+        expire(key, ttl) {
+          commands.push(['expire', key, ttl])
+          return pipelineApi
+        },
+        hdel(key, ...fields) {
+          commands.push(['hdel', key, ...fields])
+          return pipelineApi
+        },
+        async exec() {
+          const results = []
+          for (const [command, ...args] of commands) {
+            // eslint-disable-next-line no-await-in-loop
+            const value = await this._apply(command, args)
+            results.push([null, value])
+          }
+          return results
+        },
+        async _apply(command, args) {
+          switch (command) {
+            case 'hgetall':
+              return { ...(hashes.get(args[0]) || {}) }
+            case 'hset': {
+              const [key, field, value] = args
+              const hash = ensureHash(key)
+              hash[field] = value
+              return 1
+            }
+            case 'expire':
+              return 1
+            case 'hdel': {
+              const [key, ...fields] = args
+              const hash = hashes.get(key)
+              if (!hash) {
+                return 0
+              }
+              let deleted = 0
+              for (const field of fields) {
+                if (Object.prototype.hasOwnProperty.call(hash, field)) {
+                  delete hash[field]
+                  deleted += 1
+                }
+              }
+              return deleted
+            }
+            default:
+              throw new Error(`Unsupported pipeline command: ${command}`)
+          }
+        }
+      }
+      return pipelineApi
+    }
+  }
+}
+
+describe('slidingWindowRateLimit', () => {
+  test('buildSnapshotFromBuckets only sums buckets inside the rolling window', () => {
+    const now = Date.UTC(2026, 0, 1, 10, 30, 0)
+    const currentBucket = Math.floor(now / 60000)
+    const rawBuckets = {
+      [currentBucket - 70]: slidingWindowRateLimit.serializeBucketValue({
+        requests: 9,
+        tokens: 900,
+        cost: 9.5
+      }),
+      [currentBucket - 59]: slidingWindowRateLimit.serializeBucketValue({
+        requests: 2,
+        tokens: 200,
+        cost: 2.25
+      }),
+      [currentBucket - 5]: slidingWindowRateLimit.serializeBucketValue({
+        requests: 3,
+        tokens: 300,
+        cost: 3.75
+      })
+    }
+
+    const snapshot = slidingWindowRateLimit.buildSnapshotFromBuckets(rawBuckets, 60, now)
+
+    expect(snapshot.hasActiveWindow).toBe(true)
+    expect(snapshot.requests).toBe(5)
+    expect(snapshot.tokens).toBe(500)
+    expect(snapshot.cost).toBe(6)
+    expect(snapshot.windowStartTime).toBe((currentBucket - 59) * 60000)
+    expect(snapshot.windowEndTime).toBe((currentBucket - 58) * 60000 + 60 * 60000)
+    expect(snapshot.staleFields).toContain(String(currentBucket - 70))
+  })
+
+  test('getWindowSnapshot migrates legacy fixed-window counters into sliding buckets', async () => {
+    const client = createFakeRedisClient()
+    const keyId = 'key-123'
+    const now = Date.UTC(2026, 0, 2, 12, 0, 0)
+    const legacyWindowStart = now - 20 * 60 * 1000
+
+    client.strings.set(`rate_limit:requests:${keyId}`, '4')
+    client.strings.set(`rate_limit:tokens:${keyId}`, '1200')
+    client.strings.set(`rate_limit:cost:${keyId}`, '18.5')
+    client.strings.set(`rate_limit:window_start:${keyId}`, String(legacyWindowStart))
+
+    const snapshot = await slidingWindowRateLimit.getWindowSnapshot(keyId, 60, {
+      client,
+      now
+    })
+
+    expect(snapshot.hasActiveWindow).toBe(true)
+    expect(snapshot.requests).toBe(4)
+    expect(snapshot.tokens).toBe(1200)
+    expect(snapshot.cost).toBe(18.5)
+
+    const bucketKey = slidingWindowRateLimit._private.getBucketKey(keyId)
+    const migratedBuckets = await client.hgetall(bucketKey)
+    expect(Object.keys(migratedBuckets)).toHaveLength(1)
+
+    const migratedValue = Object.values(migratedBuckets)[0]
+    expect(migratedValue).toBe(
+      slidingWindowRateLimit.serializeBucketValue({ requests: 4, tokens: 1200, cost: 18.5 })
+    )
+  })
+})


### PR DESCRIPTION
  修改滑动窗口限额问题，当前实现针对滑动窗口实现有很严重的 bug，无法限制 比如 10080 分钟，150 美金使用，当前 codex 完全限制不住
  
  - 滑动窗口限额改成真实滚动窗口
  - 补上 Codex / OpenAI-Responses / OpenAI-Gemini 的窗口费用回写
  - 管理端与统计接口统一读取新窗口数据
  - 新增回归测试 tests/slidingWindowRateLimit.test.js