### PR TITLE
Add Docker Build and Push GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,47 @@
+name: Docker Build and Push Pipeline
+
+on:
+  push:
+    branches: [ "hqli-dev" ]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: '请输入镜像标签 (例如: v1.0.0)'
+        required: true
+        default: 'latest'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Image Tag
+        id: vars
+        run: |
+          # 如果是手动触发，使用输入的值；如果是 push 触发，使用分支名
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.image_tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
This workflow builds and pushes a Docker image to GitHub Container Registry based on the specified image tag or branch name.