### PR TITLE
fix: resolve concurrency leak in Claude Console streaming path

### DIFF
--- a/src/services/relay/claudeConsoleRelayService.js
+++ b/src/services/relay/claudeConsoleRelayService.js
@@ -755,6 +755,13 @@ class ClaudeConsoleRelayService {
   ) {
     return new Promise((resolve, reject) => {
       let aborted = false
+      let settled = false
+      const settleOnce = (fn) => {
+        if (settled) return
+        settled = true
+        fn()
+      }
+      const abortController = new AbortController()
 
       // 构建完整的API URL
       const cleanUrl = account.apiUrl.replace(/\/$/, '') // 移除末尾斜杠
@@ -786,7 +793,8 @@ class ClaudeConsoleRelayService {
         },
         timeout: config.requestTimeout || 600000,
         responseType: 'stream',
-        validateStatus: () => true // 接受所有状态码
+        validateStatus: () => true, // 接受所有状态码
+        signal: abortController.signal
       }
 
       if (proxyAgent) {
@@ -1254,6 +1262,10 @@ class ClaudeConsoleRelayService {
           })
 
           response.data.on('error', (error) => {
+            if (aborted) {
+              settleOnce(() => resolve())
+              return
+            }
             logger.error(
               `❌ Claude Console stream error (Account: ${account?.name || accountId}):`,
               error
@@ -1281,6 +1293,7 @@ class ClaudeConsoleRelayService {
         })
         .catch((error) => {
           if (aborted) {
+            settleOnce(() => resolve())
             return
           }
 
@@ -1363,6 +1376,7 @@ class ClaudeConsoleRelayService {
       responseStream.on('close', () => {
         logger.debug('🔌 Client disconnected, cleaning up Claude Console stream')
         aborted = true
+        abortController.abort()
       })
     })
   }


### PR DESCRIPTION
## Summary

修复 Claude Console 流式响应路径中的并发计数泄漏问题。

## Why this must be merged

**这是一个资源泄漏 bug，会逐渐耗尽可用并发槽位**，最终导致所有请求排队超时。

### 根因分析

当客户端在流式传输过程中断开连接时，存在两个问题：

1. **Promise 永不 settle**：`aborted = true` 后，`response.data.on('error')` 和 `.catch()` 直接 `return` 而不调用 `resolve()`/`reject()`，导致 Promise 永远 pending，上层的 `finally` 块（负责释放并发计数）永远不会执行
2. **上游连接未中断**：客户端断开后没有通知上游停止发送数据，上游继续传输直到超时，浪费带宽和连接资源

### 修复方案

- 引入 `settled` flag + `settleOnce()` 确保 Promise 只 settle 一次
- 客户端断开时 `abortController.abort()` 立即中断上游请求
- `on('error')` 和 `.catch()` 在 aborted 状态下调用 `resolve()` 而不是静默 return

## Changes

- `src/services/relay/claudeConsoleRelayService.js` — 添加 `settleOnce` 防重入、`AbortController` 中断上游、aborted 路径正确 resolve

## Test plan

- [ ] 流式请求过程中客户端断开 → 检查 Redis 并发计数是否正确减少
- [ ] 正常流式请求完成 → 确认行为无回归
- [ ] 并发压测：多个客户端同时断开 → 无并发计数泄漏