### PR TITLE
feat: add GPT-5.4 and GPT-5.4 Pro model support

### DIFF
--- a/resources/model-pricing/model_prices_and_context_window.json
+++ b/resources/model-pricing/model_prices_and_context_window.json
@@ -4553,6 +4553,72 @@
     "supports_tool_choice": true,
     "supports_vision": true
   },
+  "gpt-5.4": {
+    "cache_read_input_token_cost": 6.25e-07,
+    "cache_read_input_token_cost_priority": 1.25e-06,
+    "input_cost_per_token": 2.5e-06,
+    "input_cost_per_token_priority": 5e-06,
+    "litellm_provider": "openai",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "mode": "responses",
+    "output_cost_per_token": 1.5e-05,
+    "output_cost_per_token_priority": 2.25e-05,
+    "supported_endpoints": [
+      "/v1/responses"
+    ],
+    "supported_modalities": [
+      "text",
+      "image"
+    ],
+    "supported_output_modalities": [
+      "text"
+    ],
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_parallel_function_calling": true,
+    "supports_pdf_input": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-pro": {
+    "cache_read_input_token_cost": 7.5e-06,
+    "cache_read_input_token_cost_priority": 1.5e-05,
+    "input_cost_per_token": 3e-05,
+    "input_cost_per_token_priority": 6e-05,
+    "litellm_provider": "openai",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "mode": "responses",
+    "output_cost_per_token": 1.8e-04,
+    "output_cost_per_token_priority": 2.7e-04,
+    "supported_endpoints": [
+      "/v1/responses"
+    ],
+    "supported_modalities": [
+      "text",
+      "image"
+    ],
+    "supported_output_modalities": [
+      "text"
+    ],
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_parallel_function_calling": true,
+    "supports_pdf_input": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": true
+  },
   "gpt-5.3-codex-spark": {
     "cache_read_input_token_cost": 1.75e-7,
     "cache_read_input_token_cost_priority": 3.5e-7,

--- a/resources/model-pricing/model_prices_and_context_window.json
+++ b/resources/model-pricing/model_prices_and_context_window.json
@@ -4554,12 +4554,12 @@
     "supports_vision": true
   },
   "gpt-5.4": {
-    "cache_read_input_token_cost": 6.25e-07,
-    "cache_read_input_token_cost_priority": 1.25e-06,
+    "cache_read_input_token_cost": 2.5e-07,
+    "cache_read_input_token_cost_priority": 5e-07,
     "input_cost_per_token": 2.5e-06,
     "input_cost_per_token_priority": 5e-06,
     "litellm_provider": "openai",
-    "max_input_tokens": 1048576,
+    "max_input_tokens": 922000,
     "max_output_tokens": 128000,
     "max_tokens": 128000,
     "mode": "responses",
@@ -4584,15 +4584,14 @@
     "supports_response_schema": true,
     "supports_system_messages": true,
     "supports_tool_choice": true,
-    "supports_vision": true
+    "supports_vision": true,
+    "supports_web_search": true
   },
   "gpt-5.4-pro": {
-    "cache_read_input_token_cost": 7.5e-06,
-    "cache_read_input_token_cost_priority": 1.5e-05,
     "input_cost_per_token": 3e-05,
     "input_cost_per_token_priority": 6e-05,
     "litellm_provider": "openai",
-    "max_input_tokens": 1048576,
+    "max_input_tokens": 922000,
     "max_output_tokens": 128000,
     "max_tokens": 128000,
     "mode": "responses",
@@ -4612,12 +4611,13 @@
     "supports_native_streaming": true,
     "supports_parallel_function_calling": true,
     "supports_pdf_input": true,
-    "supports_prompt_caching": true,
+    "supports_prompt_caching": false,
     "supports_reasoning": true,
     "supports_response_schema": true,
     "supports_system_messages": true,
     "supports_tool_choice": true,
-    "supports_vision": true
+    "supports_vision": true,
+    "supports_web_search": true
   },
   "gpt-5.3-codex-spark": {
     "cache_read_input_token_cost": 1.75e-7,


### PR DESCRIPTION
## Summary

添加 GPT-5.4 和 GPT-5.4 Pro 模型的定价数据，并修正初始定价参数中的错误。

## Why this must be merged

**没有定价数据 = 费用统计全部为零**。GPT-5.4 系列已上线，如果不添加定价配置：

1. 所有经过 relay 的 GPT-5.4 / GPT-5.4 Pro 请求费用会被计为 $0，用户看到的费用统计完全失真
2. 管理员无法基于真实费用做配额管理和成本控制决策

### 定价修正内容

初始提交的定价参数存在偏差，第二个 commit 修正了以下问题：

- **GPT-5.4 cache_read 价格**：`6.25e-07` → `2.5e-07`（原值是 input 的 0.25x，实际是 0.1x）
- **GPT-5.4 Pro**：移除了 `cache_read` 定价（该模型不支持 prompt caching）
- **max_input_tokens**：`1048576` → `922000`（与 OpenAI 官方文档对齐）
- **supports_prompt_caching**：GPT-5.4 Pro 设为 `false`
- 新增 `supports_web_search: true`

## Changes

- `resources/model-pricing/model_prices_and_context_window.json` — 新增 GPT-5.4、GPT-5.4 Pro 定价条目并修正参数

## Test plan

- [ ] 发送 GPT-5.4 请求，验证费用统计是否按新定价正确计算
- [ ] 确认 GPT-5.4 Pro 不会尝试 prompt caching