### PR TITLE
feat: block 1M context requests for PRO accounts

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -346,7 +346,8 @@ async function handleMessagesRequest(req, res) {
           req.apiKey,
           sessionHash,
           requestedModel,
-          forcedAccount
+          forcedAccount,
+          { betaHeader: req.headers['anthropic-beta'] || '' }
         )
         ;({ accountId, accountType } = selection)
       } catch (error) {
@@ -1020,7 +1021,8 @@ async function handleMessagesRequest(req, res) {
           req.apiKey,
           sessionHash,
           requestedModel,
-          forcedAccountNonStream
+          forcedAccountNonStream,
+          { betaHeader: req.headers['anthropic-beta'] || '' }
         )
         ;({ accountId, accountType } = selection)
       } catch (error) {
@@ -1694,7 +1696,9 @@ router.post('/v1/messages/count_tokens', authenticateApiKey, async (req, res) =>
     const { accountId, accountType } = await unifiedClaudeScheduler.selectAccountForApiKey(
       req.apiKey,
       sessionHash,
-      requestedModel
+      requestedModel,
+      null,
+      { betaHeader: req.headers['anthropic-beta'] || '' }
     )
 
     if (accountType === 'ccr') {

--- a/src/routes/openaiClaudeRoutes.js
+++ b/src/routes/openaiClaudeRoutes.js
@@ -232,7 +232,9 @@ async function handleChatCompletion(req, res, apiKeyData) {
       accountSelection = await unifiedClaudeScheduler.selectAccountForApiKey(
         apiKeyData,
         sessionHash,
-        claudeRequest.model
+        claudeRequest.model,
+        null,
+        { betaHeader: req.headers['anthropic-beta'] || '' }
       )
     } catch (error) {
       if (error.code === 'CLAUDE_DEDICATED_RATE_LIMITED') {

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -72,6 +72,9 @@ class ClaudeRelayService {
         .split(',')
         .map((p) => p.trim())
         .filter(Boolean)
+        // Strip context-1m beta: 1M context is now GA (no header needed).
+        // Keeping it triggers legacy extra-usage checks on some orgs.
+        .filter((p) => !p.startsWith('context-1m'))
         .forEach(addBeta)
     }
 
@@ -432,7 +435,9 @@ class ClaudeRelayService {
         accountSelection = await unifiedClaudeScheduler.selectAccountForApiKey(
           apiKeyData,
           sessionHash,
-          requestBody.model
+          requestBody.model,
+          null,
+          { betaHeader: clientHeaders?.['anthropic-beta'] || '' }
         )
       } catch (error) {
         if (error.code === 'CLAUDE_DEDICATED_RATE_LIMITED') {
@@ -1776,7 +1781,9 @@ class ClaudeRelayService {
         accountSelection = await unifiedClaudeScheduler.selectAccountForApiKey(
           apiKeyData,
           sessionHash,
-          requestBody.model
+          requestBody.model,
+          null,
+          { betaHeader: clientHeaders?.['anthropic-beta'] || '' }
         )
       } catch (error) {
         if (error.code === 'CLAUDE_DEDICATED_RATE_LIMITED') {

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -40,8 +40,14 @@ class UnifiedClaudeScheduler {
     this.SESSION_MAPPING_PREFIX = 'unified_claude_session_mapping:'
   }
 
+  // 🔍 Check if the request uses 1M context (detected via anthropic-beta header)
+  _is1mContextRequest(betaHeader) {
+    if (!betaHeader) return false
+    return betaHeader.includes('context-1m')
+  }
+
   // 🔍 检查账户是否支持请求的模型
-  _isModelSupportedByAccount(account, accountType, requestedModel, context = '') {
+  _isModelSupportedByAccount(account, accountType, requestedModel, context = '', betaHeader = '') {
     if (!requestedModel) {
       return true // 没有指定模型时，默认支持
     }
@@ -64,7 +70,27 @@ class UnifiedClaudeScheduler {
         return false
       }
 
-      // 2. Opus model subscription level check
+      // 2. 1M context check for Pro accounts
+      // Pro accounts do not support 1M context models (detected via anthropic-beta header containing "context-1m")
+      if (betaHeader && this._is1mContextRequest(betaHeader) && account.subscriptionInfo) {
+        try {
+          const info =
+            typeof account.subscriptionInfo === 'string'
+              ? JSON.parse(account.subscriptionInfo)
+              : account.subscriptionInfo
+
+          if (isProAccount(info)) {
+            logger.info(
+              `🚫 Claude account ${account.name} (Pro) does not support 1M context model${context ? ` ${context}` : ''}`
+            )
+            return false
+          }
+        } catch (_e) {
+          // Parse failed, assume Max, allow 1M
+        }
+      }
+
+      // 3. Opus model subscription level check
       // VERSION RESTRICTION LOGIC:
       // - Free: No Opus models
       // - Pro: Only Opus 4.5+ (isOpus45OrNewer = true)
@@ -176,8 +202,11 @@ class UnifiedClaudeScheduler {
     apiKeyData,
     sessionHash = null,
     requestedModel = null,
-    forcedAccount = null
+    forcedAccount = null,
+    requestOptions = {}
   ) {
+    const betaHeader = requestOptions?.betaHeader || ''
+
     try {
       // 🔒 如果有强制绑定的账户（全局会话绑定），仅 claude-official 类型受影响
       if (forcedAccount && forcedAccount.accountId && forcedAccount.accountType) {
@@ -251,7 +280,8 @@ class UnifiedClaudeScheduler {
             groupId,
             sessionHash,
             effectiveModel,
-            vendor === 'ccr'
+            vendor === 'ccr',
+            betaHeader
           )
         }
 
@@ -390,7 +420,8 @@ class UnifiedClaudeScheduler {
             const isAvailable = await this._isAccountAvailable(
               mappedAccount.accountId,
               mappedAccount.accountType,
-              effectiveModel
+              effectiveModel,
+              betaHeader
             )
             if (isAvailable) {
               // 🚀 智能会话续期：剩余时间少于14天时自动续期到15天（续期正确的 unified 映射键）
@@ -399,6 +430,11 @@ class UnifiedClaudeScheduler {
                 `🎯 Using sticky session account: ${mappedAccount.accountId} (${mappedAccount.accountType}) for session ${sessionHash}`
               )
               return mappedAccount
+            } else if (betaHeader && this._is1mContextRequest(betaHeader)) {
+              // 1M context bypass: preserve mapping, just skip for this request
+              logger.info(
+                `🔄 Sticky session account ${mappedAccount.accountId} does not support 1M context, bypassing (mapping preserved)`
+              )
             } else {
               logger.warn(
                 `⚠️ Mapped account ${mappedAccount.accountId} is no longer available, selecting new account`
@@ -433,8 +469,9 @@ class UnifiedClaudeScheduler {
       // 选择第一个账户
       const selectedAccount = sortedAccounts[0]
 
-      // 如果有会话哈希，建立新的映射
-      if (sessionHash) {
+      // Create new session mapping if we have a session hash (skip on 1M bypass to preserve original mapping)
+      const is1mBypassMain = betaHeader && this._is1mContextRequest(betaHeader)
+      if (sessionHash && !is1mBypassMain) {
         await this._setSessionMapping(
           sessionHash,
           selectedAccount.accountId,
@@ -626,7 +663,15 @@ class UnifiedClaudeScheduler {
         // 检查是否可调度
 
         // 检查模型支持
-        if (!this._isModelSupportedByAccount(account, 'claude-official', requestedModel)) {
+        if (
+          !this._isModelSupportedByAccount(
+            account,
+            'claude-official',
+            requestedModel,
+            '',
+            betaHeader
+          )
+        ) {
           continue
         }
 
@@ -979,7 +1024,7 @@ class UnifiedClaudeScheduler {
   }
 
   // 🔍 检查账户是否可用
-  async _isAccountAvailable(accountId, accountType, requestedModel = null) {
+  async _isAccountAvailable(accountId, accountType, requestedModel = null, betaHeader = '') {
     try {
       if (accountType === 'claude-official') {
         const account = await redis.getClaudeAccount(accountId)
@@ -1003,7 +1048,8 @@ class UnifiedClaudeScheduler {
             account,
             'claude-official',
             requestedModel,
-            'in session check'
+            'in session check',
+            betaHeader
           )
         ) {
           return false
@@ -1463,7 +1509,8 @@ class UnifiedClaudeScheduler {
     groupId,
     sessionHash = null,
     requestedModel = null,
-    allowCcr = false
+    allowCcr = false,
+    betaHeader = ''
   ) {
     try {
       // 获取分组信息
@@ -1488,7 +1535,8 @@ class UnifiedClaudeScheduler {
               const isAvailable = await this._isAccountAvailable(
                 mappedAccount.accountId,
                 mappedAccount.accountType,
-                requestedModel
+                requestedModel,
+                betaHeader
               )
               if (isAvailable) {
                 // 🚀 智能会话续期：续期 unified 映射键
@@ -1498,10 +1546,22 @@ class UnifiedClaudeScheduler {
                 )
                 return mappedAccount
               }
+              // 1M context bypass: don't delete sticky mapping, just skip for this request
+              // so non-1M requests continue using the original account
+              if (betaHeader && this._is1mContextRequest(betaHeader)) {
+                logger.info(
+                  `🔄 Sticky session account ${mappedAccount.accountId} does not support 1M context, bypassing for this request (mapping preserved)`
+                )
+                // Fall through to normal account selection without deleting mapping
+              } else {
+                // Other unavailability reasons: delete mapping
+                await this._deleteSessionMapping(sessionHash)
+              }
             }
+          } else {
+            // Mapped account not in this group, delete mapping
+            await this._deleteSessionMapping(sessionHash)
           }
-          // 如果映射的账户不可用或不在分组中，删除映射
-          await this._deleteSessionMapping(sessionHash)
         }
       }
 
@@ -1569,7 +1629,15 @@ class UnifiedClaudeScheduler {
 
         if (isActive && status && isSchedulable(account.schedulable)) {
           // 检查模型支持
-          if (!this._isModelSupportedByAccount(account, accountType, requestedModel, 'in group')) {
+          if (
+            !this._isModelSupportedByAccount(
+              account,
+              accountType,
+              requestedModel,
+              'in group',
+              betaHeader
+            )
+          ) {
             continue
           }
 
@@ -1628,7 +1696,9 @@ class UnifiedClaudeScheduler {
       const selectedAccount = sortedAccounts[0]
 
       // 如果有会话哈希，建立新的映射
-      if (sessionHash) {
+      // On 1M context bypass, do not overwrite the existing sticky session mapping
+      const is1mBypass = betaHeader && this._is1mContextRequest(betaHeader)
+      if (sessionHash && !is1mBypass) {
         await this._setSessionMapping(
           sessionHash,
           selectedAccount.accountId,
@@ -1636,6 +1706,10 @@ class UnifiedClaudeScheduler {
         )
         logger.info(
           `🎯 Created new sticky session mapping in group: ${selectedAccount.name} (${selectedAccount.accountId}, ${selectedAccount.accountType}) for session ${sessionHash}`
+        )
+      } else if (sessionHash && is1mBypass) {
+        logger.info(
+          `🔄 1M context bypass: using ${selectedAccount.name} (${selectedAccount.accountId}) without updating sticky session mapping`
         )
       }
 

--- a/tests/claudeRelayBetaHeader.test.js
+++ b/tests/claudeRelayBetaHeader.test.js
@@ -1,0 +1,101 @@
+/**
+ * _getBetaHeader - context-1m stripping tests
+ *
+ * 1M context is now GA. The context-1m beta header is no longer needed and
+ * can trigger legacy extra-usage checks on some orgs. The relay strips it.
+ *
+ * Tests the beta header construction logic directly without loading
+ * the full ClaudeRelayService (which has many transitive dependencies).
+ */
+
+describe('_getBetaHeader - context-1m stripping', () => {
+  // Replicate the _getBetaHeader logic to test in isolation
+  function getBetaHeader(modelId, clientBetaHeader) {
+    const OAUTH_BETA = 'oauth-2025-04-20'
+    const CLAUDE_CODE_BETA = 'claude-code-20250219'
+    const INTERLEAVED_THINKING_BETA = 'interleaved-thinking-2025-05-14'
+    const TOOL_STREAMING_BETA = 'fine-grained-tool-streaming-2025-05-14'
+
+    const isHaikuModel = modelId && modelId.toLowerCase().includes('haiku')
+    const baseBetas = isHaikuModel
+      ? [OAUTH_BETA, INTERLEAVED_THINKING_BETA]
+      : [CLAUDE_CODE_BETA, OAUTH_BETA, INTERLEAVED_THINKING_BETA, TOOL_STREAMING_BETA]
+
+    const betaList = []
+    const seen = new Set()
+    const addBeta = (beta) => {
+      if (!beta || seen.has(beta)) return
+      seen.add(beta)
+      betaList.push(beta)
+    }
+
+    baseBetas.forEach(addBeta)
+
+    if (clientBetaHeader) {
+      clientBetaHeader
+        .split(',')
+        .map((p) => p.trim())
+        .filter(Boolean)
+        // Strip context-1m beta: 1M context is now GA (no header needed).
+        // Keeping it triggers legacy extra-usage checks on some orgs.
+        .filter((p) => !p.startsWith('context-1m'))
+        .forEach(addBeta)
+    }
+
+    return betaList.join(',')
+  }
+
+  it('should strip context-1m from client beta header', () => {
+    const clientBeta =
+      'claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12'
+    const result = getBetaHeader('claude-sonnet-4-6', clientBeta)
+    expect(result).not.toContain('context-1m')
+    expect(result).toContain('interleaved-thinking-2025-05-14')
+    expect(result).toContain('redact-thinking-2026-02-12')
+  })
+
+  it('should strip context-1m regardless of version suffix', () => {
+    const clientBeta = 'context-1m-2026-01-01,interleaved-thinking-2025-05-14'
+    const result = getBetaHeader('claude-opus-4-6', clientBeta)
+    expect(result).not.toContain('context-1m')
+    expect(result).toContain('interleaved-thinking-2025-05-14')
+  })
+
+  it('should preserve all other beta flags from client', () => {
+    const clientBeta =
+      'interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,prompt-caching-scope-2026-01-05,effort-2025-11-24'
+    const result = getBetaHeader('claude-sonnet-4-6', clientBeta)
+    expect(result).toContain('redact-thinking-2026-02-12')
+    expect(result).toContain('prompt-caching-scope-2026-01-05')
+    expect(result).toContain('effort-2025-11-24')
+  })
+
+  it('should work when client sends no beta header', () => {
+    const result = getBetaHeader('claude-sonnet-4-6', '')
+    expect(result).not.toContain('context-1m')
+    expect(result).toContain('claude-code-20250219')
+  })
+
+  it('should work when client sends only context-1m', () => {
+    const result = getBetaHeader('claude-sonnet-4-6', 'context-1m-2025-08-07')
+    expect(result).not.toContain('context-1m')
+    // Should still have base betas
+    expect(result).toContain('claude-code-20250219')
+    expect(result).toContain('oauth-2025-04-20')
+  })
+
+  it('should include base betas for non-haiku models', () => {
+    const result = getBetaHeader('claude-opus-4-6', '')
+    expect(result).toContain('claude-code-20250219')
+    expect(result).toContain('oauth-2025-04-20')
+    expect(result).toContain('interleaved-thinking-2025-05-14')
+    expect(result).toContain('fine-grained-tool-streaming-2025-05-14')
+  })
+
+  it('should use haiku-specific betas for haiku models', () => {
+    const result = getBetaHeader('claude-haiku-4-5-20251001', '')
+    expect(result).not.toContain('claude-code-20250219')
+    expect(result).toContain('oauth-2025-04-20')
+    expect(result).toContain('interleaved-thinking-2025-05-14')
+  })
+})

--- a/tests/unifiedClaudeScheduler1mContext.test.js
+++ b/tests/unifiedClaudeScheduler1mContext.test.js
@@ -1,0 +1,173 @@
+/**
+ * UnifiedClaudeScheduler - 1M context PRO account restriction tests
+ *
+ * PRO accounts do not support 1M context models.
+ * 1M context is detected via the "context-1m" flag in the anthropic-beta header.
+ * When a sticky session is bound to a Pro account, 1M requests bypass it
+ * without deleting the mapping, so non-1M requests continue using Pro.
+ */
+
+jest.mock('../src/utils/logger', () => ({
+  api: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  success: jest.fn(),
+  database: jest.fn(),
+  security: jest.fn()
+}))
+
+jest.mock('../src/models/redis', () => ({}))
+jest.mock('../src/services/account/claudeAccountService', () => ({}))
+jest.mock('../src/services/account/claudeConsoleAccountService', () => ({}))
+jest.mock('../src/services/account/bedrockAccountService', () => ({}))
+jest.mock('../src/services/account/ccrAccountService', () => ({}))
+jest.mock('../src/services/accountGroupService', () => ({}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({}))
+jest.mock('../src/utils/modelHelper', () => ({
+  parseVendorPrefixedModel: jest.fn((m) => ({ vendor: null, baseModel: m })),
+  isOpus45OrNewer: jest.fn(() => true)
+}))
+jest.mock('../src/utils/commonHelper', () => ({
+  isSchedulable: jest.fn(() => true),
+  sortAccountsByPriority: jest.fn((a) => a)
+}))
+
+describe('UnifiedClaudeScheduler - 1M context restrictions', () => {
+  let scheduler
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    scheduler = require('../src/services/scheduler/unifiedClaudeScheduler')
+  })
+
+  // --- _is1mContextRequest ---
+
+  describe('_is1mContextRequest', () => {
+    it('should return true when beta header contains context-1m', () => {
+      expect(
+        scheduler._is1mContextRequest(
+          'claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14'
+        )
+      ).toBe(true)
+    })
+
+    it('should return false when beta header has no context-1m', () => {
+      expect(
+        scheduler._is1mContextRequest(
+          'claude-code-20250219,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12'
+        )
+      ).toBe(false)
+    })
+
+    it('should return false for empty/null/undefined', () => {
+      expect(scheduler._is1mContextRequest('')).toBe(false)
+      expect(scheduler._is1mContextRequest(null)).toBe(false)
+      expect(scheduler._is1mContextRequest(undefined)).toBe(false)
+    })
+  })
+
+  // --- _isModelSupportedByAccount with 1M context ---
+
+  describe('_isModelSupportedByAccount - 1M context check', () => {
+    const beta1m = 'claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14'
+    const betaDefault =
+      'claude-code-20250219,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12'
+
+    const proAccount = {
+      name: 'pro-account-1',
+      subscriptionInfo: JSON.stringify({
+        hasClaudePro: true,
+        hasClaudeMax: false,
+        accountType: 'claude_pro'
+      })
+    }
+
+    const maxAccount = {
+      name: 'max-account-1',
+      subscriptionInfo: JSON.stringify({
+        hasClaudePro: false,
+        hasClaudeMax: true,
+        accountType: 'claude_max'
+      })
+    }
+
+    const noSubInfoAccount = { name: 'legacy-account-1' }
+
+    it('should reject PRO account for opus with 1M context', () => {
+      expect(
+        scheduler._isModelSupportedByAccount(proAccount, 'claude-official', 'claude-opus-4-6', '', beta1m)
+      ).toBe(false)
+    })
+
+    it('should reject PRO account for sonnet with 1M context', () => {
+      expect(
+        scheduler._isModelSupportedByAccount(
+          proAccount,
+          'claude-official',
+          'claude-sonnet-4-6',
+          '',
+          beta1m
+        )
+      ).toBe(false)
+    })
+
+    it('should allow PRO account without 1M context', () => {
+      expect(
+        scheduler._isModelSupportedByAccount(
+          proAccount,
+          'claude-official',
+          'claude-sonnet-4-6',
+          '',
+          betaDefault
+        )
+      ).toBe(true)
+    })
+
+    it('should allow PRO account with empty beta header', () => {
+      expect(
+        scheduler._isModelSupportedByAccount(proAccount, 'claude-official', 'claude-sonnet-4-6', '', '')
+      ).toBe(true)
+    })
+
+    it('should allow Max account with 1M context', () => {
+      expect(
+        scheduler._isModelSupportedByAccount(maxAccount, 'claude-official', 'claude-opus-4-6', '', beta1m)
+      ).toBe(true)
+    })
+
+    it('should allow account without subscriptionInfo (legacy compatibility)', () => {
+      expect(
+        scheduler._isModelSupportedByAccount(
+          noSubInfoAccount,
+          'claude-official',
+          'claude-opus-4-6',
+          '',
+          beta1m
+        )
+      ).toBe(true)
+    })
+
+    it('should not affect non-claude-official account types', () => {
+      expect(
+        scheduler._isModelSupportedByAccount(proAccount, 'claude-console', 'claude-opus-4-6', '', beta1m)
+      ).toBe(true)
+    })
+
+    it('should include context string in log message', () => {
+      const logger = require('../src/utils/logger')
+      scheduler._isModelSupportedByAccount(
+        proAccount,
+        'claude-official',
+        'claude-opus-4-6',
+        'in session check',
+        beta1m
+      )
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('does not support 1M context model')
+      )
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('in session check'))
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- PRO accounts are excluded from 1M context requests by detecting `context-1m` in the `anthropic-beta` header during scheduling
- Sticky session bypass: 1M requests skip Pro-bound sessions without deleting the mapping, so non-1M requests continue using Pro. No new sticky mappings are created on bypass.
- Strip `context-1m` from the `anthropic-beta` header forwarded to Anthropic — 1M context is now GA and sending the legacy beta flag triggers extra-usage checks on orgs without overage enabled
- `betaHeader` passed through `selectAccountForApiKey` → `selectAccountFromGroup` → `_isAccountAvailable` → `_isModelSupportedByAccount`
- All 6 caller sites updated to forward `req.headers['anthropic-beta']`

## Test plan
- [x] 11 unit tests for scheduler 1M context restrictions (`unifiedClaudeScheduler1mContext.test.js`)
- [x] 7 unit tests for beta header context-1m stripping (`claudeRelayBetaHeader.test.js`)
- [x] Manual: Sonnet 1M with Pro+Max enabled — routes to Max, succeeds
- [x] Manual: Opus 1M with Pro+Max enabled — routes to Max, succeeds
- [x] Manual: Normal Sonnet with Pro+Max enabled — routes to Pro (higher priority)
- [x] Manual: Pro-only with 1M request — returns "No available accounts" (expected)