### PR TITLE
fix: 修复 Claude Code 2.1.76+ 使用 -p 模式时客户端限制验证失败 (403)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,6 +168,10 @@ TRUST_PROXY=true
 
 # 🔒 客户端限制（可选）
 # ALLOW_CUSTOM_CLIENTS=false
+# Claude Code 系统提示词最少匹配条目数
+# 0（默认）= 严格模式，system 数组中所有条目都必须通过相似度检测
+# N > 0    = 宽松模式，至少 N 条匹配即可（推荐设为 1，兼容带 billing-header 的新版本）
+# CLAUDE_CODE_MIN_SYSTEM_PROMPT_MATCHES=0
 
 # 🔐 LDAP 认证配置
 LDAP_ENABLED=false

--- a/src/validators/clients/claudeCodeValidator.js
+++ b/src/validators/clients/claudeCodeValidator.js
@@ -2,6 +2,11 @@ const logger = require('../../utils/logger')
 const { CLIENT_DEFINITIONS } = require('../clientDefinitions')
 const { bestSimilarityByTemplates, SYSTEM_PROMPT_THRESHOLD } = require('../../utils/contents')
 
+// 0 = 所有条目都必须匹配（默认严格模式），N > 0 = 至少 N 条匹配即可通过
+const parsedMinMatches = parseInt(process.env.CLAUDE_CODE_MIN_SYSTEM_PROMPT_MATCHES)
+const MIN_SYSTEM_PROMPT_MATCHES =
+  Number.isInteger(parsedMinMatches) && parsedMinMatches >= 0 ? parsedMinMatches : 0
+
 /**
  * Claude Code CLI 验证器
  * 验证请求是否来自 Claude Code CLI
@@ -36,11 +41,13 @@ class ClaudeCodeValidator {
   }
 
   /**
-   * 检查请求是否包含 Claude Code 系统提示词
+   * 检查请求中 system 条目的系统提示词匹配情况
    * @param {Object} body - 请求体
-   * @returns {boolean} 是否包含 Claude Code 系统提示词
+   * @param {number} [customThreshold] - 自定义相似度阈值
+   * @param {number} [minMatchCount] - 最少需要匹配的条目数；0 表示全部都必须匹配（严格模式）
+   * @returns {boolean}
    */
