### PR TITLE
feat: group fallback to shared account pool

### DIFF
--- a/src/routes/admin/accountGroups.js
+++ b/src/routes/admin/accountGroups.js
@@ -15,12 +15,13 @@ const router = express.Router()
 // 创建账户分组
 router.post('/', authenticateAdmin, async (req, res) => {
   try {
-    const { name, platform, description } = req.body
+    const { name, platform, description, allowSharedFallback } = req.body
 
     const group = await accountGroupService.createGroup({
       name,
       platform,
-      description
+      description,
+      allowSharedFallback
     })
 
     return res.json({ success: true, data: group })

--- a/src/services/accountGroupService.js
+++ b/src/services/accountGroupService.js
@@ -75,7 +75,7 @@ class AccountGroupService {
    */
   async createGroup(groupData) {
     try {
-      const { name, platform, description = '' } = groupData
+      const { name, platform, description = '', allowSharedFallback = false } = groupData
 
       // 验证必填字段
       if (!name || !platform) {
@@ -96,6 +96,7 @@ class AccountGroupService {
         name,
         platform,
         description,
+        allowSharedFallback: allowSharedFallback ? 'true' : 'false',
         createdAt: now,
         updatedAt: now
       }
@@ -150,6 +151,11 @@ class AccountGroupService {
       delete updateData.id
       delete updateData.platform
       delete updateData.createdAt
+
+      // Convert boolean to string for Redis
+      if (updateData.allowSharedFallback !== undefined) {
+        updateData.allowSharedFallback = updateData.allowSharedFallback ? 'true' : 'false'
+      }
 
       // 更新分组
       await client.hmset(groupKey, updateData)

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -1508,6 +1508,19 @@ class UnifiedClaudeScheduler {
       // 获取分组内的所有账户
       const memberIds = await accountGroupService.getGroupMembers(groupId)
       if (memberIds.length === 0) {
+        if (group.allowSharedFallback === 'true') {
+          logger.info(`🔄 Group ${group.name} has no members, falling back to shared pool`)
+          const fallbackResult = await this._selectSharedFallbackAccount(
+            group.platform,
+            requestedModel
+          )
+          if (fallbackResult) {
+            logger.info(
+              `🎯 Shared fallback selected: ${fallbackResult.accountId} (${fallbackResult.accountType}) for group ${group.name}`
+            )
+            return fallbackResult
+          }
+        }
         throw new Error(`Group ${group.name} has no members`)
       }
 
@@ -1618,6 +1631,27 @@ class UnifiedClaudeScheduler {
       }
 
       if (availableAccounts.length === 0) {
+        // Check if the group allows falling back to the shared account pool
+        if (group.allowSharedFallback === 'true') {
+          logger.info(
+            `🔄 Group ${group.name} has no available members, falling back to shared pool`
+          )
+          const fallbackResult = await this._selectSharedFallbackAccount(
+            group.platform,
+            requestedModel
+          )
+          if (fallbackResult) {
+            logger.info(
+              `🎯 Shared fallback selected: ${fallbackResult.accountId} (${fallbackResult.accountType}) for group ${group.name}`
+            )
+            // Do not create sticky session mapping for fallback accounts
+            return fallbackResult
+          }
+          // Shared pool also empty
+          throw new Error(
+            `No available accounts in group ${group.name} and no shared accounts available`
+          )
+        }
         throw new Error(`No available accounts in group ${group.name}`)
       }
 
@@ -1650,6 +1684,119 @@ class UnifiedClaudeScheduler {
     } catch (error) {
       logger.error(`❌ Failed to select account from group ${groupId}:`, error)
       throw error
+    }
+  }
+
+  // 🔄 Select a shared account as fallback when group has no available members
+  async _selectSharedFallbackAccount(platform, requestedModel, betaHeader = '') {
+    const availableAccounts = []
+    const isOpusRequest =
+      requestedModel && typeof requestedModel === 'string'
+        ? requestedModel.toLowerCase().includes('opus')
+        : false
+
+    if (platform === 'claude') {
+      // Claude Official shared accounts
+      const claudeAccounts = await redis.getAllClaudeAccounts()
+      for (const account of claudeAccounts) {
+        if (
+          account.isActive === 'true' &&
+          account.status !== 'error' &&
+          account.status !== 'blocked' &&
+          account.status !== 'temp_error' &&
+          (account.accountType === 'shared' || !account.accountType) &&
+          isSchedulable(account.schedulable)
+        ) {
+          if (
+            !this._isModelSupportedByAccount(
+              account,
+              'claude-official',
+              requestedModel,
+              'shared fallback',
+              betaHeader
+            )
+          ) {
+            continue
+          }
+          if (await this.isAccountTemporarilyUnavailable(account.id, 'claude-official')) continue
+          if (await claudeAccountService.isAccountRateLimited(account.id)) continue
+          if (isOpusRequest) {
+            if (await claudeAccountService.isAccountOpusRateLimited(account.id)) continue
+          }
+          availableAccounts.push({
+            ...account,
+            accountId: account.id,
+            accountType: 'claude-official',
+            priority: parseInt(account.priority) || 50,
+            lastUsedAt: account.lastUsedAt || '0'
+          })
+        }
+      }
+
+      // Claude Console accounts
+      const consoleAccounts = await claudeConsoleAccountService.getAllAccounts()
+      for (const account of consoleAccounts) {
+        if (
+          account.isActive === true &&
+          account.status === 'active' &&
+          isSchedulable(account.schedulable)
+        ) {
+          if (
+            !this._isModelSupportedByAccount(
+              account,
+              'claude-console',
+              requestedModel,
+              'shared fallback'
+            )
+          ) {
+            continue
+          }
+          if (await this.isAccountTemporarilyUnavailable(account.id, 'claude-console')) continue
+          if (await this.isAccountRateLimited(account.id, 'claude-console')) continue
+          if (account.maxConcurrentTasks > 0) {
+            const concurrency = await redis.getConsoleAccountConcurrency(account.id)
+            if (concurrency >= account.maxConcurrentTasks) continue
+          }
+          availableAccounts.push({
+            ...account,
+            accountId: account.id,
+            accountType: 'claude-console',
+            priority: parseInt(account.priority) || 50,
+            lastUsedAt: account.lastUsedAt || '0'
+          })
+        }
+      }
+
+      // CCR accounts
+      const ccrAccounts = await ccrAccountService.getAllAccounts()
+      for (const account of ccrAccounts) {
+        if (account.status === 'active' && isSchedulable(account.schedulable)) {
+          if (!this._isModelSupportedByAccount(account, 'ccr', requestedModel, 'shared fallback')) {
+            continue
+          }
+          if (await this.isAccountTemporarilyUnavailable(account.id, 'ccr')) continue
+          if (await this.isAccountRateLimited(account.id, 'ccr')) continue
+          availableAccounts.push({
+            ...account,
+            accountId: account.id,
+            accountType: 'ccr',
+            priority: parseInt(account.priority) || 50,
+            lastUsedAt: account.lastUsedAt || '0'
+          })
+        }
+      }
+    }
+
+    // TODO: Add gemini/openai/droid shared pool fallback if needed
+
+    if (availableAccounts.length === 0) {
+      return null
+    }
+
+    const sorted = sortAccountsByPriority(availableAccounts)
+    return {
+      accountId: sorted[0].accountId,
+      accountType: sorted[0].accountType
     }
   }
 

--- a/tests/groupSharedFallback.test.js
+++ b/tests/groupSharedFallback.test.js
@@ -1,0 +1,247 @@
+/**
+ * Group shared fallback tests
+ *
+ * When a group has allowSharedFallback enabled and no group members are
+ * available, the scheduler should fall back to the shared account pool.
+ */
+
+jest.mock('../src/utils/logger', () => ({
+  api: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  success: jest.fn(),
+  database: jest.fn(),
+  security: jest.fn()
+}))
+
+jest.mock('../src/models/redis', () => ({
+  getAllClaudeAccounts: jest.fn(),
+  getConsoleAccountConcurrency: jest.fn(),
+  getClientSafe: jest.fn()
+}))
+
+jest.mock('../src/services/account/claudeAccountService', () => ({
+  isAccountRateLimited: jest.fn(),
+  isAccountOpusRateLimited: jest.fn()
+}))
+
+jest.mock('../src/services/account/claudeConsoleAccountService', () => ({
+  getAllAccounts: jest.fn()
+}))
+
+jest.mock('../src/services/account/bedrockAccountService', () => ({}))
+
+jest.mock('../src/services/account/ccrAccountService', () => ({
+  getAllAccounts: jest.fn()
+}))
+
+jest.mock('../src/services/accountGroupService', () => ({
+  getGroup: jest.fn(),
+  getGroupMembers: jest.fn()
+}))
+
+jest.mock('../src/utils/upstreamErrorHelper', () => ({}))
+jest.mock('../src/utils/modelHelper', () => ({
+  parseVendorPrefixedModel: jest.fn((m) => ({ vendor: null, baseModel: m })),
+  isOpus45OrNewer: jest.fn(() => true)
+}))
+jest.mock('../src/utils/commonHelper', () => ({
+  isSchedulable: jest.fn(() => true),
+  sortAccountsByPriority: jest.fn((a) => a)
+}))
+
+const redis = require('../src/models/redis')
+const claudeAccountService = require('../src/services/account/claudeAccountService')
+const claudeConsoleAccountService = require('../src/services/account/claudeConsoleAccountService')
+const ccrAccountService = require('../src/services/account/ccrAccountService')
+const accountGroupService = require('../src/services/accountGroupService')
+
+describe('Group shared fallback', () => {
+  let scheduler
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    scheduler = require('../src/services/scheduler/unifiedClaudeScheduler')
+    // Mock instance methods that aren't covered by module mocks
+    scheduler.isAccountTemporarilyUnavailable = jest.fn().mockResolvedValue(false)
+    scheduler.isAccountRateLimited = jest.fn().mockResolvedValue(false)
+    scheduler._getSessionMapping = jest.fn().mockResolvedValue(null)
+    scheduler._setSessionMapping = jest.fn().mockResolvedValue(undefined)
+  })
+
+  describe('_selectSharedFallbackAccount', () => {
+    it('should return a shared claude-official account when available', async () => {
+      redis.getAllClaudeAccounts.mockResolvedValue([
+        {
+          id: 'shared-1',
+          name: 'shared-account',
+          isActive: 'true',
+          status: 'active',
+          accountType: 'shared',
+          schedulable: 'true',
+          priority: '10'
+        }
+      ])
+      claudeAccountService.isAccountRateLimited.mockResolvedValue(false)
+      claudeConsoleAccountService.getAllAccounts.mockResolvedValue([])
+      ccrAccountService.getAllAccounts.mockResolvedValue([])
+
+      const result = await scheduler._selectSharedFallbackAccount('claude', 'claude-sonnet-4-6')
+      expect(result).toEqual({
+        accountId: 'shared-1',
+        accountType: 'claude-official'
+      })
+    })
+
+    it('should return null when no shared accounts are available', async () => {
+      redis.getAllClaudeAccounts.mockResolvedValue([])
+      claudeConsoleAccountService.getAllAccounts.mockResolvedValue([])
+      ccrAccountService.getAllAccounts.mockResolvedValue([])
+
+      const result = await scheduler._selectSharedFallbackAccount('claude', 'claude-sonnet-4-6')
+      expect(result).toBeNull()
+    })
+
+    it('should skip inactive shared accounts', async () => {
+      redis.getAllClaudeAccounts.mockResolvedValue([
+        {
+          id: 'inactive-1',
+          name: 'inactive-account',
+          isActive: 'false',
+          status: 'active',
+          accountType: 'shared',
+          schedulable: 'true'
+        }
+      ])
+      claudeConsoleAccountService.getAllAccounts.mockResolvedValue([])
+      ccrAccountService.getAllAccounts.mockResolvedValue([])
+
+      const result = await scheduler._selectSharedFallbackAccount('claude', 'claude-sonnet-4-6')
+      expect(result).toBeNull()
+    })
+
+    it('should include console accounts in claude platform fallback', async () => {
+      redis.getAllClaudeAccounts.mockResolvedValue([])
+      claudeConsoleAccountService.getAllAccounts.mockResolvedValue([
+        {
+          id: 'console-1',
+          name: 'console-account',
+          isActive: true,
+          status: 'active',
+          schedulable: true,
+          maxConcurrentTasks: 0,
+          priority: '20'
+        }
+      ])
+      ccrAccountService.getAllAccounts.mockResolvedValue([])
+
+      const result = await scheduler._selectSharedFallbackAccount('claude', 'claude-sonnet-4-6')
+      expect(result).toEqual({
+        accountId: 'console-1',
+        accountType: 'claude-console'
+      })
+    })
+
+    it('should include ccr accounts in claude platform fallback', async () => {
+      redis.getAllClaudeAccounts.mockResolvedValue([])
+      claudeConsoleAccountService.getAllAccounts.mockResolvedValue([])
+      ccrAccountService.getAllAccounts.mockResolvedValue([
+        {
+          id: 'ccr-1',
+          name: 'ccr-account',
+          status: 'active',
+          schedulable: true,
+          priority: '30'
+        }
+      ])
+
+      const result = await scheduler._selectSharedFallbackAccount('claude', 'claude-sonnet-4-6')
+      expect(result).toEqual({
+        accountId: 'ccr-1',
+        accountType: 'ccr'
+      })
+    })
+  })
+
+  describe('selectAccountFromGroup with fallback', () => {
+    it('should fall back to shared pool when group has no members and allowSharedFallback is true', async () => {
+      accountGroupService.getGroup.mockResolvedValue({
+        name: 'test-group',
+        platform: 'claude',
+        allowSharedFallback: 'true'
+      })
+      accountGroupService.getGroupMembers.mockResolvedValue([])
+      redis.getAllClaudeAccounts.mockResolvedValue([
+        {
+          id: 'shared-1',
+          name: 'shared-account',
+          isActive: 'true',
+          status: 'active',
+          accountType: 'shared',
+          schedulable: 'true',
+          priority: '10'
+        }
+      ])
+      claudeAccountService.isAccountRateLimited.mockResolvedValue(false)
+      claudeConsoleAccountService.getAllAccounts.mockResolvedValue([])
+      ccrAccountService.getAllAccounts.mockResolvedValue([])
+
+      const result = await scheduler.selectAccountFromGroup('group-1', null, 'claude-sonnet-4-6')
+      expect(result.accountId).toBe('shared-1')
+      expect(result.accountType).toBe('claude-official')
+    })
+
+    it('should throw error when group has no members and allowSharedFallback is false', async () => {
+      accountGroupService.getGroup.mockResolvedValue({
+        name: 'test-group',
+        platform: 'claude',
+        allowSharedFallback: 'false'
+      })
+      accountGroupService.getGroupMembers.mockResolvedValue([])
+
+      await expect(
+        scheduler.selectAccountFromGroup('group-1', null, 'claude-sonnet-4-6')
+      ).rejects.toThrow('has no members')
+    })
+
+    it('should throw error when allowSharedFallback is not set (default behavior)', async () => {
+      accountGroupService.getGroup.mockResolvedValue({
+        name: 'test-group',
+        platform: 'claude'
+      })
+      accountGroupService.getGroupMembers.mockResolvedValue([])
+
+      await expect(
+        scheduler.selectAccountFromGroup('group-1', null, 'claude-sonnet-4-6')
+      ).rejects.toThrow('has no members')
+    })
+
+    it('should not create sticky session mapping for fallback accounts', async () => {
+      accountGroupService.getGroup.mockResolvedValue({
+        name: 'test-group',
+        platform: 'claude',
+        allowSharedFallback: 'true'
+      })
+      accountGroupService.getGroupMembers.mockResolvedValue([])
+      redis.getAllClaudeAccounts.mockResolvedValue([
+        {
+          id: 'shared-1',
+          name: 'shared-account',
+          isActive: 'true',
+          status: 'active',
+          accountType: 'shared',
+          schedulable: 'true',
+          priority: '10'
+        }
+      ])
+      claudeAccountService.isAccountRateLimited.mockResolvedValue(false)
+      claudeConsoleAccountService.getAllAccounts.mockResolvedValue([])
+      ccrAccountService.getAllAccounts.mockResolvedValue([])
+
+      await scheduler.selectAccountFromGroup('group-1', 'session-hash', 'claude-sonnet-4-6')
+      expect(scheduler._setSessionMapping).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/web/admin-spa/src/components/accounts/GroupManagementModal.vue
+++ b/web/admin-spa/src/components/accounts/GroupManagementModal.vue
@@ -194,6 +194,18 @@
             />
           </div>
 
+          <div class="flex items-center justify-between">
+            <div>
+              <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                >允许共享账户回退</label
+              >
+              <p class="text-xs text-gray-500 dark:text-gray-400">
+                分组内无可用账户时使用共享账户池
+              </p>
+            </div>
+            <el-switch v-model="editForm.allowSharedFallback" />
+          </div>
+
           <div class="flex gap-3 pt-4">
             <button
               class="btn btn-primary flex-1 px-4 py-2"
@@ -274,6 +286,18 @@
             />
           </div>
 
+          <div class="flex items-center justify-between">
+            <div>
+              <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                >允许共享账户回退</label
+              >
+              <p class="text-xs text-gray-500 dark:text-gray-400">
+                分组内无可用账户时使用共享账户池
+              </p>
+            </div>
+            <el-switch v-model="createForm.allowSharedFallback" />
+          </div>
+
           <div class="flex gap-3 pt-4">
             <button
               class="btn btn-primary flex-1 px-4 py-2"
@@ -351,7 +375,8 @@ const creating = ref(false)
 const createForm = ref({
   name: '',
   platform: 'claude',
-  description: ''
+  description: '',
+  allowSharedFallback: false
 })
 
 // 编辑表单
@@ -361,7 +386,8 @@ const editingGroup = ref(null)
 const editForm = ref({
   name: '',
   platform: '',
-  description: ''
+  description: '',
+  allowSharedFallback: false
 })
 
 // 格式化日期
@@ -391,7 +417,8 @@ const createGroup = async () => {
     await httpApis.createAccountGroupApi({
       name: createForm.value.name,
       platform: createForm.value.platform,
-      description: createForm.value.description
+      description: createForm.value.description,
+      allowSharedFallback: createForm.value.allowSharedFallback
     })
 
     showToast('分组创建成功', 'success')
@@ -417,7 +444,8 @@ const cancelCreate = () => {
   createForm.value = {
     name: '',
     platform: 'claude',
-    description: ''
+    description: '',
+    allowSharedFallback: false
   }
 }
 
@@ -427,7 +455,8 @@ const editGroup = (group) => {
   editForm.value = {
     name: group.name,
     platform: group.platform,
-    description: group.description || ''
+    description: group.description || '',
+    allowSharedFallback: group.allowSharedFallback === 'true'
   }
   showEditForm.value = true
 }
@@ -443,7 +472,8 @@ const updateGroup = async () => {
   try {
     await httpApis.updateAccountGroupApi(editingGroup.value.id, {
       name: editForm.value.name,
-      description: editForm.value.description
+      description: editForm.value.description,
+      allowSharedFallback: editForm.value.allowSharedFallback
     })
 
     showToast('分组更新成功', 'success')
@@ -464,7 +494,8 @@ const cancelEdit = () => {
   editForm.value = {
     name: '',
     platform: '',
-    description: ''
+    description: '',
+    allowSharedFallback: false
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `allowSharedFallback` toggle to account groups (default: off)
- When enabled and no group members are available, the scheduler falls back to the shared account pool matching the group's platform (claude-official + claude-console + ccr)
- Fallback accounts do not create sticky session mappings, keeping group routing independent

## Changes
- **Data model** (`accountGroupService.js`): `allowSharedFallback` field in create/update
- **Admin API** (`accountGroups.js`): Accept field in POST/PUT
- **Scheduler** (`unifiedClaudeScheduler.js`): `_selectSharedFallbackAccount` method, fallback at both "no members" and "no available accounts" paths
- **Frontend** (`GroupManagementModal.vue`): el-switch toggle in create/edit forms

## Test plan
- [x] 9 unit tests in `tests/groupSharedFallback.test.js` — all passing
- [x] Create group with fallback enabled, disable all members, verify request uses shared pool
- [x] Same with fallback disabled, verify 500 error
- [x] Verify fallback does not create sticky session mapping