### PR TITLE
fix: safeStringify 截断逻辑缺陷和类型过滤缺失导致内存耗尽

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -42,9 +42,15 @@ const safeStringify = (obj, maxDepth = Infinity) => {
       if (value.constructor) {
         const constructorName = value.constructor.name
         if (
-          ['Socket', 'TLSSocket', 'HTTPParser', 'IncomingMessage', 'ServerResponse'].includes(
-            constructorName
-          )
+          [
+            'Socket',
+            'TLSSocket',
+            'HTTPParser',
+            'IncomingMessage',
+            'ServerResponse',
+            'ClientRequest',
+            'Writable'
+          ].includes(constructorName)
         ) {
           return `[${constructorName} Object]`
         }
@@ -76,7 +82,7 @@ const safeStringify = (obj, maxDepth = Infinity) => {
       const truncated = { ...processed, _truncated: true, _totalChars: result.length }
       // 第一轮: 截断单个大字段
       for (const [k, v] of Object.entries(truncated)) {
-        if (k.startsWith('_')) {
+        if (k === '_truncated' || k === '_totalChars') {
           continue
         }
         const fieldStr = typeof v === 'string' ? v : JSON.stringify(v)
@@ -88,7 +94,7 @@ const safeStringify = (obj, maxDepth = Infinity) => {
       let secondResult = JSON.stringify(truncated)
       if (secondResult.length > 50000) {
         for (const [k, v] of Object.entries(truncated)) {
-          if (k.startsWith('_')) {
+          if (k === '_truncated' || k === '_totalChars') {
             continue
           }
           const fieldStr = typeof v === 'string' ? v : JSON.stringify(v)

--- a/tests/safeStringify.test.js
+++ b/tests/safeStringify.test.js
@@ -1,0 +1,193 @@
+/**
+ * Tests for safeStringify fixes:
+ *
+ * Fix 1: Truncation now applies to `_` prefixed fields (only skips _truncated/_totalChars)
+ * Fix 2: Replacer filters ClientRequest and Writable types
+ */
+
+const fs = require('fs')
+const path = require('path')
+const http = require('http')
+
+// Extract safeStringify from logger.js source (it's not exported)
+function extractSafeStringify() {
+  const source = fs.readFileSync(path.join(__dirname, '../src/utils/logger.js'), 'utf-8')
+  const startMarker = '// 安全的 JSON 序列化函数，处理循环引用和特殊字符'
+  const endMarker = '\n// 控制台不显示的 metadata 字段'
+  const startIdx = source.indexOf(startMarker)
+  const endIdx = source.indexOf(endMarker)
+  if (startIdx === -1 || endIdx === -1) {
+    throw new Error('Cannot extract safeStringify from logger.js')
+  }
+  const fnSource = source.substring(startIdx, endIdx)
+  const wrapped = `${fnSource}\nreturn safeStringify;`
+  return new Function(wrapped)()
+}
+
+let safeStringify
+
+beforeAll(() => {
+  safeStringify = extractSafeStringify()
+})
+
+describe('Fix 1: truncation applies to _ prefixed fields', () => {
+  test('_ prefixed fields are now truncated when result > 50KB', () => {
+    const bigData = 'A'.repeat(200000)
+    const obj = {
+      _writableState: bigData,
+      _header: bigData,
+      _contentLength: bigData
+    }
+    const result = safeStringify(obj)
+    const parsed = JSON.parse(result)
+
+    // _ prefixed fields are now truncated (no longer bypassed)
+    expect(parsed._truncated).toBe(true)
+    expect(result.length).toBeLessThan(100000)
+  })
+
+  test('_ prefixed and non-_ prefixed fields are truncated equally', () => {
+    const bigData = 'C'.repeat(200000)
+
+    const underscoreObj = {
+      _field1: bigData,
+      _field2: bigData,
+      _field3: bigData
+    }
+    const underscoreResult = safeStringify(underscoreObj)
+
+    const normalObj = {
+      field1: bigData,
+      field2: bigData,
+      field3: bigData
+    }
+    const normalResult = safeStringify(normalObj)
+
+    // Both should now be similar size (ratio close to 1)
+    const ratio = underscoreResult.length / normalResult.length
+    expect(ratio).toBeLessThan(2)
+    expect(ratio).toBeGreaterThan(0.5)
+  })
+
+  test('_truncated and _totalChars metadata fields are preserved', () => {
+    const bigData = 'D'.repeat(200000)
+    const obj = { _bigField: bigData }
+    const result = safeStringify(obj)
+    const parsed = JSON.parse(result)
+
+    // safeStringify's own metadata fields are not truncated
+    expect(parsed._truncated).toBe(true)
+    expect(typeof parsed._totalChars).toBe('number')
+    expect(parsed._totalChars).toBeGreaterThan(50000)
+  })
+
+  test('non-_ prefixed fields still truncated correctly', () => {
+    const bigData = 'B'.repeat(200000)
+    const obj = {
+      writableState: bigData,
+      header: bigData,
+      contentLength: bigData
+    }
+    const result = safeStringify(obj)
+    const parsed = JSON.parse(result)
+
+    expect(parsed._truncated).toBe(true)
+    expect(parsed.writableState.length).toBeLessThanOrEqual(10100)
+    expect(result.length).toBeLessThan(100000)
+  })
+})
+
+describe('Fix 2: replacer filters ClientRequest and Writable', () => {
+  test('ClientRequest is now filtered', () => {
+    const req = http.request({ hostname: '127.0.0.1', port: 1, method: 'GET' })
+    req.on('error', () => {})
+    req.destroy()
+
+    const result = safeStringify({ req })
+    expect(result).toContain('[ClientRequest Object]')
+  })
+
+  test('Socket is still filtered', () => {
+    const net = require('net')
+    const socket = new net.Socket()
+    const result = safeStringify({ sock: socket })
+    expect(result).toContain('[Socket Object]')
+    socket.destroy()
+  })
+
+  test('filter list includes ClientRequest and Writable', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../src/utils/logger.js'), 'utf-8')
+    for (const type of ['ClientRequest', 'Writable']) {
+      expect(source).toContain(`'${type}'`)
+    }
+  })
+})
+
+describe('combined: simulated axios ETIMEDOUT error is now safe', () => {
+  test('mock axios error request field is truncated to safe size', () => {
+    const largeRequestBody = JSON.stringify({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 8096,
+      messages: Array(50).fill({
+        role: 'user',
+        content: 'x'.repeat(10000)
+      })
+    })
+
+    // Simulate ClientRequest-like structure (plain object, not real ClientRequest)
+    const mockRequest = {
+      _writableState: { objectMode: false, highWaterMark: 16384 },
+      _events: { error: '[Function]', close: '[Function]' },
+      _header: `POST /v1/messages HTTP/1.1\r\nHost: api.anthropic.com\r\n`,
+      _requestBodyBuffers: [
+        { data: Array.from(Buffer.from(largeRequestBody)), encoding: 'buffer' }
+      ],
+      _options: { protocol: 'https:', hostname: 'api.anthropic.com', path: '/v1/messages' },
+      _ended: false,
+      _contentLength: largeRequestBody.length
+    }
+
+    const result = safeStringify(mockRequest)
+
+    // With fix: truncation now applies to _ prefixed fields
+    expect(result.length).toBeLessThan(100000)
+    const parsed = JSON.parse(result)
+    expect(parsed._truncated).toBe(true)
+  })
+
+  test('real http.ClientRequest is filtered by replacer', () => {
+    const req = http.request({
+      hostname: '127.0.0.1',
+      port: 1,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    })
+    req.on('error', () => {})
+    req.write(JSON.stringify({ test: 'data'.repeat(1000) }))
+    req.destroy()
+
+    const result = safeStringify(req)
+
+    // Fix 2: ClientRequest is now filtered at replacer level
+    expect(result).toContain('[ClientRequest Object]')
+    // Output is tiny placeholder, not MB-level serialization
+    expect(result.length).toBeLessThan(200)
+  })
+
+  test('Buffer byte array in _ prefixed field is now truncated', () => {
+    const bodySize = 100000
+    const body = Buffer.alloc(bodySize, 0x41)
+    const bufferArray = Array.from(body)
+
+    const obj = {
+      _requestBodyBuffers: [{ data: bufferArray, encoding: 'buffer' }]
+    }
+
+    const result = safeStringify(obj)
+
+    // With fix: result is truncated even though field starts with _
+    expect(result.length).toBeLessThan(100000)
+    const parsed = JSON.parse(result)
+    expect(parsed._truncated).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

修复 `src/utils/logger.js` 中 `safeStringify()` 的两个缺陷，当上游连接超时 (ETIMEDOUT) 时，这两个缺陷会导致单次错误产生 5\~7MB 的日志字符串，长时间运行后累积耗尽服务器内存。

## Changes

### 1. 截断逻辑修复 (`logger.js:79,91`)

将 `k.startsWith('_')` 改为 `k === '_truncated' || k === '_totalChars'`。

**修复前**：截断逻辑跳过所有 `_` 前缀字段，而 Node.js 内部对象（如 `ClientRequest`）的属性几乎全部以 `_` 开头，导致截断完全失效。

**修复后**：只跳过 `safeStringify` 自身添加的两个元数据字段，所有其他字段（包括 `_` 前缀）正常参与截断。

### 2. replacer 过滤列表补全 (`logger.js:45`)

在过滤列表中添加 `ClientRequest` 和 `Writable`。

**修复前**：过滤列表包含 `Socket`、`TLSSocket`、`IncomingMessage`、`ServerResponse`，但缺少 `ClientRequest` 和 `Writable`（axios 通过 `follow-redirects` 发请求，`error.request` 的 `constructor.name` 为 `Writable`）。

**修复后**：这些类型在 replacer 阶段直接被替换为 `[ClassName Object]` 占位符，避免递归展开构建 MB 级中间对象。

### 为什么不修改调用方

relay 目录下有 44 处、整个 `src/` 有 738 处 `logger.error(..., error)` 传入完整 error 对象。在 `logger.js` 中修复可一次性保护所有调用点，无需逐个修改。

## Test plan

- [x] `npm test -- safeStringify` — 10 个测试全部通过
- [x] `npm test` — 全量 119 个测试通过，无回归（3 个 suite 因缺少 `config/config.js` 失败是已有问题）
- [x] `npm run lint` — 无错误

Closes #1099