### PR TITLE
feat: block sensitive prompts and cool down quota errors

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -39,6 +39,7 @@ const {
   requestSizeLimit
 } = require('./middleware/auth')
 const { browserFallbackMiddleware } = require('./middleware/browserFallback')
+const sensitiveContentGuard = require('./middleware/sensitiveContentGuard')
 
 class Application {
   constructor() {
@@ -242,6 +243,7 @@ class Application {
         })
       )
       this.app.use(express.urlencoded({ extended: true, limit: '100mb' }))
+      this.app.use(sensitiveContentGuard)
       this.app.use(securityMiddleware)
 
       // 🎯 信任代理

--- a/src/handlers/geminiHandlers.js
+++ b/src/handlers/geminiHandlers.js
@@ -21,6 +21,7 @@ const axios = require('axios')
 const { getSafeMessage } = require('../utils/errorSanitizer')
 const ProxyHelper = require('../utils/proxyHelper')
 const upstreamErrorHelper = require('../utils/upstreamErrorHelper')
+const { applyQuotaExceededCooldown } = require('../utils/quotaExceededHelper')
 
 // 处理 Gemini 上游错误，标记账户为临时不可用
 const handleGeminiUpstreamError = async (
@@ -29,13 +30,28 @@ const handleGeminiUpstreamError = async (
   accountType,
   sessionHash,
   headers,
-  disableAutoProtection = false
+  disableAutoProtection = false,
+  payload = null
 ) => {
   if (!accountId || !errorStatus) {
     return
   }
   const autoProtectionDisabled = disableAutoProtection === true || disableAutoProtection === 'true'
   try {
+    if (!autoProtectionDisabled) {
+      const quotaCooldown = await applyQuotaExceededCooldown({
+        accountId,
+        accountType: accountType || 'gemini',
+        statusCode: errorStatus,
+        payload,
+        sessionHash,
+        clearSessionMapping: (hash) => unifiedGeminiScheduler._deleteSessionMapping(hash)
+      })
+      if (quotaCooldown.applied) {
+        return
+      }
+    }
+
     if (errorStatus === 429) {
       if (!autoProtectionDisabled) {
         const ttl = upstreamErrorHelper.parseRetryAfter(headers)
@@ -772,7 +788,8 @@ async function handleMessages(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
 
     // 返回错误响应
@@ -1761,7 +1778,8 @@ async function handleGenerateContent(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
     res.status(500).json({
       error: {
@@ -2150,7 +2168,8 @@ async function handleStreamGenerateContent(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
 
     if (!res.headersSent) {
@@ -2449,7 +2468,8 @@ async function handleStandardGenerateContent(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
 
     res.status(500).json({
@@ -2934,7 +2954,8 @@ async function handleStandardStreamGenerateContent(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
 
     if (!res.headersSent) {

--- a/src/middleware/sensitiveContentGuard.js
+++ b/src/middleware/sensitiveContentGuard.js
@@ -16,12 +16,14 @@ const SENSITIVE_PATTERNS = [
   {
     type: 'aws_access_key',
     pattern: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/
-  },
-  {
-    type: 'aws_secret_key',
-    pattern: /\b[A-Za-z0-9/+=]{40}\b/
   }
 ]
+
+const AWS_SECRET_KEY_VALUE_PATTERN = /^[A-Za-z0-9/+=]{40}$/
+const AWS_SECRET_KEY_CONTEXT_PATTERN =
+  /(?:^|[^A-Za-z0-9])(?:aws[_-]?)?secret(?:[_-]?access)?[_-]?key(?:[^A-Za-z0-9]|$)/i
+const AWS_SECRET_KEY_INLINE_PATTERN =
+  /(?:^|[^A-Za-z0-9])(?:aws[_-]?)?secret(?:[_-]?access)?[_-]?key\s*[:=]\s*['"]?([A-Za-z0-9/+=]{40})['"]?/i
 
 const PROTECTED_PATH_PREFIXES = [
   '/api',
@@ -59,34 +61,156 @@ function shouldInspectRequest(req) {
   return PROTECTED_PATH_PREFIXES.some((prefix) => lowerPath.startsWith(prefix))
 }
 
-function collectSensitiveTypes(value, collector, depth = 0) {
+function isResponsesStylePath(req) {
+  const path = normalizePath(req.originalUrl || req.url || req.path).toLowerCase()
+  return (
+    path.startsWith('/openai/responses') ||
+    path.startsWith('/openai/v1/responses') ||
+    path.startsWith('/azure/response')
+  )
+}
+
+function appendTextContent(content, collector, allowedTypes = null) {
+  if (typeof content === 'string') {
+    collector.push(content)
+    return
+  }
+
+  if (!Array.isArray(content)) {
+    return
+  }
+
+  for (const item of content) {
+    if (typeof item === 'string') {
+      collector.push(item)
+      continue
+    }
+
+    if (!item || typeof item !== 'object') {
+      continue
+    }
+
+    if (
+      typeof item.text === 'string' &&
+      (!allowedTypes || allowedTypes.has(item.type) || item.type === undefined)
+    ) {
+      collector.push(item.text)
+    }
+  }
+}
+
+function getInspectablePayloads(req) {
+  if (!isResponsesStylePath(req) || !req.body || typeof req.body !== 'object') {
+    return [req.body]
+  }
+
+  const payloads = []
+  const ignoredTopLevelKeys = new Set([
+    'model',
+    'instructions',
+    'tools',
+    'include',
+    'reasoning',
+    'text',
+    'input',
+    'messages',
+    'stream',
+    'store',
+    'service_tier',
+    'prompt_cache_key',
+    'conversation_id',
+    'session_id',
+    'max_output_tokens',
+    'temperature',
+    'top_p',
+    'user'
+  ])
+
+  if (typeof req.body.prompt === 'string') {
+    payloads.push(req.body.prompt)
+  }
+
+  if (Array.isArray(req.body.messages)) {
+    for (const message of req.body.messages) {
+      if (!message || message.role !== 'user') {
+        continue
+      }
+      appendTextContent(message.content, payloads)
+    }
+  }
+
+  if (typeof req.body.input === 'string') {
+    payloads.push(req.body.input)
+  } else if (Array.isArray(req.body.input)) {
+    for (const item of req.body.input) {
+      if (!item || typeof item !== 'object') {
+        continue
+      }
+
+      if (item.type === 'message') {
+        if (item.role !== 'user' && item.role !== 'developer') {
+          continue
+        }
+        appendTextContent(item.content, payloads, new Set(['input_text', 'text']))
+        continue
+      }
+
+      if (item.type === 'input_text' && typeof item.text === 'string') {
+        payloads.push(item.text)
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(req.body)) {
+    if (ignoredTopLevelKeys.has(key)) {
+      continue
+    }
+    payloads.push({ [key]: value })
+  }
+
+  return payloads
+}
+
+function containsAwsSecretKey(value, keyContext = '') {
+  if (typeof value !== 'string') {
+    return false
+  }
+
+  const trimmed = value.trim()
+  if (AWS_SECRET_KEY_INLINE_PATTERN.test(trimmed)) {
+    return true
+  }
+
+  return AWS_SECRET_KEY_CONTEXT_PATTERN.test(keyContext) && AWS_SECRET_KEY_VALUE_PATTERN.test(trimmed)
+}
+
+function collectSensitiveTypes(value, collector, depth = 0, keyContext = '') {
   if (value === undefined || value === null || depth > 8) {
     return
   }
 
   if (typeof value === 'string') {
-    const hasModelProviderKey =
-      SENSITIVE_PATTERNS.find((entry) => entry.type === 'openai_api_key').pattern.test(value) ||
-      SENSITIVE_PATTERNS.find((entry) => entry.type === 'anthropic_api_key').pattern.test(value)
-
     for (const { type, pattern } of SENSITIVE_PATTERNS) {
-      if (type === 'aws_secret_key' && hasModelProviderKey) {
-        continue
-      }
       if (pattern.test(value)) {
         collector.add(type)
       }
+    }
+    if (containsAwsSecretKey(value, keyContext)) {
+      collector.add('aws_secret_key')
     }
     return
   }
 
   if (Array.isArray(value)) {
-    value.forEach((item) => collectSensitiveTypes(item, collector, depth + 1))
+    value.forEach((item, index) => collectSensitiveTypes(item, collector, depth + 1, `${keyContext}[${index}]`))
     return
   }
 
   if (typeof value === 'object') {
-    Object.values(value).forEach((item) => collectSensitiveTypes(item, collector, depth + 1))
+    Object.entries(value).forEach(([key, item]) => {
+      const nextContext = keyContext ? `${keyContext}.${key}` : key
+      collectSensitiveTypes(item, collector, depth + 1, nextContext)
+    })
   }
 }
 
@@ -96,7 +220,9 @@ function sensitiveContentGuard(req, res, next) {
   }
 
   const detectedTypes = new Set()
-  collectSensitiveTypes(req.body, detectedTypes)
+  for (const payload of getInspectablePayloads(req)) {
+    collectSensitiveTypes(payload, detectedTypes)
+  }
 
   if (detectedTypes.size === 0) {
     return next()

--- a/src/middleware/sensitiveContentGuard.js
+++ b/src/middleware/sensitiveContentGuard.js
@@ -1,0 +1,122 @@
+const logger = require('../utils/logger')
+
+const SENSITIVE_PATTERNS = [
+  {
+    type: 'ssh_private_key',
+    pattern: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/i
+  },
+  {
+    type: 'openai_api_key',
+    pattern: /\bsk-[A-Za-z0-9_-]{16,}\b/
+  },
+  {
+    type: 'anthropic_api_key',
+    pattern: /\bsk-ant-[A-Za-z0-9_-]{10,}\b/
+  },
+  {
+    type: 'aws_access_key',
+    pattern: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/
+  },
+  {
+    type: 'aws_secret_key',
+    pattern: /\b[A-Za-z0-9/+=]{40}\b/
+  }
+]
+
+const PROTECTED_PATH_PREFIXES = [
+  '/api',
+  '/claude',
+  '/antigravity/api',
+  '/gemini-cli/api',
+  '/gemini',
+  '/openai',
+  '/droid',
+  '/azure'
+]
+const EXCLUDED_PATH_PREFIXES = ['/admin', '/web', '/users', '/apistats']
+
+function normalizePath(value) {
+  if (!value) {
+    return '/'
+  }
+
+  const [path] = String(value).split('?')
+  const normalized = path.replace(/\/{2,}/g, '/')
+  if (normalized.length > 1 && normalized.endsWith('/')) {
+    return normalized.slice(0, -1)
+  }
+  return normalized || '/'
+}
+
+function shouldInspectRequest(req) {
+  const path = normalizePath(req.originalUrl || req.url || req.path)
+  const lowerPath = path.toLowerCase()
+
+  if (EXCLUDED_PATH_PREFIXES.some((prefix) => lowerPath.startsWith(prefix))) {
+    return false
+  }
+
+  return PROTECTED_PATH_PREFIXES.some((prefix) => lowerPath.startsWith(prefix))
+}
+
+function collectSensitiveTypes(value, collector, depth = 0) {
+  if (value === undefined || value === null || depth > 8) {
+    return
+  }
+
+  if (typeof value === 'string') {
+    const hasModelProviderKey =
+      SENSITIVE_PATTERNS.find((entry) => entry.type === 'openai_api_key').pattern.test(value) ||
+      SENSITIVE_PATTERNS.find((entry) => entry.type === 'anthropic_api_key').pattern.test(value)
+
+    for (const { type, pattern } of SENSITIVE_PATTERNS) {
+      if (type === 'aws_secret_key' && hasModelProviderKey) {
+        continue
+      }
+      if (pattern.test(value)) {
+        collector.add(type)
+      }
+    }
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectSensitiveTypes(item, collector, depth + 1))
+    return
+  }
+
+  if (typeof value === 'object') {
+    Object.values(value).forEach((item) => collectSensitiveTypes(item, collector, depth + 1))
+  }
+}
+
+function sensitiveContentGuard(req, res, next) {
+  if (!shouldInspectRequest(req) || req.body === undefined || req.body === null) {
+    return next()
+  }
+
+  const detectedTypes = new Set()
+  collectSensitiveTypes(req.body, detectedTypes)
+
+  if (detectedTypes.size === 0) {
+    return next()
+  }
+
+  const detectedTypeList = Array.from(detectedTypes).sort()
+  logger.security(
+    `🚫 Sensitive content blocked for ${req.originalUrl || req.url || '/'} apiKey=${
+      req.apiKey?.id || 'unknown'
+    } detectedTypes=${detectedTypeList.join(',')}`
+  )
+
+  return res.status(400).json({
+    error: {
+      message: 'Request contains sensitive credentials and was rejected',
+      type: 'sensitive_content_detected',
+      code: 'sensitive_content_detected',
+      detectedTypes: detectedTypeList
+    }
+  })
+}
+
+module.exports = sensitiveContentGuard

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -15,6 +15,7 @@ const ProxyHelper = require('../utils/proxyHelper')
 const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
 const { IncrementalSSEParser } = require('../utils/sseParser')
 const { getSafeMessage } = require('../utils/errorSanitizer')
+const { applyQuotaExceededCooldown } = require('../utils/quotaExceededHelper')
 
 // Codex CLI 系统提示词（非 Codex CLI 客户端请求时注入，统一端点也使用）
 const CODEX_CLI_INSTRUCTIONS =
@@ -448,13 +449,24 @@ const handleResponses = async (req, res) => {
         logger.error('⚠️ Failed to parse rate limit error:', e)
       }
 
-      // 标记账户为限流状态
-      await unifiedOpenAIScheduler.markAccountRateLimited(
+      const quotaCooldown = await applyQuotaExceededCooldown({
         accountId,
-        'openai',
+        accountType: 'openai',
+        statusCode: 429,
+        payload: errorData,
         sessionHash,
-        resetsInSeconds
-      )
+        clearSessionMapping: (hash) => unifiedOpenAIScheduler._deleteSessionMapping(hash)
+      })
+
+      if (!quotaCooldown.applied) {
+        // 标记账户为限流状态
+        await unifiedOpenAIScheduler.markAccountRateLimited(
+          accountId,
+          'openai',
+          sessionHash,
+          resetsInSeconds
+        )
+      }
 
       // 返回错误响应给客户端
       const errorResponse = errorData || {
@@ -530,12 +542,23 @@ const handleResponses = async (req, res) => {
       }
 
       try {
-        await unifiedOpenAIScheduler.markAccountUnauthorized(
+        const quotaCooldown = await applyQuotaExceededCooldown({
           accountId,
-          'openai',
+          accountType: 'openai',
+          statusCode: unauthorizedStatus,
+          payload: errorData,
           sessionHash,
-          reason
-        )
+          clearSessionMapping: (hash) => unifiedOpenAIScheduler._deleteSessionMapping(hash)
+        })
+
+        if (!quotaCooldown.applied) {
+          await unifiedOpenAIScheduler.markAccountUnauthorized(
+            accountId,
+            'openai',
+            sessionHash,
+            reason
+          )
+        }
       } catch (markError) {
         logger.error(
           `❌ Failed to mark OpenAI account unauthorized after ${unauthorizedStatus}:`,

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -17,6 +17,7 @@ const { createClaudeTestPayload } = require('../../utils/testPayloadHelper')
 const userMessageQueueService = require('../userMessageQueueService')
 const { isStreamWritable } = require('../../utils/streamHelper')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
+const { applyQuotaExceededCooldown } = require('../../utils/quotaExceededHelper')
 const metadataUserIdHelper = require('../../utils/metadataUserIdHelper')
 const {
   getHttpsAgentForStream,
@@ -195,9 +196,13 @@ class ClaudeRelayService {
   // Anthropic 对未开启 Extra Usage 的账户请求长上下文模型时返回此错误
   // 这不是真正的限流，不应标记账户为 rate limited
   _isExtraUsageRequired429(statusCode, body) {
-    if (statusCode !== 429) return false
+    if (statusCode !== 429) {
+      return false
+    }
     const message = this._extractErrorMessage(body)
-    if (!message) return false
+    if (!message) {
+      return false
+    }
     return message.toLowerCase().includes('extra usage')
   }
 
@@ -732,6 +737,23 @@ class ClaudeRelayService {
         // 检查是否为403状态码（禁止访问，非封禁类）
         // 注意：如果进行了重试，retryCount > 0；这里的 403 是重试后最终的结果
         else if (response.statusCode === 403) {
+          const quotaCooldown = await applyQuotaExceededCooldown({
+            accountId,
+            accountType,
+            statusCode: 403,
+            payload: response.body,
+            sessionHash,
+            clearSessionMapping: (hash) => unifiedClaudeScheduler.clearSessionMapping(hash)
+          })
+          if (quotaCooldown.applied) {
+            return {
+              statusCode: response.statusCode,
+              headers: response.headers,
+              body: response.body,
+              dedicatedRateLimitMessage
+            }
+          }
+
           logger.error(
             `🚫 Forbidden error (403) detected for account ${accountId}${retryCount > 0 ? ` after ${retryCount} retries` : ''}, temporarily pausing`
           )
@@ -851,14 +873,24 @@ class ClaudeRelayService {
             sessionHash,
             rateLimitResetTimestamp
           )
-          await upstreamErrorHelper
-            .markTempUnavailable(
-              accountId,
-              accountType,
-              429,
-              upstreamErrorHelper.parseRetryAfter(response.headers)
-            )
-            .catch(() => {})
+          const quotaCooldown = await applyQuotaExceededCooldown({
+            accountId,
+            accountType,
+            statusCode: 429,
+            payload: response.body,
+            sessionHash,
+            clearSessionMapping: (hash) => unifiedClaudeScheduler.clearSessionMapping(hash)
+          })
+          if (!quotaCooldown.applied) {
+            await upstreamErrorHelper
+              .markTempUnavailable(
+                accountId,
+                accountType,
+                429,
+                upstreamErrorHelper.parseRetryAfter(response.headers)
+              )
+              .catch(() => {})
+          }
 
           if (dedicatedRateLimitMessage) {
             return {
@@ -2160,14 +2192,24 @@ class ClaudeRelayService {
                 sessionHash,
                 rateLimitResetTimestamp
               )
-              await upstreamErrorHelper
-                .markTempUnavailable(
-                  accountId,
-                  accountType,
-                  429,
-                  upstreamErrorHelper.parseRetryAfter(res.headers)
-                )
-                .catch(() => {})
+              const quotaCooldown = await applyQuotaExceededCooldown({
+                accountId,
+                accountType,
+                statusCode: 429,
+                payload: errorBody429,
+                sessionHash,
+                clearSessionMapping: (hash) => unifiedClaudeScheduler.clearSessionMapping(hash)
+              })
+              if (!quotaCooldown.applied) {
+                await upstreamErrorHelper
+                  .markTempUnavailable(
+                    accountId,
+                    accountType,
+                    429,
+                    upstreamErrorHelper.parseRetryAfter(res.headers)
+                  )
+                  .catch(() => {})
+              }
               logger.warn(`🚫 [Stream] Rate limit detected for account ${accountId}, status 429`)
 
               if (isDedicatedOfficialAccount) {
@@ -2315,6 +2357,18 @@ class ClaudeRelayService {
                 await unifiedClaudeScheduler.clearSessionMapping(sessionHash).catch(() => {})
               }
             } else if (res.statusCode === 403) {
+              const quotaCooldown = await applyQuotaExceededCooldown({
+                accountId,
+                accountType,
+                statusCode: 403,
+                payload: errorData,
+                sessionHash,
+                clearSessionMapping: (hash) => unifiedClaudeScheduler.clearSessionMapping(hash)
+              })
+              if (quotaCooldown.applied) {
+                return
+              }
+
               // 403 处理：先检查是否为封禁性质的 403（组织被禁用/OAuth 被禁止）
               // 注意：重试逻辑已在 handleErrorResponse 外部提前处理
               if (this._isOrganizationDisabledError(res.statusCode, errorData)) {
@@ -2500,6 +2554,7 @@ class ClaudeRelayService {
         const allUsageData = [] // 收集所有的usage事件
         let currentUsageData = {} // 当前正在收集的usage数据
         let rateLimitDetected = false // 限流检测标志
+        let streamErrorPayload = null
 
         // 监听数据块，解析SSE并寻找usage信息
         // 🧹 内存优化：在闭包创建前提取需要的值，避免闭包捕获 body 和 requestOptions
@@ -2649,6 +2704,7 @@ class ClaudeRelayService {
                     data.error.message.toLowerCase().includes("exceed your account's rate limit")
                   ) {
                     rateLimitDetected = true
+                    streamErrorPayload = data
                     logger.warn(`🚫 Rate limit detected in stream for account ${accountId}`)
                   }
                 } catch (parseError) {
@@ -2824,14 +2880,24 @@ class ClaudeRelayService {
                 sessionHash,
                 rateLimitResetTimestamp
               )
-              await upstreamErrorHelper
-                .markTempUnavailable(
-                  accountId,
-                  accountType,
-                  429,
-                  upstreamErrorHelper.parseRetryAfter(res.headers)
-                )
-                .catch(() => {})
+              const quotaCooldown = await applyQuotaExceededCooldown({
+                accountId,
+                accountType,
+                statusCode: 429,
+                payload: streamErrorPayload,
+                sessionHash,
+                clearSessionMapping: (hash) => unifiedClaudeScheduler.clearSessionMapping(hash)
+              })
+              if (!quotaCooldown.applied) {
+                await upstreamErrorHelper
+                  .markTempUnavailable(
+                    accountId,
+                    accountType,
+                    429,
+                    upstreamErrorHelper.parseRetryAfter(res.headers)
+                  )
+                  .catch(() => {})
+              }
             }
           } else if (res.statusCode === 200) {
             // 请求成功，清除401和500错误计数

--- a/src/services/relay/openaiResponsesRelayService.js
+++ b/src/services/relay/openaiResponsesRelayService.js
@@ -9,6 +9,7 @@ const config = require('../../../config/config')
 const crypto = require('crypto')
 const LRUCache = require('../../utils/lruCache')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
+const { applyQuotaExceededCooldown } = require('../../utils/quotaExceededHelper')
 
 // lastUsedAt 更新节流（每账户 60 秒内最多更新一次，使用 LRU 防止内存泄漏）
 const lastUsedAtThrottle = new LRUCache(1000) // 最多缓存 1000 个账户
@@ -176,7 +177,7 @@ class OpenAIResponsesRelayService {
 
       // 处理 429 限流错误
       if (response.status === 429) {
-        const { resetsInSeconds, errorData } = await this._handle429Error(
+        const { resetsInSeconds, errorData, quotaCooldownApplied } = await this._handle429Error(
           account,
           response,
           req.body?.stream,
@@ -185,7 +186,7 @@ class OpenAIResponsesRelayService {
 
         const oaiAutoProtectionDisabled =
           account?.disableAutoProtection === true || account?.disableAutoProtection === 'true'
-        if (!oaiAutoProtectionDisabled) {
+        if (!oaiAutoProtectionDisabled && !quotaCooldownApplied) {
           await upstreamErrorHelper
             .markTempUnavailable(
               account.id,
@@ -253,13 +254,24 @@ class OpenAIResponsesRelayService {
           errorData
         })
 
+        const oaiAutoProtectionDisabled =
+          account?.disableAutoProtection === true || account?.disableAutoProtection === 'true'
+        const quotaCooldown = oaiAutoProtectionDisabled
+          ? { applied: false }
+          : await applyQuotaExceededCooldown({
+              accountId: account?.id,
+              accountType: 'openai-responses',
+              statusCode: response.status,
+              payload: errorData,
+              sessionHash,
+              clearSessionMapping: (hash) => unifiedOpenAIScheduler._deleteSessionMapping(hash)
+            })
+
         if (response.status === 401) {
           logger.warn(`🚫 OpenAI Responses账号认证失败（401错误）for account ${account?.id}`)
 
           try {
             // 仅临时暂停，不永久禁用
-            const oaiAutoProtectionDisabled =
-              account?.disableAutoProtection === true || account?.disableAutoProtection === 'true'
             if (!oaiAutoProtectionDisabled) {
               await upstreamErrorHelper
                 .markTempUnavailable(account.id, 'openai-responses', 401)
@@ -301,10 +313,8 @@ class OpenAIResponsesRelayService {
         }
 
         // 处理 5xx 上游错误
-        if (response.status >= 500 && account?.id) {
+        if (!quotaCooldown.applied && response.status >= 500 && account?.id) {
           try {
-            const oaiAutoProtectionDisabled =
-              account?.disableAutoProtection === true || account?.disableAutoProtection === 'true'
             if (!oaiAutoProtectionDisabled) {
               await upstreamErrorHelper.markTempUnavailable(
                 account.id,
@@ -349,7 +359,7 @@ class OpenAIResponsesRelayService {
       }
 
       // 处理非流式响应
-      return this._handleNormalResponse(response, res, account, apiKeyData, req.body?.model)
+      return this._handleNormalResponse(response, res, account, apiKeyData, req.body?.model, req)
     } catch (error) {
       // 清理 AbortController
       if (abortController && !abortController.signal.aborted) {
@@ -709,7 +719,7 @@ class OpenAIResponsesRelayService {
   }
 
   // 处理非流式响应
-  async _handleNormalResponse(response, res, account, apiKeyData, requestedModel) {
+  async _handleNormalResponse(response, res, account, apiKeyData, requestedModel, req = null) {
     const responseData = response.data
 
     // 提取 usage 数据和实际 model
@@ -790,6 +800,7 @@ class OpenAIResponsesRelayService {
   async _handle429Error(account, response, isStream = false, sessionHash = null) {
     let resetsInSeconds = null
     let errorData = null
+    let quotaCooldownApplied = false
 
     try {
       // 对于429错误，响应可能是JSON或SSE格式
@@ -869,13 +880,28 @@ class OpenAIResponsesRelayService {
       logger.error('⚠️ Failed to parse rate limit error:', e)
     }
 
-    // 使用统一调度器标记账户为限流状态（与普通OpenAI账号保持一致）
-    await unifiedOpenAIScheduler.markAccountRateLimited(
-      account.id,
-      'openai-responses',
-      sessionHash,
-      resetsInSeconds
+    quotaCooldownApplied = Boolean(
+      (
+        await applyQuotaExceededCooldown({
+          accountId: account.id,
+          accountType: 'openai-responses',
+          statusCode: 429,
+          payload: errorData,
+          sessionHash,
+          clearSessionMapping: (hash) => unifiedOpenAIScheduler._deleteSessionMapping(hash)
+        })
+      ).applied
     )
+
+    if (!quotaCooldownApplied) {
+      // 使用统一调度器标记账户为限流状态（与普通OpenAI账号保持一致）
+      await unifiedOpenAIScheduler.markAccountRateLimited(
+        account.id,
+        'openai-responses',
+        sessionHash,
+        resetsInSeconds
+      )
+    }
 
     logger.warn('OpenAI-Responses account rate limited', {
       accountId: account.id,
@@ -886,7 +912,7 @@ class OpenAIResponsesRelayService {
     })
 
     // 返回处理后的数据，避免循环引用
-    return { resetsInSeconds, errorData }
+    return { resetsInSeconds, errorData, quotaCooldownApplied }
   }
 
   // 过滤请求头 - 已迁移到 headerFilter 工具类

--- a/src/utils/quotaExceededHelper.js
+++ b/src/utils/quotaExceededHelper.js
@@ -21,7 +21,10 @@ const KEYWORD_MATCHERS = [
   'insufficient_quota',
   'quota_exceeded',
   'credit balance is too low',
-  'usage limit reached'
+  'usage limit reached',
+  '无可用套餐',
+  '不允许使用余额',
+  '余额不足'
 ]
 
 function tryParseJson(value) {

--- a/src/utils/quotaExceededHelper.js
+++ b/src/utils/quotaExceededHelper.js
@@ -1,0 +1,134 @@
+const upstreamErrorHelper = require('./upstreamErrorHelper')
+
+const DEFAULT_QUOTA_EXCEEDED_COOLDOWN_SECONDS = (() => {
+  const parsed = Number.parseInt(process.env.QUOTA_EXCEEDED_COOLDOWN_SECONDS, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 2 * 60 * 60
+})()
+
+const QUOTA_STATUS_CODES = new Set([402, 403, 429])
+const EXACT_MATCHERS = new Set([
+  'insufficient_quota',
+  'quota_exceeded',
+  'billing_hard_limit',
+  'billing_hard_limit_reached'
+])
+const KEYWORD_MATCHERS = [
+  'quota exceeded',
+  'exceeded your current quota',
+  'billing hard limit',
+  'billing_hard_limit',
+  'insufficient quota',
+  'insufficient_quota',
+  'quota_exceeded',
+  'credit balance is too low',
+  'usage limit reached'
+]
+
+function tryParseJson(value) {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) {
+    return value
+  }
+
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return value
+  }
+}
+
+function collectNormalizedTokens(value, collector, depth = 0) {
+  if (value === undefined || value === null || depth > 6) {
+    return
+  }
+
+  const normalizedValue = tryParseJson(value)
+  if (typeof normalizedValue === 'string') {
+    const trimmed = normalizedValue.trim().toLowerCase()
+    if (trimmed) {
+      collector.add(trimmed)
+    }
+    return
+  }
+
+  if (Array.isArray(normalizedValue)) {
+    normalizedValue.forEach((item) => collectNormalizedTokens(item, collector, depth + 1))
+    return
+  }
+
+  if (typeof normalizedValue === 'object') {
+    Object.entries(normalizedValue).forEach(([key, item]) => {
+      const lowerKey = String(key || '')
+        .trim()
+        .toLowerCase()
+      if (lowerKey) {
+        collector.add(lowerKey)
+      }
+      collectNormalizedTokens(item, collector, depth + 1)
+    })
+  }
+}
+
+function isQuotaExceededError(statusCode, payload) {
+  const collector = new Set()
+  collectNormalizedTokens(payload, collector)
+
+  for (const token of collector) {
+    if (EXACT_MATCHERS.has(token)) {
+      return true
+    }
+  }
+
+  const joined = Array.from(collector).join(' ')
+  const hasKeyword = KEYWORD_MATCHERS.some((keyword) => joined.includes(keyword))
+  if (!hasKeyword) {
+    return false
+  }
+
+  const normalizedStatus = Number(statusCode)
+  return statusCode === undefined || statusCode === null || QUOTA_STATUS_CODES.has(normalizedStatus)
+}
+
+async function applyQuotaExceededCooldown({
+  accountId,
+  accountType,
+  statusCode,
+  payload,
+  sessionHash = null,
+  clearSessionMapping = null
+}) {
+  if (!accountId || !accountType || !isQuotaExceededError(statusCode, payload)) {
+    return { applied: false, cooldownSeconds: null }
+  }
+
+  await upstreamErrorHelper.markTempUnavailable(
+    accountId,
+    accountType,
+    Number(statusCode) || 429,
+    DEFAULT_QUOTA_EXCEEDED_COOLDOWN_SECONDS,
+    {
+      reason: 'quota_exceeded',
+      errorTypeOverride: 'quota_exceeded',
+      errorBody: payload
+    }
+  )
+
+  if (sessionHash && typeof clearSessionMapping === 'function') {
+    await clearSessionMapping(sessionHash)
+  }
+
+  return {
+    applied: true,
+    cooldownSeconds: DEFAULT_QUOTA_EXCEEDED_COOLDOWN_SECONDS
+  }
+}
+
+module.exports = {
+  DEFAULT_QUOTA_EXCEEDED_COOLDOWN_SECONDS,
+  isQuotaExceededError,
+  applyQuotaExceededCooldown
+}

--- a/src/utils/upstreamErrorHelper.js
+++ b/src/utils/upstreamErrorHelper.js
@@ -13,7 +13,8 @@ const DEFAULT_TTL = {
   overload: 600, // 529: 10分钟
   auth_error: 1800, // 401/403: 30分钟
   timeout: 300, // 504/网络超时: 5分钟
-  rate_limit: 300 // 429: 5分钟（优先使用响应头解析值）
+  rate_limit: 300, // 429: 5分钟（优先使用响应头解析值）
+  quota_exceeded: 7200 // 配额耗尽: 2小时
 }
 
 // 延迟加载配置，避免循环依赖
@@ -45,7 +46,11 @@ const getTtlConfig = () => {
     overload: config.upstreamError?.overloadTtlSeconds ?? DEFAULT_TTL.overload,
     auth_error: config.upstreamError?.authErrorTtlSeconds ?? DEFAULT_TTL.auth_error,
     timeout: config.upstreamError?.timeoutTtlSeconds ?? DEFAULT_TTL.timeout,
-    rate_limit: DEFAULT_TTL.rate_limit
+    rate_limit: DEFAULT_TTL.rate_limit,
+    quota_exceeded:
+      config.upstreamError?.quotaExceededTtlSeconds ??
+      parseEnvPositiveInt('UPSTREAM_ERROR_QUOTA_EXCEEDED_TTL_SECONDS') ??
+      DEFAULT_TTL.quota_exceeded
   }
 }
 
@@ -293,7 +298,7 @@ const markTempUnavailable = async (
   context = null
 ) => {
   try {
-    const errorType = classifyError(statusCode)
+    const errorType = context?.errorTypeOverride || classifyError(statusCode)
     if (!errorType) {
       return { success: false, reason: 'not_a_pausable_error' }
     }

--- a/tests/quotaExceededHelper.test.js
+++ b/tests/quotaExceededHelper.test.js
@@ -29,6 +29,11 @@ describe('quotaExceededHelper', () => {
     expect(isQuotaExceededError(403, 'quota exceeded for this account')).toBe(true)
   })
 
+  it('detects balance-disabled and no-plan style chinese payloads', () => {
+    expect(isQuotaExceededError(403, 'API Key 不允许使用余额且无可用套餐')).toBe(true)
+    expect(isQuotaExceededError(403, '当前无可用套餐，且该 API Key 不允许使用余额')).toBe(true)
+  })
+
   it('applies a two-hour cooldown and clears sticky mapping when quota is exceeded', async () => {
     const clearSessionMapping = jest.fn().mockResolvedValue(undefined)
 

--- a/tests/quotaExceededHelper.test.js
+++ b/tests/quotaExceededHelper.test.js
@@ -1,0 +1,85 @@
+jest.mock('../src/utils/upstreamErrorHelper', () => ({
+  markTempUnavailable: jest.fn().mockResolvedValue({ success: true })
+}))
+
+const upstreamErrorHelper = require('../src/utils/upstreamErrorHelper')
+const {
+  isQuotaExceededError,
+  applyQuotaExceededCooldown,
+  DEFAULT_QUOTA_EXCEEDED_COOLDOWN_SECONDS
+} = require('../src/utils/quotaExceededHelper')
+
+describe('quotaExceededHelper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('detects OpenAI insufficient_quota payloads', () => {
+    expect(
+      isQuotaExceededError(429, {
+        error: {
+          code: 'insufficient_quota',
+          message: 'You exceeded your current quota, please check your plan and billing details.'
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('detects plain string quota exceeded payloads', () => {
+    expect(isQuotaExceededError(403, 'quota exceeded for this account')).toBe(true)
+  })
+
+  it('applies a two-hour cooldown and clears sticky mapping when quota is exceeded', async () => {
+    const clearSessionMapping = jest.fn().mockResolvedValue(undefined)
+
+    const result = await applyQuotaExceededCooldown({
+      accountId: 'acc_1',
+      accountType: 'openai',
+      statusCode: 429,
+      payload: {
+        error: {
+          type: 'insufficient_quota',
+          message: 'billing_hard_limit_reached'
+        }
+      },
+      sessionHash: 'session_hash',
+      clearSessionMapping
+    })
+
+    expect(result).toEqual({
+      applied: true,
+      cooldownSeconds: DEFAULT_QUOTA_EXCEEDED_COOLDOWN_SECONDS
+    })
+    expect(upstreamErrorHelper.markTempUnavailable).toHaveBeenCalledWith(
+      'acc_1',
+      'openai',
+      429,
+      DEFAULT_QUOTA_EXCEEDED_COOLDOWN_SECONDS,
+      expect.objectContaining({
+        reason: 'quota_exceeded'
+      })
+    )
+    expect(clearSessionMapping).toHaveBeenCalledWith('session_hash')
+  })
+
+  it('does not cool down accounts for unrelated errors', async () => {
+    const clearSessionMapping = jest.fn()
+
+    const result = await applyQuotaExceededCooldown({
+      accountId: 'acc_2',
+      accountType: 'openai',
+      statusCode: 429,
+      payload: {
+        error: {
+          message: 'Rate limit reached, retry later.'
+        }
+      },
+      sessionHash: 'session_hash',
+      clearSessionMapping
+    })
+
+    expect(result).toEqual({ applied: false, cooldownSeconds: null })
+    expect(upstreamErrorHelper.markTempUnavailable).not.toHaveBeenCalled()
+    expect(clearSessionMapping).not.toHaveBeenCalled()
+  })
+})

--- a/tests/sensitiveContentGuard.test.js
+++ b/tests/sensitiveContentGuard.test.js
@@ -101,6 +101,157 @@ describe('sensitiveContentGuard', () => {
     expect(logger.security).not.toHaveBeenCalled()
   })
 
+  it('allows Codex-style payloads containing benign 40-character identifiers', () => {
+    const req = {
+      body: {
+        model: 'gpt-5.4',
+        instructions: 'You are Codex, a coding agent based on GPT-5.',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: 'tracking id: ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcd'
+              }
+            ]
+          }
+        ]
+      },
+      apiKey: { id: 'key_codex' },
+      originalUrl: '/openai/v1/responses'
+    }
+    const res = createResponse()
+    const next = jest.fn()
+
+    sensitiveContentGuard(req, res, next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.status).not.toHaveBeenCalled()
+    expect(logger.security).not.toHaveBeenCalled()
+  })
+
+  it('rejects contextual AWS secret access keys', () => {
+    const req = {
+      body: {
+        aws_secret_access_key: 'abcdABCD1234+/abcdABCD1234+/abcdABCD1234'
+      },
+      apiKey: { id: 'key_aws' },
+      originalUrl: '/openai/v1/responses'
+    }
+    const res = createResponse()
+    const next = jest.fn()
+
+    sensitiveContentGuard(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        message: 'Request contains sensitive credentials and was rejected',
+        type: 'sensitive_content_detected',
+        code: 'sensitive_content_detected',
+        detectedTypes: ['aws_secret_key']
+      }
+    })
+  })
+
+  it('allows Codex payloads when only instructions, assistant history, or tools contain example secrets', () => {
+    const req = {
+      body: {
+        model: 'gpt-5.4',
+        instructions:
+          'Example values: sk-ant-example1234567890 and -----BEGIN OPENSSH PRIVATE KEY-----',
+        tools: [
+          {
+            type: 'function',
+            name: 'debug',
+            parameters: {
+              type: 'object',
+              properties: {
+                apiKeyExample: {
+                  type: 'string',
+                  description: 'Example OpenAI key sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN'
+                }
+              }
+            }
+          }
+        ],
+        input: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Historical example AWS secret: aws_secret_access_key=abcdABCD1234+/abcdABCD1234+/abcdABCD1234'
+              }
+            ]
+          },
+          {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Please help me inspect the build logs.' }]
+          }
+        ]
+      },
+      apiKey: { id: 'key_codex_history' },
+      originalUrl: '/openai/v1/responses'
+    }
+    const res = createResponse()
+    const next = jest.fn()
+
+    sensitiveContentGuard(req, res, next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.status).not.toHaveBeenCalled()
+    expect(logger.security).not.toHaveBeenCalled()
+  })
+
+  it('rejects Codex payloads when the user input contains a real secret', () => {
+    const req = {
+      body: {
+        model: 'gpt-5.4',
+        instructions: 'You are Codex, a coding agent based on GPT-5.',
+        input: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'I can help inspect this.' }]
+          },
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: 'Please use this key sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN'
+              }
+            ]
+          }
+        ]
+      },
+      apiKey: { id: 'key_codex_secret' },
+      originalUrl: '/openai/v1/responses'
+    }
+    const res = createResponse()
+    const next = jest.fn()
+
+    sensitiveContentGuard(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        message: 'Request contains sensitive credentials and was rejected',
+        type: 'sensitive_content_detected',
+        code: 'sensitive_content_detected',
+        detectedTypes: ['openai_api_key']
+      }
+    })
+  })
+
   it('skips admin routes so account management payloads are not blocked', () => {
     const req = {
       body: {

--- a/tests/sensitiveContentGuard.test.js
+++ b/tests/sensitiveContentGuard.test.js
@@ -1,0 +1,120 @@
+jest.mock('../src/utils/logger', () => ({
+  security: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn()
+}))
+
+const logger = require('../src/utils/logger')
+const sensitiveContentGuard = require('../src/middleware/sensitiveContentGuard')
+
+function createResponse() {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn()
+  }
+  res.status.mockReturnValue(res)
+  return res
+}
+
+describe('sensitiveContentGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('rejects requests containing nested OpenAI API keys', () => {
+    const req = {
+      body: {
+        messages: [
+          {
+            role: 'user',
+            content: 'use this key sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN'
+          }
+        ]
+      },
+      apiKey: { id: 'key_123' },
+      originalUrl: '/openai/v1/responses'
+    }
+    const res = createResponse()
+    const next = jest.fn()
+
+    sensitiveContentGuard(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        message: 'Request contains sensitive credentials and was rejected',
+        type: 'sensitive_content_detected',
+        code: 'sensitive_content_detected',
+        detectedTypes: ['openai_api_key']
+      }
+    })
+    expect(logger.security).toHaveBeenCalledWith(
+      expect.stringContaining('detectedTypes=openai_api_key')
+    )
+    expect(logger.security).not.toHaveBeenCalledWith(
+      expect.stringContaining('sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN')
+    )
+  })
+
+  it('rejects requests containing SSH private keys', () => {
+    const req = {
+      body: {
+        prompt: '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----'
+      },
+      apiKey: { id: 'key_456' },
+      originalUrl: '/api/v1/messages'
+    }
+    const res = createResponse()
+    const next = jest.fn()
+
+    sensitiveContentGuard(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        message: 'Request contains sensitive credentials and was rejected',
+        type: 'sensitive_content_detected',
+        code: 'sensitive_content_detected',
+        detectedTypes: ['ssh_private_key']
+      }
+    })
+  })
+
+  it('allows benign requests to continue', () => {
+    const req = {
+      body: {
+        messages: [{ role: 'user', content: 'hello world' }]
+      },
+      apiKey: { id: 'key_ok' },
+      originalUrl: '/api/v1/messages'
+    }
+    const res = createResponse()
+    const next = jest.fn()
+
+    sensitiveContentGuard(req, res, next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.status).not.toHaveBeenCalled()
+    expect(logger.security).not.toHaveBeenCalled()
+  })
+
+  it('skips admin routes so account management payloads are not blocked', () => {
+    const req = {
+      body: {
+        apiKey: 'sk-ant-admin-secret'
+      },
+      apiKey: { id: 'admin_key' },
+      originalUrl: '/admin/openai-accounts'
+    }
+    const res = createResponse()
+    const next = jest.fn()
+
+    sensitiveContentGuard(req, res, next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.status).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- block relay-bound requests that contain sensitive credentials such as SSH private keys and provider API keys
- add a shared quota-exceeded cooldown helper that parks affected upstream accounts for 2 hours and clears sticky sessions
- wire the cooldown handling into OpenAI, OpenAI Responses, Gemini, and Claude upstream error paths with regression tests

## Verification
- npm test
- npm run lint:check