### PR TITLE
fix(gemini): admin test endpoint, auto setupUser, and 429 reset time parsing

### DIFF
--- a/src/handlers/geminiHandlers.js
+++ b/src/handlers/geminiHandlers.js
@@ -2189,7 +2189,7 @@ async function handleStandardGenerateContent(req, res) {
     }
 
     // 从路径参数中获取模型名
-    const model = req.params.modelName || 'gemini-2.0-flash-exp'
+    const model = (req.params.modelName || 'gemini-2.0-flash-exp').replace(/-customtools$/, '')
     sessionHash = sessionHelper.generateSessionHash(req.body)
 
     // 标准 Gemini API 请求体直接包含 contents 等字段
@@ -2478,7 +2478,7 @@ async function handleStandardStreamGenerateContent(req, res) {
     }
 
     // 从路径参数中获取模型名
-    const model = req.params.modelName || 'gemini-2.0-flash-exp'
+    const model = (req.params.modelName || 'gemini-2.0-flash-exp').replace(/-customtools$/, '')
     sessionHash = sessionHelper.generateSessionHash(req.body)
 
     // 标准 Gemini API 请求体直接包含 contents 等字段

--- a/src/handlers/geminiHandlers.js
+++ b/src/handlers/geminiHandlers.js
@@ -29,7 +29,8 @@ const handleGeminiUpstreamError = async (
   accountType,
   sessionHash,
   headers,
-  disableAutoProtection = false
+  disableAutoProtection = false,
+  responseBody = null
 ) => {
   if (!accountId || !errorStatus) {
     return
@@ -38,7 +39,7 @@ const handleGeminiUpstreamError = async (
   try {
     if (errorStatus === 429) {
       if (!autoProtectionDisabled) {
-        const ttl = upstreamErrorHelper.parseRetryAfter(headers)
+        const ttl = upstreamErrorHelper.parseRetryAfter(headers, responseBody)
         await upstreamErrorHelper.markTempUnavailable(accountId, accountType || 'gemini', 429, ttl)
         // 同时设置 rate-limit 状态，保持与 /messages handler 一致
         await unifiedGeminiScheduler
@@ -772,7 +773,8 @@ async function handleMessages(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
 
     // 返回错误响应
@@ -1761,7 +1763,8 @@ async function handleGenerateContent(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
     res.status(500).json({
       error: {
@@ -2150,7 +2153,8 @@ async function handleStreamGenerateContent(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
 
     if (!res.headersSent) {
@@ -2449,7 +2453,8 @@ async function handleStandardGenerateContent(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
 
     res.status(500).json({
@@ -2934,7 +2939,8 @@ async function handleStandardStreamGenerateContent(req, res) {
       accountType,
       sessionHash,
       error.response?.headers,
-      account?.disableAutoProtection
+      account?.disableAutoProtection,
+      error.response?.data
     )
 
     if (!res.headersSent) {

--- a/src/routes/admin/geminiAccounts.js
+++ b/src/routes/admin/geminiAccounts.js
@@ -274,6 +274,29 @@ router.post('/', authenticateAdmin, async (req, res) => {
 
     const newAccount = await geminiAccountService.createAccount(accountData)
 
+    // OAuth 账户创建后自动执行 setupUser（onboard 到正确层级）
+    if (newAccount.id && accountData.refreshToken) {
+      setImmediate(async () => {
+        try {
+          const account = await geminiAccountService.getAccount(newAccount.id)
+          if (!account?.refreshToken) return
+          const client = await geminiAccountService.getOauthClient(
+            account.accessToken,
+            account.refreshToken,
+            account.proxy,
+            account.oauthProvider
+          )
+          const result = await geminiAccountService.setupUser(client, account.projectId || null, null, account.proxy)
+          if (result.projectId) {
+            await geminiAccountService.updateTempProjectId(newAccount.id, result.projectId)
+          }
+          logger.info(`✅ Auto setupUser completed for new account: ${account.name} (${newAccount.id}), tier: ${result.userTier}`)
+        } catch (err) {
+          logger.warn(`⚠️ Auto setupUser failed for account ${newAccount.id}: ${err.message}`)
+        }
+      })
+    }
+
     // 如果是分组类型，处理分组绑定
     if (accountData.accountType === 'group') {
       if (accountData.groupIds && accountData.groupIds.length > 0) {
@@ -356,6 +379,29 @@ router.put('/:accountId', authenticateAdmin, async (req, res) => {
     }
 
     const updatedAccount = await geminiAccountService.updateAccount(accountId, mappedUpdates)
+
+    // 如果更新了 token，自动执行 setupUser
+    if (updates.refreshToken || updates.accessToken) {
+      setImmediate(async () => {
+        try {
+          const account = await geminiAccountService.getAccount(accountId)
+          if (!account?.refreshToken) return
+          const client = await geminiAccountService.getOauthClient(
+            account.accessToken,
+            account.refreshToken,
+            account.proxy,
+            account.oauthProvider
+          )
+          const result = await geminiAccountService.setupUser(client, account.projectId || null, null, account.proxy)
+          if (result.projectId) {
+            await geminiAccountService.updateTempProjectId(accountId, result.projectId)
+          }
+          logger.info(`✅ Auto setupUser completed on token update: ${account.name} (${accountId}), tier: ${result.userTier}`)
+        } catch (err) {
+          logger.warn(`⚠️ Auto setupUser failed for account ${accountId}: ${err.message}`)
+        }
+      })
+    }
 
     logger.success(`📝 Admin updated Gemini account: ${accountId}`)
     return res.json({ success: true, data: updatedAccount })

--- a/src/routes/admin/geminiAccounts.js
+++ b/src/routes/admin/geminiAccounts.js
@@ -275,7 +275,8 @@ router.post('/', authenticateAdmin, async (req, res) => {
     const newAccount = await geminiAccountService.createAccount(accountData)
 
     // OAuth 账户创建后自动执行 setupUser（onboard 到正确层级）
-    if (newAccount.id && accountData.refreshToken) {
+    const hasOAuthToken = accountData.refreshToken || accountData.geminiOauth?.refresh_token
+    if (newAccount.id && hasOAuthToken) {
       setImmediate(async () => {
         try {
           const account = await geminiAccountService.getAccount(newAccount.id)

--- a/src/routes/admin/geminiAccounts.js
+++ b/src/routes/admin/geminiAccounts.js
@@ -506,6 +506,41 @@ router.post('/:id/reset-status', authenticateAdmin, async (req, res) => {
   }
 })
 
+// 触发 setupUser（onboard 到正确层级）
+router.post('/:accountId/setup', authenticateAdmin, async (req, res) => {
+  const { accountId } = req.params
+  try {
+    const account = await geminiAccountService.getAccount(accountId)
+    if (!account) return res.status(404).json({ error: 'Account not found' })
+
+    const client = await geminiAccountService.getOauthClient(
+      account.accessToken,
+      account.refreshToken,
+      account.proxy,
+      account.oauthProvider
+    )
+
+    const result = await geminiAccountService.setupUser(client, account.projectId || null, null, account.proxy)
+
+    // 把 onboard 后拿到的 projectId 存回账号
+    if (result.projectId && result.projectId !== account.tempProjectId) {
+      await geminiAccountService.updateTempProjectId(accountId, result.projectId)
+    }
+
+    return res.json({
+      success: true,
+      projectId: result.projectId,
+      userTier: result.userTier,
+      currentTier: result.loadRes?.currentTier,
+      allowedTiers: result.loadRes?.allowedTiers,
+      onboardRes: result.onboardRes
+    })
+  } catch (error) {
+    logger.error(`❌ setupUser failed for account: ${accountId}`, error.message)
+    return res.status(500).json({ success: false, error: error.message })
+  }
+})
+
 // 测试 Gemini 账户连通性
 router.post('/:accountId/test', authenticateAdmin, async (req, res) => {
   const { accountId } = req.params
@@ -520,50 +555,46 @@ router.post('/:accountId/test', authenticateAdmin, async (req, res) => {
       return res.status(404).json({ error: 'Account not found' })
     }
 
-    // 确保 token 有效
-    const tokenResult = await geminiAccountService.ensureValidToken(accountId)
-    if (!tokenResult.success) {
-      return res.status(401).json({
-        error: 'Token refresh failed',
-        message: tokenResult.error
-      })
-    }
+    // 获取 OAuth 客户端
+    const client = await geminiAccountService.getOauthClient(
+      account.accessToken,
+      account.refreshToken,
+      account.proxy,
+      account.oauthProvider
+    )
 
-    const { accessToken } = tokenResult
+    // 使用与生产流量一致的 cloudcode-pa.googleapis.com 端点测试
+    let projectId = account.projectId || account.tempProjectId || null
 
-    // 构造测试请求
-    const axios = require('axios')
-    const { createGeminiTestPayload } = require('../../utils/testPayloadHelper')
-    const { getProxyAgent } = require('../../utils/proxyHelper')
-
-    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`
-    const payload = createGeminiTestPayload(model)
-
-    const requestConfig = {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`
-      },
-      timeout: 30000
-    }
-
-    // 配置代理
-    if (account.proxy) {
-      const agent = getProxyAgent(account.proxy)
-      if (agent) {
-        requestConfig.httpsAgent = agent
-        requestConfig.httpAgent = agent
+    // 若无 projectId，先调 loadCodeAssist 获取（与生产流量逻辑一致）
+    if (!projectId) {
+      const loadRes = await geminiAccountService.loadCodeAssist(client, null, account.proxy)
+      if (loadRes.cloudaicompanionProject) {
+        projectId = loadRes.cloudaicompanionProject
+        await geminiAccountService.updateTempProjectId(accountId, projectId)
       }
     }
 
-    const response = await axios.post(apiUrl, payload, requestConfig)
+    const requestData = {
+      model,
+      request: {
+        contents: [{ role: 'user', parts: [{ text: 'Hi' }] }]
+      }
+    }
+
+    const response = await geminiAccountService.generateContent(
+      client,
+      requestData,
+      null,
+      projectId,
+      null,
+      account.proxy
+    )
     const latency = Date.now() - startTime
 
-    // 提取响应文本
-    let responseText = ''
-    if (response.data?.candidates?.[0]?.content?.parts?.[0]?.text) {
-      responseText = response.data.candidates[0].content.parts[0].text
-    }
+    // 提取响应文本（Code Assist API 响应包在 response 字段里）
+    const candidates = response?.response?.candidates || response?.candidates || []
+    const responseText = candidates?.[0]?.content?.parts?.[0]?.text || ''
 
     logger.success(
       `✅ Gemini account test passed: ${account.name} (${accountId}), latency: ${latency}ms`

--- a/src/utils/upstreamErrorHelper.js
+++ b/src/utils/upstreamErrorHelper.js
@@ -163,7 +163,21 @@ const classifyError = (statusCode) => {
 }
 
 // 解析 429 响应头中的重置时间（返回秒数）
-const parseRetryAfter = (headers) => {
+const parseRetryAfter = (headers, responseBody) => {
+  // Google Code Assist API 在 body 里返回 reset 时间
+  // e.g. "Your quota will reset after 10s."
+  if (responseBody) {
+    const msg =
+      typeof responseBody === 'string'
+        ? responseBody
+        : responseBody?.error?.message || ''
+    const match = msg.match(/reset after (\d+)s/i)
+    if (match) {
+      const seconds = parseInt(match[1], 10)
+      if (seconds > 0) return seconds
+    }
+  }
+
   if (!headers) {
     return null
   }


### PR DESCRIPTION
## Summary

修复 Gemini 账户管理的三个关键问题：测试端点与生产不一致、OAuth 账户需要手动 onboard、429 限流恢复时间不准。

## Why this must be merged

### 1. 测试端点与生产流量走的是不同 API — 测试通过 ≠ 生产可用

**之前**：管理后台的「测试连通性」按钮使用 `generativelanguage.googleapis.com` 公共端点 + Bearer token 直接调用  
**生产**：实际流量走 `cloudcode-pa.googleapis.com` Code Assist API

这意味着测试通过的账户在生产中可能 403（projectId 缺失/层级未 onboard），而测试失败的账户可能生产完全正常。**测试结果毫无参考价值。**

修复后测试端点与生产一致，使用 `generateContent()` 通过 Code Assist API 发送请求。

### 2. OAuth 账户创建后必须手动 setupUser — 遗漏就无法使用

新建 OAuth 账户后，需要调用 `setupUser`（即 `onboard` 到正确的 tier/projectId）才能正常使用。之前这一步完全依赖人工操作，一旦遗漏，账户会在调度时被跳过或报 403。

修复后：
- 创建 OAuth 账户时自动 `setImmediate` 执行 setupUser
- 更新 token 时自动重新执行 setupUser
- 新增手动触发 `POST /:accountId/setup` 端点

### 3. Google 429 响应的重置时间被丢弃 — 限流恢复靠猜

Google Code Assist API 的 429 响应不在 `Retry-After` header 里给重置时间，而是在 body 中：`"Your quota will reset after 10s."`。之前只解析 header，拿不到重置时间就用默认值，可能过早重试（浪费请求）或等待过久（浪费配额时间）。

修复后 `parseRetryAfter` 同时解析 header 和 response body。

### 4. `-customtools` 后缀导致模型名不匹配

Gemini 某些客户端会在模型名后追加 `-customtools` 后缀（如 `gemini-2.5-pro-customtools`），导致模型查找失败。添加了 `.replace(/-customtools$/, '')` 正规化。

## Changes

- `src/routes/admin/geminiAccounts.js` — 重写测试端点使用 Code Assist API；新增 setupUser 端点；创建/更新时自动 setupUser
- `src/handlers/geminiHandlers.js` — 模型名去除 `-customtools` 后缀；429 handler 传递 response body
- `src/utils/upstreamErrorHelper.js` — `parseRetryAfter` 新增 body 解析（`reset after Ns` 模式）

## Test plan

- [ ] 创建新 OAuth 账户 → 确认自动 setupUser 完成，projectId 已写入
- [ ] 更新账户 token → 确认 setupUser 重新执行
- [ ] 管理后台测试按钮 → 确认走 Code Assist API 路径
- [ ] 触发 429 → 确认从 body 正确解析重置时间
- [ ] 发送 `gemini-2.5-pro-customtools` 模型请求 → 确认正确路由