-  static hasClaudeCodeSystemPrompt(body, customThreshold) {
+  static hasClaudeCodeSystemPrompt(body, customThreshold, minMatchCount) {
     if (!body || typeof body !== 'object') {
       return false
     }
@@ -60,10 +67,25 @@ class ClaudeCodeValidator {
         ? customThreshold
         : SYSTEM_PROMPT_THRESHOLD
 
+    // minRequired: 0 = 所有条目都必须匹配；N > 0 = 至少 N 条匹配即可
+    const minRequired =
+      typeof minMatchCount === 'number' && Number.isInteger(minMatchCount) && minMatchCount > 0
+        ? minMatchCount
+        : 0
+
+    let matchCount = 0
+
     for (const entry of systemEntries) {
       const rawText = typeof entry?.text === 'string' ? entry.text : ''
       const { bestScore, templateId, maskedRaw } = bestSimilarityByTemplates(rawText)
-      if (bestScore < threshold) {
+
+      if (bestScore >= threshold) {
+        matchCount++
+        if (minRequired > 0 && matchCount >= minRequired) {
+          return true
+        }
+      } else if (minRequired === 0) {
+        // 严格模式：任意一条不匹配就失败
         logger.error(
           `Claude system prompt similarity below threshold: score=${bestScore.toFixed(4)}, threshold=${threshold}`
         )
@@ -76,55 +98,25 @@ class ClaudeCodeValidator {
         return false
       }
     }
-    return true
-  }
 
-  /**
-   * 判断是否存在 Claude Code 系统提示词（存在即返回 true）
-   * @param {Object} body - 请求体
-   * @param {number} [customThreshold] - 自定义阈值
-   * @returns {boolean} 是否存在 Claude Code 系统提示词
-   */
-  static includesClaudeCodeSystemPrompt(body, customThreshold) {
-    if (!body || typeof body !== 'object') {
-      return false
-    }
-
-    const model = typeof body.model === 'string' ? body.model : null
-    if (!model) {
-      return false
-    }
-
-    const systemEntries = Array.isArray(body.system) ? body.system : null
-    if (!systemEntries) {
-      return false
-    }
-
-    const threshold =
-      typeof customThreshold === 'number' && Number.isFinite(customThreshold)
-        ? customThreshold
-        : SYSTEM_PROMPT_THRESHOLD
-
-    let bestMatchScore = 0
-
-    for (const entry of systemEntries) {
-      const rawText = typeof entry?.text === 'string' ? entry.text : ''
-      const { bestScore } = bestSimilarityByTemplates(rawText)
-
-      if (bestScore > bestMatchScore) {
-        bestMatchScore = bestScore
-      }
-
-      if (bestScore >= threshold) {
-        return true
-      }
+    if (minRequired === 0) {
+      return true
     }
 
     logger.debug(
-      `Claude system prompt not detected: bestScore=${bestMatchScore.toFixed(4)}, threshold=${threshold}`
+      `Claude system prompt not detected: matchCount=${matchCount}, minRequired=${minRequired}`
     )
+    return matchCount >= minRequired
+  }
 
-    return false
+  /**
+   * 判断是否存在 Claude Code 系统提示词（至少一条匹配即返回 true）
+   * @param {Object} body - 请求体
+   * @param {number} [customThreshold] - 自定义阈值
+   * @returns {boolean}
+   */
+  static includesClaudeCodeSystemPrompt(body, customThreshold) {
+    return this.hasClaudeCodeSystemPrompt(body, customThreshold, 1)
   }
 
   /**
@@ -151,8 +143,8 @@ class ClaudeCodeValidator {
         return true
       }
 
-      // 3. 检查系统提示词是否为 Claude Code 的系统提示词
-      if (!this.hasClaudeCodeSystemPrompt(req.body)) {
+      // 3. 检查系统提示词匹配（由 CLAUDE_CODE_MIN_SYSTEM_PROMPT_MATCHES 控制匹配策略）
+      if (!this.hasClaudeCodeSystemPrompt(req.body, undefined, MIN_SYSTEM_PROMPT_MATCHES)) {
         logger.debug('Claude Code validation failed - missing or invalid Claude Code system prompt')
         return false
       }


### PR DESCRIPTION
## 问题

Claude Code 2.1.76 开始，在 `-p`（自定义系统提示词）模式下，`system` 数组中会新增一条 billing header 条目：

```
x-anthropic-billing-header: cc_version=2.1.76.b57; cc_entrypoint=cli; cch=00000;
```

`hasClaudeCodeSystemPrompt()` 要求所有 `system` 条目都通过相似度检测，billing header 与系统提示词模板毫无相似度，导致验证失败，返回 **403 Client not allowed**。

Fixes #1103

## 变更内容

**`src/validators/clients/claudeCodeValidator.js`**

- 将 `hasClaudeCodeSystemPrompt` 和 `includesClaudeCodeSystemPrompt` 合并为统一实现
- 新增 `minMatchCount` 参数：
  - `0`（默认）= 严格模式，所有条目必须匹配
  - `N > 0` = 宽松模式，至少 N 条匹配即可
- `includesClaudeCodeSystemPrompt` 保留为 wrapper（向后兼容 `claudeRelayService.js` 的调用）
- `validate()` 通过环境变量 `CLAUDE_CODE_MIN_SYSTEM_PROMPT_MATCHES` 读取配置

**`.env.example`**

- 新增 `CLAUDE_CODE_MIN_SYSTEM_PROMPT_MATCHES` 配置说明

## 修复方式

在 `.env` 中设置：

```
CLAUDE_CODE_MIN_SYSTEM_PROMPT_MATCHES=1
```

即可兼容 Claude Code 2.1.76+ 的 `-p` 模式，同时不影响默认严格验证行为。