### PR TITLE
fix: resolve cost calculation and statistics pipeline bugs

### DIFF
--- a/src/models/redis.js
+++ b/src/models/redis.js
@@ -1365,7 +1365,8 @@ class RedisClient {
     ephemeral5mTokens = 0,
     ephemeral1hTokens = 0,
     model = 'unknown',
-    isLongContextRequest = false
+    isLongContextRequest = false,
+    preComputedCost = 0
   ) {
     const now = new Date()
     const today = getDateStringInTimezone(now)
@@ -1505,8 +1506,20 @@ class RedisClient {
       this.client.hincrby(accountModelHourly, 'ephemeral5mTokens', finalEphemeral5mTokens),
       this.client.hincrby(accountModelHourly, 'ephemeral1hTokens', finalEphemeral1hTokens),
       this.client.hincrby(accountModelHourly, 'allTokens', actualTotalTokens),
-      this.client.hincrby(accountModelHourly, 'requests', 1),
+      this.client.hincrby(accountModelHourly, 'requests', 1)
+    ]
 
+    // 累加预计算的费用（原子操作，避免重算导致的偏差）
+    // 始终写入（包括 0），确保 key 存在以表明预计算路径已启用
+    if (preComputedCost >= 0) {
+      const accountDailyCostKey = `account_usage:cost:daily:${accountId}:${today}`
+      operations.push(
+        this.client.incrbyfloat(accountDailyCostKey, preComputedCost),
+        this.client.expire(accountDailyCostKey, 86400 * 32)
+      )
+    }
+
+    operations.push(
       // 设置过期时间
       this.client.expire(accountDaily, 86400 * 32), // 32天过期
       this.client.expire(accountMonthly, 86400 * 365), // 1年过期
@@ -1536,7 +1549,7 @@ class RedisClient {
       this.client.del(`account_usage:model:hourly:index:${currentHour}:empty`),
       this.client.del(`account_usage:daily:index:${today}:empty`),
       this.client.del(`account_usage:model:daily:index:${today}:empty`)
-    ]
+    )
 
     // 如果是 1M 上下文请求，添加额外的统计
     if (isLongContextRequest) {
@@ -1799,9 +1812,10 @@ class RedisClient {
 
   // 💰 获取当日费用
   async getDailyCost(keyId) {
+    const client = this.getClientSafe()
     const today = getDateStringInTimezone()
     const costKey = `usage:cost:daily:${keyId}:${today}`
-    const cost = await this.client.get(costKey)
+    const cost = await client.get(costKey)
     const result = parseFloat(cost || 0)
     logger.debug(
       `💰 Getting daily cost for ${keyId}, date: ${today}, key: ${costKey}, value: ${cost}, result: ${result}`
@@ -1937,6 +1951,17 @@ class RedisClient {
     const CostCalculator = require('../utils/costCalculator')
     const today = getDateStringInTimezone()
 
+    // 优先使用预计算的费用（原子累加，包含 Fast Mode 等运行时信息）
+    // key 存在即表明预计算路径已启用，信任其值（含 0）
+    const preComputedCostKey = `account_usage:cost:daily:${accountId}:${today}`
+    const preComputedCost = await this.client.get(preComputedCostKey)
+    if (preComputedCost !== null) {
+      const cost = parseFloat(preComputedCost)
+      logger.debug(`💰 Account ${accountId} daily cost (pre-computed): $${cost}`)
+      return cost
+    }
+
+    // 回退：从 token 数据重新计算（兼容历史数据）
     // 使用索引集合替代 KEYS 命令
     const indexKey = `account_usage:model:daily:index:${today}`
     const allEntries = await this.client.smembers(indexKey)
@@ -2002,13 +2027,40 @@ class RedisClient {
 
     const CostCalculator = require('../utils/costCalculator')
     const today = getDateStringInTimezone()
+    const costMap = new Map(accountIds.map((id) => [id, 0]))
 
+    // 优先批量读取预计算的费用
+    const preComputedPipeline = this.client.pipeline()
+    for (const accountId of accountIds) {
+      preComputedPipeline.get(`account_usage:cost:daily:${accountId}:${today}`)
+    }
+    const preComputedResults = await preComputedPipeline.exec()
+
+    const missingAccountIds = []
+    for (let i = 0; i < accountIds.length; i++) {
+      const [err, value] = preComputedResults[i]
+      if (!err && value !== null) {
+        const cost = parseFloat(value)
+        if (cost > 0) {
+          costMap.set(accountIds[i], cost)
+          continue
+        }
+      }
+      missingAccountIds.push(accountIds[i])
+    }
+
+    // 所有账户都有预计算值，直接返回
+    if (missingAccountIds.length === 0) {
+      return costMap
+    }
+
+    // 回退：从 token 数据重新计算（兼容历史数据）
     // 一次获取索引
     const indexKey = `account_usage:model:daily:index:${today}`
     const allEntries = await this.client.smembers(indexKey)
 
-    // 按 accountId 分组
-    const accountIdSet = new Set(accountIds)
+    // 按 accountId 分组（只处理缺失的账户）
+    const missingSet = new Set(missingAccountIds)
     const entriesByAccount = new Map()
     for (const entry of allEntries) {
       const colonIndex = entry.indexOf(':')
@@ -2017,7 +2069,7 @@ class RedisClient {
       }
       const accountId = entry.substring(0, colonIndex)
       const model = entry.substring(colonIndex + 1)
-      if (accountIdSet.has(accountId)) {
+      if (missingSet.has(accountId)) {
         if (!entriesByAccount.has(accountId)) {
           entriesByAccount.set(accountId, [])
         }
@@ -2025,12 +2077,10 @@ class RedisClient {
       }
     }
 
-    const costMap = new Map(accountIds.map((id) => [id, 0]))
-
     // 如果索引为空，回退到 KEYS 命令（兼容旧数据）
     if (allEntries.length === 0) {
       logger.debug('💰 Daily cost index empty, falling back to KEYS for batch cost calculation')
-      for (const accountId of accountIds) {
+      for (const accountId of missingAccountIds) {
         try {
           const cost = await this.getAccountDailyCostFallback(accountId, today, CostCalculator)
           costMap.set(accountId, cost)
@@ -2110,8 +2160,11 @@ class RedisClient {
         continue
       }
 
-      const parts = key.split(':')
-      const model = parts[4]
+      // Key format: account_usage:model:daily:{accountId}:{model}:{today}
+      // Model name may contain ':', so extract between accountId and date
+      const prefix = `account_usage:model:daily:${accountId}:`
+      const suffix = `:${today}`
+      const model = key.slice(prefix.length, key.length - suffix.length)
 
       if (modelUsage.inputTokens || modelUsage.outputTokens) {
         const usage = {

--- a/src/routes/admin/apiKeys.js
+++ b/src/routes/admin/apiKeys.js
@@ -1064,6 +1064,7 @@ router.post('/api-keys/batch-stats', authenticateAdmin, async (req, res) => {
  */
 async function calculateKeyStats(keyId, timeRange, startDate, endDate) {
   const client = redis.getClientSafe()
+  const now = new Date()
   const tzDate = redis.getDateInTimezone()
   const today = redis.getDateStringInTimezone()
 
@@ -1071,20 +1072,23 @@ async function calculateKeyStats(keyId, timeRange, startDate, endDate) {
   const searchPatterns = []
 
   if (timeRange === 'custom' && startDate && endDate) {
-    // 自定义日期范围
-    const start = new Date(startDate)
-    const end = new Date(endDate)
-    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-      const dateStr = redis.getDateStringInTimezone(d)
+    // 自定义日期范围：startDate/endDate 是用户输入的本地日期字符串（YYYY-MM-DD）
+    // 直接按天枚举，避免 new Date(dateStr) 被解析为 UTC 导致时区偏移
+    const [sy, sm, sd] = startDate.split('-').map(Number)
+    const [ey, em, ed] = endDate.split('-').map(Number)
+    const startTs = Date.UTC(sy, sm - 1, sd)
+    const endTs = Date.UTC(ey, em - 1, ed)
+    for (let ts = startTs; ts <= endTs; ts += 86400000) {
+      const d = new Date(ts)
+      const dateStr = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`
       searchPatterns.push(`usage:${keyId}:model:daily:*:${dateStr}`)
     }
   } else if (timeRange === 'today') {
     searchPatterns.push(`usage:${keyId}:model:daily:*:${today}`)
   } else if (timeRange === '7days') {
-    // 最近7天
+    // 最近7天：从真实当前时间往前推，让 getDateStringInTimezone 处理时区转换
     for (let i = 0; i < 7; i++) {
-      const d = new Date(tzDate)
-      d.setDate(d.getDate() - i)
+      const d = new Date(now.getTime() - i * 86400000)
       const dateStr = redis.getDateStringInTimezone(d)
       searchPatterns.push(`usage:${keyId}:model:daily:*:${dateStr}`)
     }

--- a/src/routes/admin/apiKeys.js
+++ b/src/routes/admin/apiKeys.js
@@ -1163,14 +1163,14 @@ async function calculateKeyStats(keyId, timeRange, startDate, endDate) {
       // 获取窗口开始时间和计算剩余时间
       const windowStart = await client.get(windowStartKey)
       if (windowStart) {
-        const now = Date.now()
+        const nowMs = Date.now()
         windowStartTime = parseInt(windowStart)
         const windowDuration = rateLimitWindow * 60 * 1000 // 转换为毫秒
         windowEndTime = windowStartTime + windowDuration
 
         // 如果窗口还有效
-        if (now < windowEndTime) {
-          windowRemainingSeconds = Math.max(0, Math.floor((windowEndTime - now) / 1000))
+        if (nowMs < windowEndTime) {
+          windowRemainingSeconds = Math.max(0, Math.floor((windowEndTime - nowMs) / 1000))
         } else {
           // 窗口已过期
           windowRemainingSeconds = 0

--- a/src/routes/apiStats.js
+++ b/src/routes/apiStats.js
@@ -811,7 +811,7 @@ router.post('/api/batch-model-stats', async (req, res) => {
     const _client = redis.getClientSafe()
     const tzDate = redis.getDateInTimezone()
     const today = redis.getDateStringInTimezone()
-    const currentMonth = `${tzDate.getFullYear()}-${String(tzDate.getMonth() + 1).padStart(2, '0')}`
+    const currentMonth = `${tzDate.getUTCFullYear()}-${String(tzDate.getUTCMonth() + 1).padStart(2, '0')}`
 
     const modelUsageMap = new Map()
 
@@ -1399,7 +1399,7 @@ router.post('/api/user-model-stats', async (req, res) => {
     // 使用与管理页面相同的时区处理逻辑
     const tzDate = redis.getDateInTimezone()
     const today = redis.getDateStringInTimezone()
-    const currentMonth = `${tzDate.getFullYear()}-${String(tzDate.getMonth() + 1).padStart(2, '0')}`
+    const currentMonth = `${tzDate.getUTCFullYear()}-${String(tzDate.getUTCMonth() + 1).padStart(2, '0')}`
 
     let pattern
     let matchRegex

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -1578,8 +1578,8 @@ class ApiKeyService {
         cacheCreateTokens,
         cacheReadTokens,
         model,
-        0, // ephemeral5mTokens - 暂时为0，后续处理
-        0, // ephemeral1hTokens - 暂时为0，后续处理
+        cacheCreateTokens, // ephemeral5mTokens - 旧路径无详细拆分，全部归为5m
+        0, // ephemeral1hTokens
         isLongContextRequest,
         realCost,
         ratedCost
@@ -1623,10 +1623,11 @@ class ApiKeyService {
             outputTokens,
             cacheCreateTokens,
             cacheReadTokens,
-            0, // ephemeral5mTokens - recordUsage 不含详细缓存数据
-            0, // ephemeral1hTokens - recordUsage 不含详细缓存数据
+            cacheCreateTokens, // ephemeral5mTokens - 旧路径无详细拆分，全部归为5m
+            0, // ephemeral1hTokens
             model,
-            isLongContextRequest
+            isLongContextRequest,
+            realCost
           )
           logger.database(
             `📊 Recorded account usage: ${accountId} - ${totalTokens} tokens (API Key: ${keyId})`
@@ -1871,7 +1872,8 @@ class ApiKeyService {
             ephemeral5mTokens,
             ephemeral1hTokens,
             model,
-            costInfo.isLongContextRequest || false
+            costInfo.isLongContextRequest || false,
+            realCostWithDetails
           )
           logger.database(
             `📊 Recorded account usage: ${accountId} - ${totalTokens} tokens (API Key: ${keyId})`

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -1447,8 +1447,9 @@ class ApiKeyService {
       }
 
       // 删除所有相关的使用统计数据
-      const today = new Date().toISOString().split('T')[0]
-      const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0]
+      const today = redis.getDateStringInTimezone()
+      const yesterdayDate = new Date(Date.now() - 86400000)
+      const yesterday = redis.getDateStringInTimezone(yesterdayDate)
 
       // 删除每日统计
       await redis.client.del(`usage:daily:${today}:${keyId}`)

--- a/src/services/pricingService.js
+++ b/src/services/pricingService.js
@@ -388,9 +388,14 @@ class PricingService {
     // 尝试模糊匹配（处理版本号等变化）
     const normalizedModel = modelName.toLowerCase().replace(/[_-]/g, '')
 
+    // 避免过短的模型名产生误匹配（如 "o1" 匹配到含 "o1" 的任意模型）
+    const MIN_FUZZY_LENGTH = 8
     for (const [key, value] of Object.entries(this.pricingData)) {
       const normalizedKey = key.toLowerCase().replace(/[_-]/g, '')
-      if (normalizedKey.includes(normalizedModel) || normalizedModel.includes(normalizedKey)) {
+      if (
+        (normalizedModel.length >= MIN_FUZZY_LENGTH && normalizedKey.includes(normalizedModel)) ||
+        (normalizedKey.length >= MIN_FUZZY_LENGTH && normalizedModel.includes(normalizedKey))
+      ) {
         logger.debug(`💰 Found pricing for ${modelName} using fuzzy match: ${key}`)
         return value
       }
@@ -419,14 +424,16 @@ class PricingService {
       return pricing
     }
 
+    // 返回副本以避免污染共享的 pricingData
+    const result = { ...pricing }
     // 如果缺少缓存价格，根据输入价格计算（缓存创建价格通常是输入价格的1.25倍，缓存读取是0.1倍）
-    if (!pricing.cache_creation_input_token_cost && pricing.input_cost_per_token) {
-      pricing.cache_creation_input_token_cost = pricing.input_cost_per_token * 1.25
+    if (!result.cache_creation_input_token_cost && result.input_cost_per_token) {
+      result.cache_creation_input_token_cost = result.input_cost_per_token * 1.25
     }
-    if (!pricing.cache_read_input_token_cost && pricing.input_cost_per_token) {
-      pricing.cache_read_input_token_cost = pricing.input_cost_per_token * 0.1
+    if (!result.cache_read_input_token_cost && result.input_cost_per_token) {
+      result.cache_read_input_token_cost = result.input_cost_per_token * 0.1
     }
-    return pricing
+    return result
   }
 
   // 从 usage 对象中提取 beta 特性列表（小写）
@@ -524,7 +531,7 @@ class PricingService {
       responseSpeed === this.claudeFeatureFlags.fastModeSpeed ||
       requestSpeed === this.claudeFeatureFlags.fastModeSpeed
     const isFastModeRequest = hasFastModeBeta && hasFastSpeedSignal
-    const standardPricing = this.getModelPricing(modelName)
+    const standardPricing = this.getModelPricing(normalizedModelName)
     const pricing = standardPricing
     const isLongContextModeEnabled = isLongContextModel || hasContext1mBeta
     const ignores200kLongContextPricing =

--- a/src/services/relay/droidRelayService.js
+++ b/src/services/relay/droidRelayService.js
@@ -1310,17 +1310,39 @@ class DroidRelayService {
           'droid'
         )
       } else if (accountId) {
+        const CostCalculator = require('../../utils/costCalculator')
+        const costResult = CostCalculator.calculateCost(usageObject, model)
+        const droidCost = costResult?.costs?.total || 0
+
+        // 提取详细的缓存创建数据
+        let eph5m = usageObject.cache_creation_input_tokens || 0
+        let eph1h = 0
+        if (usageObject.cache_creation && typeof usageObject.cache_creation === 'object') {
+          eph5m = usageObject.cache_creation.ephemeral_5m_input_tokens || 0
+          eph1h = usageObject.cache_creation.ephemeral_1h_input_tokens || 0
+        }
+
+        // 检测长上下文请求
+        const inputTokens = usageObject.input_tokens || 0
+        const cacheCreateTokens = usageObject.cache_creation_input_tokens || 0
+        const cacheReadTokens = usageObject.cache_read_input_tokens || 0
+        const isLongCtx =
+          model &&
+          model.includes('[1m]') &&
+          inputTokens + cacheCreateTokens + cacheReadTokens > 200000
+
         await redis.incrementAccountUsage(
           accountId,
           totalTokens,
-          usageObject.input_tokens || 0,
+          inputTokens,
           usageObject.output_tokens || 0,
-          usageObject.cache_creation_input_tokens || 0,
-          usageObject.cache_read_input_tokens || 0,
-          0, // ephemeral5mTokens - Droid 不含详细缓存数据
-          0, // ephemeral1hTokens - Droid 不含详细缓存数据
+          cacheCreateTokens,
+          cacheReadTokens,
+          eph5m,
+          eph1h,
           model,
-          false
+          isLongCtx,
+          droidCost
         )
       } else {
         logger.warn('⚠️ 无法记录 Droid usage：缺少 API Key 和账户标识')

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -1039,12 +1039,8 @@ class UnifiedClaudeScheduler {
         if (!account || !account.isActive) {
           return false
         }
-        // 检查账户状态
-        if (
-          account.status !== 'active' &&
-          account.status !== 'unauthorized' &&
-          account.status !== 'overloaded'
-        ) {
+        // 检查账户状态（unauthorized 在后续单独检查）
+        if (account.status !== 'active' && account.status !== 'overloaded') {
           return false
         }
         // 检查是否可调度
@@ -1090,10 +1086,6 @@ class UnifiedClaudeScheduler {
         if (await claudeConsoleAccountService.isAccountQuotaExceeded(accountId)) {
           return false
         }
-        // 检查是否未授权（401错误）
-        if (account.status === 'unauthorized') {
-          return false
-        }
         // 检查是否过载（529错误）
         if (await claudeConsoleAccountService.isAccountOverloaded(accountId)) {
           return false
@@ -1133,12 +1125,8 @@ class UnifiedClaudeScheduler {
         if (!account || !account.isActive) {
           return false
         }
-        // 检查账户状态
-        if (
-          account.status !== 'active' &&
-          account.status !== 'unauthorized' &&
-          account.status !== 'overloaded'
-        ) {
+        // 检查账户状态（unauthorized 在后续单独检查）
+        if (account.status !== 'active' && account.status !== 'overloaded') {
           return false
         }
         // 检查是否可调度
@@ -1175,10 +1163,6 @@ class UnifiedClaudeScheduler {
           return false
         }
         if (await ccrAccountService.isAccountQuotaExceeded(accountId)) {
-          return false
-        }
-        // 检查是否未授权（401错误）
-        if (account.status === 'unauthorized') {
           return false
         }
         // 检查是否过载（529错误）

--- a/src/utils/costCalculator.js
+++ b/src/utils/costCalculator.js
@@ -83,20 +83,25 @@ class CostCalculator {
    * @returns {Object} 费用详情
    */
   static calculateCost(usage, model = 'unknown', serviceTier = null) {
+    // 确保 model 是字符串
+    if (!model || typeof model !== 'string') {
+      model = 'unknown'
+    }
     // 如果 usage 包含详细的 cache_creation 对象或是 1M 模型，使用 pricingService 来处理
     if (
       (usage.cache_creation && typeof usage.cache_creation === 'object') ||
-      (model && model.includes('[1m]'))
+      model.includes('[1m]')
     ) {
       const result = pricingService.calculateCost(usage, model)
       // 转换 pricingService 返回的格式到 costCalculator 的格式
+      const resultPricing = result.pricing || {}
       return {
         model,
         pricing: {
-          input: result.pricing.input * 1000000, // 转换为 per 1M tokens
-          output: result.pricing.output * 1000000,
-          cacheWrite: result.pricing.cacheCreate * 1000000,
-          cacheRead: result.pricing.cacheRead * 1000000
+          input: (resultPricing.input || 0) * 1000000, // 转换为 per 1M tokens
+          output: (resultPricing.output || 0) * 1000000,
+          cacheWrite: (resultPricing.cacheCreate || 0) * 1000000,
+          cacheRead: (resultPricing.cacheRead || 0) * 1000000
         },
         usingDynamicPricing: true,
         isLongContextRequest: result.isLongContextRequest || false,
@@ -127,10 +132,10 @@ class CostCalculator {
         },
         debug: {
           isOpenAIModel: model.includes('gpt') || model.includes('o1'),
-          hasCacheCreatePrice: !!result.pricing.cacheCreate,
+          hasCacheCreatePrice: !!resultPricing.cacheCreate,
           cacheCreateTokens: usage.cache_creation_input_tokens || 0,
-          cacheWritePriceUsed: result.pricing.cacheCreate * 1000000,
-          isLongContextModel: model && model.includes('[1m]'),
+          cacheWritePriceUsed: (resultPricing.cacheCreate || 0) * 1000000,
+          isLongContextModel: model.includes('[1m]'),
           isLongContextRequest: result.isLongContextRequest || false
         }
       }
@@ -142,8 +147,9 @@ class CostCalculator {
     const cacheCreateTokens = usage.cache_creation_input_tokens || 0
     const cacheReadTokens = usage.cache_read_input_tokens || 0
 
-    // 优先使用动态价格服务
-    const pricingData = pricingService.getModelPricing(model)
+    // 优先使用动态价格服务（去掉 [1m] 后缀以匹配定价表）
+    const lookupModel = model ? model.replace(/\[1m\]/gi, '').trim() : model
+    const pricingData = pricingService.getModelPricing(lookupModel)
     let pricing
     let usingDynamicPricing = false
 
@@ -188,7 +194,7 @@ class CostCalculator {
       usingDynamicPricing = true
     } else {
       // 回退到静态价格
-      pricing = MODEL_PRICING[model] || MODEL_PRICING['unknown']
+      pricing = MODEL_PRICING[lookupModel] || MODEL_PRICING[model] || MODEL_PRICING['unknown']
     }
 
     // 计算各类型token的费用 (USD)

--- a/web/admin-spa/src/stores/dashboard.js
+++ b/web/admin-spa/src/stores/dashboard.js
@@ -529,8 +529,14 @@ export const useDashboardStore = defineStore('dashboard', () => {
       return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
     }
 
-    dateFilter.value.customStart = startDate ? startDate.toISOString().split('T')[0] : ''
-    dateFilter.value.customEnd = endDate ? endDate.toISOString().split('T')[0] : ''
+    const formatLocalDate = (d) =>
+      d.getFullYear() +
+      '-' +
+      String(d.getMonth() + 1).padStart(2, '0') +
+      '-' +
+      String(d.getDate()).padStart(2, '0')
+    dateFilter.value.customStart = startDate ? formatLocalDate(startDate) : ''
+    dateFilter.value.customEnd = endDate ? formatLocalDate(endDate) : ''
     dateFilter.value.customRange =
       startDate && endDate ? [formatDateForDisplay(startDate), formatDateForDisplay(endDate)] : null
 

--- a/web/admin-spa/src/views/ApiKeysView.vue
+++ b/web/admin-spa/src/views/ApiKeysView.vue
@@ -3614,8 +3614,8 @@ const setGlobalDateFilterPreset = (preset) => {
       }
 
       globalDateFilter.customRange = [formatDate(startDate), formatDate(today)]
-      globalDateFilter.customStart = startDate.toISOString().split('T')[0]
-      globalDateFilter.customEnd = today.toISOString().split('T')[0]
+      globalDateFilter.customStart = formatLocalDate(startDate)
+      globalDateFilter.customEnd = formatLocalDate(today)
     }
   } else if (preset === 'all') {
     // 全部时间选项
@@ -3637,8 +3637,8 @@ const setGlobalDateFilterPreset = (preset) => {
       startDate.setDate(today.getDate() - 29)
     }
 
-    globalDateFilter.customStart = startDate.toISOString().split('T')[0]
-    globalDateFilter.customEnd = today.toISOString().split('T')[0]
+    globalDateFilter.customStart = formatLocalDate(startDate)
+    globalDateFilter.customEnd = formatLocalDate(today)
   }
 
   loadApiKeys()
@@ -3668,8 +3668,8 @@ const initApiKeyDateFilter = (keyId) => {
   apiKeyDateFilters.value[keyId] = {
     type: 'preset',
     preset: 'today',
-    customStart: today.toISOString().split('T')[0],
-    customEnd: today.toISOString().split('T')[0],
+    customStart: formatLocalDate(today),
+    customEnd: formatLocalDate(today),
     customRange: null,
     presetOptions: [
       { value: 'today', label: '今日', days: 1 },
@@ -3717,8 +3717,8 @@ const setApiKeyDateFilterPreset = (preset, keyId) => {
         }
 
         filter.customRange = [formatDate(startDate), formatDate(today)]
-        filter.customStart = startDate.toISOString().split('T')[0]
-        filter.customEnd = today.toISOString().split('T')[0]
+        filter.customStart = formatLocalDate(startDate)
+        filter.customEnd = formatLocalDate(today)
       }
     } else {
       // 预设选项
@@ -3726,8 +3726,8 @@ const setApiKeyDateFilterPreset = (preset, keyId) => {
       const startDate = new Date(today)
       startDate.setDate(today.getDate() - (option.days - 1))
 
-      filter.customStart = startDate.toISOString().split('T')[0]
-      filter.customEnd = today.toISOString().split('T')[0]
+      filter.customStart = formatLocalDate(startDate)
+      filter.customEnd = formatLocalDate(today)
 
       const formatDate = (date) => {
         return (
@@ -3766,6 +3766,16 @@ const onApiKeyCustomDateRangeChange = (keyId, value) => {
 }
 
 // 禁用未来日期
+const formatLocalDate = (date) => {
+  return (
+    date.getFullYear() +
+    '-' +
+    String(date.getMonth() + 1).padStart(2, '0') +
+    '-' +
+    String(date.getDate()).padStart(2, '0')
+  )
+}
+
 const disabledDate = (date) => {
   return date > new Date()
 }
@@ -3782,8 +3792,8 @@ const resetApiKeyDateFilter = (keyId) => {
   const startDate = new Date(today)
   startDate.setHours(0, 0, 0, 0) // 今日从0点开始
 
-  filter.customStart = today.toISOString().split('T')[0]
-  filter.customEnd = today.toISOString().split('T')[0]
+  filter.customStart = formatLocalDate(today)
+  filter.customEnd = formatLocalDate(today)
   filter.customRange = null
 
   // 重新加载数据


### PR DESCRIPTION
## Summary

修复成本计算和统计管线中的多个关键 bug，涵盖后端计算逻辑、时区处理和前端日期格式化三个层面。

## Why this must be merged

**这些 bug 直接导致用户看到的费用数据不准确**，具体影响：

1. **成本计算偏差**：账户级费用依赖后计算（从 token 重算），但无法感知运行时信息（如 Fast Mode 倍率）。现在改为请求时预计算费用并原子累加到 Redis，消除后算偏差
2. **模型名包含冒号导致解析错误**：`key.split(':')` 取 `parts[4]` 作为模型名，但模型名本身可能含 `:`（如 `gemini-2.0-flash-exp:free`），导致费用归到错误模型。改为 prefix/suffix 截取
3. **模糊匹配误命中**：`o1` 会匹配到所有含 `o1` 的模型定价，加了最小长度保护
4. **pricing 对象被污染**：`getModelPricing()` 返回共享引用，计算缓存价格时直接修改了源对象，影响后续所有调用。改为返回副本
5. **双重时区偏移**：`getDateInTimezone()` 已返回偏移后时间，再用 `getFullYear()/getMonth()` 读取又偏移一次，导致日期计算错位。改用 `getUTCFullYear()/getUTCMonth()`
6. **前端 `toISOString()` 时区问题**：UTC 转换导致东八区用户在 0:00-8:00 之间选择日期范围会差一天。改为 `formatLocalDate()` 使用本地时间

## Changes

- `src/models/redis.js` — 新增 `preComputedCost` 参数，支持原子累加预计算费用；修复模型名解析；费用读取优先使用预计算值
- `src/utils/costCalculator.js` — 修复 model null safety、`[1m]` 后缀剥离、pricing 对象副本、空 pricing 字段防护
- `src/services/pricingService.js` — 模糊匹配最小长度限制、pricing 副本返回、标准化模型名传递
- `src/services/apiKeyService.js` — 传递预计算费用到 `incrementAccountUsage`
- `src/services/relay/droidRelayService.js` — Droid 路径补齐缓存拆分、长上下文检测、预计算费用
- `src/services/scheduler/unifiedClaudeScheduler.js` — 移除 unauthorized 状态的重复过滤（该状态在后续单独检查）
- `src/routes/admin/apiKeys.js` — 修复自定义日期范围和 7 天范围的时区偏移
- `src/routes/apiStats.js` — `getFullYear` → `getUTCFullYear` 修复月份计算
- `web/admin-spa/src/stores/dashboard.js` — `toISOString()` → `formatLocalDate()`
- `web/admin-spa/src/views/ApiKeysView.vue` — 同上，全部日期格式化改为本地时间

## Test plan

- [ ] 验证费用统计：发送请求后对比预计算费用与 token 重算费用是否一致
- [ ] 验证时区：在 UTC+8 环境的 0:00-8:00 时段检查日期范围筛选是否正确
- [ ] 验证模型名含冒号的场景（如 `gemini-2.0-flash-exp:free`）费用是否正确归类
- [ ] 验证 `o1` 等短模型名不会误匹配到其他模型定价