### PR TITLE
feat(identity): per-account identity isolation to prevent device fingerprint anomalies

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -102,7 +102,7 @@ const config = {
   },
 
   // ⏱️ 请求超时配置
-  requestTimeout: parseInt(process.env.REQUEST_TIMEOUT) || 600000, // 默认 10 分钟
+  requestTimeout: parseInt(process.env.REQUEST_TIMEOUT) || 3600000, // 默认 60 分钟
 
   // 📈 使用限制
   limits: {
@@ -239,6 +239,26 @@ const config = {
     overloadTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_OVERLOAD_TTL_SECONDS) || 600, // 529过载暂停秒数
     authErrorTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_AUTH_TTL_SECONDS) || 1800, // 401/403认证错误暂停秒数
     timeoutTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_TIMEOUT_TTL_SECONDS) || 300 // 504超时暂停秒数
+  },
+
+  // 🔒 身份重写配置（防封号统一身份）
+  identityRewrite: {
+    enabled: process.env.IDENTITY_REWRITE_ENABLED === 'true', // 默认关闭
+    forwardEventBatch: process.env.IDENTITY_FORWARD_EVENT_BATCH === 'true', // 转发遥测事件
+    defaults: {
+      platform: process.env.IDENTITY_PLATFORM || 'darwin',
+      shell: process.env.IDENTITY_SHELL || 'zsh',
+      osVersion: process.env.IDENTITY_OS_VERSION || 'Darwin 24.4.0',
+      workingDir: process.env.IDENTITY_WORKING_DIR || '/Users/user/projects',
+      version: process.env.IDENTITY_CC_VERSION || '2.1.81',
+      arch: process.env.IDENTITY_ARCH || 'arm64',
+      nodeVersion: process.env.IDENTITY_NODE_VERSION || 'v24.3.0',
+      terminal: process.env.IDENTITY_TERMINAL || 'iTerm2.app',
+      constrainedMemory: parseInt(process.env.IDENTITY_CONSTRAINED_MEMORY) || 34359738368, // 32GB
+      rssRange: [300000000, 500000000], // 300-500MB
+      heapTotalRange: [40000000, 80000000], // 40-80MB
+      heapUsedRange: [100000000, 200000000] // 100-200MB
+    }
   }
 }
 

--- a/src/routes/admin/system.js
+++ b/src/routes/admin/system.js
@@ -451,4 +451,96 @@ router.post('/models/pricing/refresh', authenticateAdmin, async (req, res) => {
   }
 })
 
+// ==================== 身份重写验证 ====================
+
+// 预览身份重写效果（dry-run）
+router.get('/identity-rewrite/verify', authenticateAdmin, async (req, res) => {
+  try {
+    const identityRewriteService = require('../../services/identityRewriteService')
+    const identityRewriteConfig = config.identityRewrite
+
+    if (!identityRewriteConfig?.enabled) {
+      return res.json({
+        enabled: false,
+        message: 'Identity rewrite is disabled (IDENTITY_REWRITE_ENABLED=false)'
+      })
+    }
+
+    // 构造样本输入
+    const sampleInput = {
+      metadata: {
+        user_id: JSON.stringify({
+          device_id: 'REAL_DEVICE_ID_abc123def456',
+          account_uuid: 'shared-account-uuid',
+          session_id: 'session-xxx'
+        })
+      },
+      system: [
+        {
+          type: 'text',
+          text: 'x-anthropic-billing-header: cc_version=2.1.81.a1b; cc_entrypoint=cli;'
+        },
+        {
+          type: 'text',
+          text: 'Here is useful information about the environment:\n<env>\nWorking directory: /home/bob/myproject\nPlatform: linux\nShell: bash\nOS Version: Linux 6.5.0-generic\n</env>'
+        }
+      ],
+      messages: [{ role: 'user', content: 'Check /home/bob/myproject/src/main.js' }]
+    }
+
+    // 可选：传入 accountId 使用账户级配置
+    const accountId = req.query.accountId || null
+    const profile = await identityRewriteService.getProfile(accountId)
+
+    // 深拷贝用于重写
+    const rewritten = JSON.parse(JSON.stringify(sampleInput))
+    identityRewriteService.rewriteSystemPrompt(rewritten, profile)
+
+    // 样本事件批量
+    const sampleEvent = {
+      events: [
+        {
+          event_data: {
+            device_id: 'original-device-id',
+            email: 'realuser@company.com',
+            env: { platform: 'linux', is_ci: true, terminal: 'gnome-terminal' },
+            baseUrl: 'https://relay.example.com'
+          }
+        }
+      ]
+    }
+
+    const rewrittenEvent = identityRewriteService.rewriteEventBatch(sampleEvent, profile)
+
+    res.json({
+      enabled: true,
+      forwardEventBatch: identityRewriteConfig.forwardEventBatch || false,
+      profile,
+      messages_rewrite: {
+        _info: 'Shows how identity rewrite transforms a sample /v1/messages request',
+        before: {
+          system_billing: sampleInput.system[0].text,
+          system_env: sampleInput.system[1].text,
+          user_message: sampleInput.messages[0].content
+        },
+        after: {
+          system_billing: rewritten.system[0].text,
+          system_env: rewritten.system[1].text,
+          user_message: rewritten.messages[0].content,
+          user_message_note:
+            'User messages are NOT rewritten (preserves real file paths for tool calls)'
+        }
+      },
+      event_rewrite: {
+        _info: 'Shows how event_logging/batch events are rewritten',
+        before: sampleEvent.events[0].event_data,
+        after: rewrittenEvent.events[0].event_data
+      }
+    })
+  } catch (error) {
+    logger.error('Failed to verify identity rewrite:', error)
+    res.status(500).json({ error: 'Failed to verify identity rewrite', message: error.message })
+  }
+})
+
 module.exports = router

--- a/src/routes/admin/system.js
+++ b/src/routes/admin/system.js
@@ -510,7 +510,7 @@ router.get('/identity-rewrite/verify', authenticateAdmin, async (req, res) => {
       ]
     }
 
-    const rewrittenEvent = identityRewriteService.rewriteEventBatch(sampleEvent, profile)
+    const rewrittenEvent = identityRewriteService.rewriteEventBatch(sampleEvent, profile, accountId)
 
     res.json({
       enabled: true,

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1908,9 +1908,13 @@ router.all('/api/organizations/:orgId/policy_limits*', authenticateApiKey, async
     const identityRewriteConfig = config.identityRewrite
 
     if (identityRewriteConfig?.enabled && req.body && typeof req.body === 'object') {
+      const claudeAccountService = require('../services/account/claudeAccountService')
       const accountId = req.apiKey?.claudeAccountId || null
-      const profile = await identityRewriteService.getProfile(accountId)
-      identityRewriteService.rewriteGenericIdentity(req.body, profile, accountId)
+      const [profile, accountEmail] = await Promise.all([
+        identityRewriteService.getProfile(accountId),
+        accountId ? claudeAccountService.getAccountEmail(accountId) : Promise.resolve('')
+      ])
+      identityRewriteService.rewriteGenericIdentity(req.body, profile, accountId, accountEmail)
     }
 
     // 返回空成功响应（relay 不需要真正转发这些管理路径）
@@ -1927,9 +1931,13 @@ router.all('/api/settings*', authenticateApiKey, async (req, res) => {
     const identityRewriteConfig = config.identityRewrite
 
     if (identityRewriteConfig?.enabled && req.body && typeof req.body === 'object') {
+      const claudeAccountService = require('../services/account/claudeAccountService')
       const accountId = req.apiKey?.claudeAccountId || null
-      const profile = await identityRewriteService.getProfile(accountId)
-      identityRewriteService.rewriteGenericIdentity(req.body, profile, accountId)
+      const [profile, accountEmail] = await Promise.all([
+        identityRewriteService.getProfile(accountId),
+        accountId ? claudeAccountService.getAccountEmail(accountId) : Promise.resolve('')
+      ])
+      identityRewriteService.rewriteGenericIdentity(req.body, profile, accountId, accountEmail)
     }
 
     res.status(200).json({})

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1887,12 +1887,14 @@ router.post('/v1/messages/count_tokens', authenticateApiKey, async (req, res) =>
 })
 
 // Claude Code 客户端遥测端点 - 身份重写后转发或丢弃
-router.post('/api/event_logging/batch', async (req, res) => {
+// 使用 authenticateApiKey 确保使用客户端绑定的账户，避免跨账户遥测污染
+router.post('/api/event_logging/batch', authenticateApiKey, async (req, res) => {
   // 立即返回 200，转发在后台进行（火忘式）
   res.status(200).json({ success: true })
 
   try {
-    await claudeRelayService.forwardEventBatch(req.body, req.headers)
+    const accountId = req.apiKey?.claudeAccountId || null
+    await claudeRelayService.forwardEventBatch(req.body, req.headers, accountId)
   } catch (error) {
     logger.debug('📡 Telemetry forward error (non-critical):', error.message)
   }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1906,8 +1906,9 @@ router.all('/api/organizations/:orgId/policy_limits*', authenticateApiKey, async
     const identityRewriteConfig = config.identityRewrite
 
     if (identityRewriteConfig?.enabled && req.body && typeof req.body === 'object') {
-      const profile = await identityRewriteService.getProfile(null)
-      identityRewriteService.rewriteGenericIdentity(req.body, profile)
+      const accountId = req.apiKey?.claudeAccountId || null
+      const profile = await identityRewriteService.getProfile(accountId)
+      identityRewriteService.rewriteGenericIdentity(req.body, profile, accountId)
     }
 
     // 返回空成功响应（relay 不需要真正转发这些管理路径）
@@ -1924,8 +1925,9 @@ router.all('/api/settings*', authenticateApiKey, async (req, res) => {
     const identityRewriteConfig = config.identityRewrite
 
     if (identityRewriteConfig?.enabled && req.body && typeof req.body === 'object') {
-      const profile = await identityRewriteService.getProfile(null)
-      identityRewriteService.rewriteGenericIdentity(req.body, profile)
+      const accountId = req.apiKey?.claudeAccountId || null
+      const profile = await identityRewriteService.getProfile(accountId)
+      identityRewriteService.rewriteGenericIdentity(req.body, profile, accountId)
     }
 
     res.status(200).json({})

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -11,6 +11,7 @@ const logger = require('../utils/logger')
 const { getEffectiveModel, parseVendorPrefixedModel } = require('../utils/modelHelper')
 const sessionHelper = require('../utils/sessionHelper')
 const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
+const config = require('../../config/config')
 const claudeRelayConfigService = require('../services/claudeRelayConfigService')
 const claudeAccountService = require('../services/account/claudeAccountService')
 const claudeConsoleAccountService = require('../services/account/claudeConsoleAccountService')
@@ -1885,9 +1886,53 @@ router.post('/v1/messages/count_tokens', authenticateApiKey, async (req, res) =>
   }
 })
 
-// Claude Code 客户端遥测端点 - 返回成功响应避免 404 日志
-router.post('/api/event_logging/batch', (req, res) => {
+// Claude Code 客户端遥测端点 - 身份重写后转发或丢弃
+router.post('/api/event_logging/batch', async (req, res) => {
+  // 立即返回 200，转发在后台进行（火忘式）
   res.status(200).json({ success: true })
+
+  try {
+    await claudeRelayService.forwardEventBatch(req.body, req.headers)
+  } catch (error) {
+    logger.debug('📡 Telemetry forward error (non-critical):', error.message)
+  }
+})
+
+// Claude Code 客户端旁路请求 - 重写身份字段后转发
+// policy_limits 和 settings 路径会携带 device_id/email，需要重写防止旁路泄漏
+router.all('/api/organizations/:orgId/policy_limits*', authenticateApiKey, async (req, res) => {
+  try {
+    const identityRewriteService = require('../services/identityRewriteService')
+    const identityRewriteConfig = config.identityRewrite
+
+    if (identityRewriteConfig?.enabled && req.body && typeof req.body === 'object') {
+      const profile = await identityRewriteService.getProfile(null)
+      identityRewriteService.rewriteGenericIdentity(req.body, profile)
+    }
+
+    // 返回空成功响应（relay 不需要真正转发这些管理路径）
+    res.status(200).json({})
+  } catch (error) {
+    logger.debug('⚠️ Policy limits request error:', error.message)
+    res.status(200).json({})
+  }
+})
+
+router.all('/api/settings*', authenticateApiKey, async (req, res) => {
+  try {
+    const identityRewriteService = require('../services/identityRewriteService')
+    const identityRewriteConfig = config.identityRewrite
+
+    if (identityRewriteConfig?.enabled && req.body && typeof req.body === 'object') {
+      const profile = await identityRewriteService.getProfile(null)
+      identityRewriteService.rewriteGenericIdentity(req.body, profile)
+    }
+
+    res.status(200).json({})
+  } catch (error) {
+    logger.debug('⚠️ Settings request error:', error.message)
+    res.status(200).json({})
+  }
 })
 
 module.exports = router

--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -1340,6 +1340,19 @@ class ClaudeAccountService {
     return this._encryptionKeyCache
   }
 
+  // 🔓 获取账户真实邮箱（解密后，不掩码）
+  async getAccountEmail(accountId) {
+    try {
+      const accountData = await redis.getClaudeAccount(accountId)
+      if (!accountData?.email) {
+        return ''
+      }
+      return this._decryptSensitiveData(accountData.email)
+    } catch (_error) {
+      return ''
+    }
+  }
+
   // 🎭 掩码邮箱地址
   _maskEmail(email) {
     if (!email || !email.includes('@')) {

--- a/src/services/identityRewriteService.js
+++ b/src/services/identityRewriteService.js
@@ -259,8 +259,9 @@ function rewriteHomePaths(text, workingDir) {
  * @param {Object} body - 请求体（会被修改）
  * @param {Object} profile - 身份配置
  * @param {string} [accountId] - 账户 ID（用于生成唯一 device_id/email）
+ * @param {string} [accountEmail] - 账户真实邮箱（优先使用）
  */
-function rewriteGenericIdentity(body, profile, accountId) {
+function rewriteGenericIdentity(body, profile, accountId, accountEmail) {
   if (!body || typeof body !== 'object') {
     return
   }
@@ -269,7 +270,7 @@ function rewriteGenericIdentity(body, profile, accountId) {
     body.device_id = generateDeviceId(profile || getDefaultProfile(), accountId)
   }
   if (body.email) {
-    body.email = generateEmail(accountId)
+    body.email = accountEmail || body.email
   }
 }
 
@@ -293,9 +294,11 @@ function stripLeakFields(body) {
  * 重写 device_id, email, env, process，剥离泄漏字段
  * @param {Object} body - 事件批量请求体
  * @param {Object} profile - 身份配置
+ * @param {string} [accountId] - 账户 ID
+ * @param {string} [accountEmail] - 账户真实邮箱（优先使用）
  * @returns {Object} 重写后的请求体
  */
-function rewriteEventBatch(body, profile, accountId) {
+function rewriteEventBatch(body, profile, accountId, accountEmail) {
   if (!body || typeof body !== 'object' || !Array.isArray(body.events)) {
     return body
   }
@@ -315,7 +318,7 @@ function rewriteEventBatch(body, profile, accountId) {
       data.device_id = generateDeviceId(p, accountId)
     }
     if (data.email) {
-      data.email = generateEmail(accountId)
+      data.email = accountEmail || data.email
     }
 
     // 重写环境对象（完全替换）

--- a/src/services/identityRewriteService.js
+++ b/src/services/identityRewriteService.js
@@ -1,0 +1,473 @@
+/**
+ * Identity Rewrite Service
+ *
+ * 防封号统一身份重写服务
+ * 移植自 cc-gateway 的 rewriter.ts 逻辑
+ * 纯函数，无全局状态
+ */
+
+const logger = require('../utils/logger')
+const redis = require('../models/redis')
+const config = require('../../config/config')
+
+// Redis 键前缀
+const PROFILE_KEY_PREFIX = 'fmt_identity_profile:'
+const PROFILE_TTL_SECONDS = 30 * 24 * 60 * 60 // 30 天
+
+// 关键正则表达式（来自 cc-gateway）
+const REGEX = {
+  billingFingerprint: /cc_version=[\d.]+\.[a-f0-9]{3}/g,
+  platform: /Platform:\s*\S+/g,
+  shell: /Shell:\s*\S+/g,
+  osVersion: /OS Version:\s*[^\n<]+/g,
+  workingDir: /((?:Primary )?[Ww]orking directory:\s*)\/\S+/g,
+  homePath: /\/(?:Users|home)\/[^/\s]+\//g
+}
+
+/**
+ * 获取规范化身份配置
+ * 优先从 Redis 获取账户级配置，后备到全局默认值
+ * @param {string} accountId - 账户 ID
+ * @returns {Object} 身份配置
+ */
+async function getProfile(accountId) {
+  if (!accountId) {
+    return getDefaultProfile()
+  }
+
+  try {
+    const key = `${PROFILE_KEY_PREFIX}${accountId}`
+    const data = await redis.getClient().get(key)
+
+    if (data) {
+      logger.debug(`📋 Retrieved identity profile for account ${accountId}`)
+      return JSON.parse(data)
+    }
+  } catch (error) {
+    logger.warn(`⚠️ Failed to get identity profile for ${accountId}:`, error.message)
+  }
+
+  return getDefaultProfile()
+}
+
+/**
+ * 播种账户级身份配置
+ * 使用 NX（仅当不存在时设置），30 天 TTL
+ * @param {string} accountId - 账户 ID
+ * @param {Object} capturedEnv - 捕获的环境信息
+ */
+async function seedProfile(accountId, capturedEnv) {
+  if (!accountId || !capturedEnv) {
+    return
+  }
+
+  try {
+    const key = `${PROFILE_KEY_PREFIX}${accountId}`
+
+    // 根据捕获的平台选择合适的默认值，避免 Linux/Windows 混入 Darwin 特征
+    const defaults = getDefaultProfile()
+    const platformDefaults = getPlatformDefaults(capturedEnv.platform || defaults.platform)
+
+    // 构建配置对象
+    const profile = {
+      platform: capturedEnv.platform || defaults.platform,
+      shell: capturedEnv.shell || platformDefaults.shell,
+      osVersion: capturedEnv.osVersion || platformDefaults.osVersion,
+      workingDir: capturedEnv.workingDir || platformDefaults.workingDir,
+      version: capturedEnv.version || defaults.version,
+      arch: capturedEnv.arch || defaults.arch,
+      nodeVersion: capturedEnv.nodeVersion || defaults.nodeVersion,
+      terminal: capturedEnv.terminal || platformDefaults.terminal,
+      constrainedMemory: capturedEnv.constrainedMemory || defaults.constrainedMemory,
+      rssRange: defaults.rssRange,
+      heapTotalRange: defaults.heapTotalRange,
+      heapUsedRange: defaults.heapUsedRange,
+      packageManagers: capturedEnv.packageManagers || 'npm',
+      runtimes: capturedEnv.runtimes || 'node',
+      buildTime: capturedEnv.buildTime || new Date().toISOString(),
+      deploymentEnvironment: capturedEnv.deploymentEnvironment || 'unknown',
+      vcs: capturedEnv.vcs || 'git',
+      seededAt: new Date().toISOString()
+    }
+
+    // 使用 NX（仅当不存在时设置）
+    await redis.getClient().set(key, JSON.stringify(profile), 'EX', PROFILE_TTL_SECONDS, 'NX')
+    logger.info(`✅ Seeded identity profile for account ${accountId}`)
+  } catch (error) {
+    logger.warn(`⚠️ Failed to seed identity profile for ${accountId}:`, error.message)
+  }
+}
+
+/**
+ * 获取默认身份配置
+ * @returns {Object} 默认配置
+ */
+function getDefaultProfile() {
+  const defaults = config.identityRewrite?.defaults || {}
+
+  return {
+    platform: defaults.platform || 'darwin',
+    shell: defaults.shell || 'zsh',
+    osVersion: defaults.osVersion || 'Darwin 24.4.0',
+    workingDir: defaults.workingDir || '/Users/user/projects',
+    version: defaults.version || '2.1.81',
+    arch: defaults.arch || 'arm64',
+    nodeVersion: defaults.nodeVersion || 'v24.3.0',
+    terminal: defaults.terminal || 'iTerm2.app',
+    constrainedMemory: defaults.constrainedMemory || 34359738368,
+    rssRange: defaults.rssRange || [300000000, 500000000],
+    heapTotalRange: defaults.heapTotalRange || [40000000, 80000000],
+    heapUsedRange: defaults.heapUsedRange || [100000000, 200000000],
+    packageManagers: 'npm',
+    runtimes: 'node',
+    buildTime: new Date().toISOString(),
+    deploymentEnvironment: 'unknown',
+    vcs: 'git'
+  }
+}
+
+/**
+ * 根据平台返回匹配的默认值
+ * 避免将 Darwin 特征混入 Linux/Windows 配置
+ * @param {string} platform - 平台标识（darwin/linux/win32）
+ * @returns {Object} 平台相关的默认值
+ */
+function getPlatformDefaults(platform) {
+  const defaults = getDefaultProfile()
+
+  switch (platform) {
+    case 'linux':
+      return {
+        shell: 'bash',
+        osVersion: 'Linux 6.8.0',
+        workingDir: '/home/user/projects',
+        terminal: 'xterm-256color'
+      }
+    case 'win32':
+      return {
+        shell: 'powershell',
+        osVersion: 'Windows 10.0.22631',
+        workingDir: 'C:\\Users\\user\\projects',
+        terminal: 'Windows Terminal'
+      }
+    default:
+      // darwin 或其他 — 使用全局配置的默认值
+      return {
+        shell: defaults.shell,
+        osVersion: defaults.osVersion,
+        workingDir: defaults.workingDir,
+        terminal: defaults.terminal
+      }
+  }
+}
+
+/**
+ * 重写系统提示词
+ * 重写 Platform/Shell/OS/workingDir/homePaths + billing 指纹
+ * @param {Object} body - 请求体（会被修改）
+ * @param {Object} profile - 身份配置
+ */
+function rewriteSystemPrompt(body, profile) {
+  if (!body || typeof body !== 'object') {
+    return
+  }
+
+  const p = profile || getDefaultProfile()
+
+  // 处理 system 字段
+  if (body.system) {
+    if (typeof body.system === 'string') {
+      body.system = rewritePromptText(body.system, p)
+    } else if (Array.isArray(body.system)) {
+      body.system = body.system.map((item) => {
+        if (item && typeof item.text === 'string') {
+          return {
+            ...item,
+            text: rewritePromptText(item.text, p)
+          }
+        }
+        return item
+      })
+    }
+  }
+
+  // 注意：不重写 body.messages 中的路径
+  // 用户消息包含真实的文件路径，模型需要这些路径来正确调用工具（读/写文件）
+  // 重写会导致模型引用不存在的路径
+}
+
+/**
+ * 重写提示词文本
+ * 替换 Platform/Shell/OS/workingDir/billing 指纹
+ * @param {string} text - 原始文本
+ * @param {Object} profile - 身份配置
+ * @returns {string} 重写后的文本
+ */
+function rewritePromptText(text, profile) {
+  if (typeof text !== 'string') {
+    return text
+  }
+
+  const p = profile || getDefaultProfile()
+  let result = text
+
+  // 重写 billing header 指纹
+  result = result.replace(REGEX.billingFingerprint, `cc_version=${p.version}.000`)
+
+  // 重写 Platform
+  result = result.replace(REGEX.platform, `Platform: ${p.platform}`)
+
+  // 重写 Shell
+  result = result.replace(REGEX.shell, `Shell: ${p.shell}`)
+
+  // 重写 OS Version
+  result = result.replace(REGEX.osVersion, `OS Version: ${p.osVersion}`)
+
+  // 重写 Working directory
+  result = result.replace(REGEX.workingDir, `$1${p.workingDir}`)
+
+  // 重写 home 路径
+  result = rewriteHomePaths(result, p.workingDir)
+
+  return result
+}
+
+/**
+ * 重写 home 路径
+ * 将 /Users/xxx/ 或 /home/xxx/ 替换为规范路径
+ * @param {string} text - 原始文本
+ * @param {string} workingDir - 工作目录前缀
+ * @returns {string} 重写后的文本
+ */
+function rewriteHomePaths(text, workingDir) {
+  if (typeof text !== 'string') {
+    return text
+  }
+
+  // 提取工作目录的前缀（如 /Users/user/）
+  const prefix = workingDir || '/Users/user/'
+  const homePrefix = prefix.endsWith('/') ? prefix : `${prefix}/`
+
+  return text.replace(REGEX.homePath, homePrefix)
+}
+
+/**
+ * 剥离泄漏字段
+ * 删除可能暴露 relay/gateway 信息的字段
+ * @param {Object} body - 请求体（会被修改）
+ */
+function stripLeakFields(body) {
+  if (!body || typeof body !== 'object') {
+    return
+  }
+
+  delete body.baseUrl
+  delete body.base_url
+  delete body.gateway
+}
+
+/**
+ * 重写事件批量请求
+ * 重写 device_id, email, env, process，剥离泄漏字段
+ * @param {Object} body - 事件批量请求体
+ * @param {Object} profile - 身份配置
+ * @returns {Object} 重写后的请求体
+ */
+function rewriteEventBatch(body, profile) {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.events)) {
+    return body
+  }
+
+  const p = profile || getDefaultProfile()
+  const result = { ...body }
+
+  result.events = body.events.map((event) => {
+    if (!event || typeof event !== 'object' || !event.event_data) {
+      return event
+    }
+
+    const data = { ...event.event_data }
+
+    // 重写 identity 字段
+    if (data.device_id) {
+      data.device_id = generateDeviceId(p)
+    }
+    if (data.email) {
+      data.email = 'user@example.com' // 使用默认邮箱
+    }
+
+    // 重写环境对象（完全替换）
+    if (data.env && typeof data.env === 'object') {
+      data.env = buildCanonicalEnv(p)
+    }
+
+    // 重写 process 指标
+    if (data.process) {
+      data.process = buildCanonicalProcess(data.process, p)
+    }
+
+    // 剥离泄漏字段
+    stripLeakFields(data)
+
+    // 重写 additional_metadata
+    if (data.additional_metadata) {
+      data.additional_metadata = rewriteAdditionalMetadata(data.additional_metadata, p)
+    }
+
+    return {
+      ...event,
+      event_data: data
+    }
+  })
+
+  return result
+}
+
+/**
+ * 构建规范化环境对象
+ * @param {Object} profile - 身份配置
+ * @returns {Object} 规范化环境对象
+ */
+function buildCanonicalEnv(profile) {
+  const p = profile || getDefaultProfile()
+
+  return {
+    platform: p.platform,
+    platform_raw: p.platform,
+    arch: p.arch,
+    node_version: p.nodeVersion,
+    terminal: p.terminal,
+    package_managers: p.packageManagers || 'npm',
+    runtimes: p.runtimes || 'node',
+    is_running_with_bun: false,
+    is_ci: false, // 强制为 false
+    is_claubbit: false,
+    is_claude_code_remote: false,
+    is_local_agent_mode: false,
+    is_conductor: false,
+    is_github_action: false,
+    is_claude_code_action: false,
+    is_claude_ai_auth: true,
+    version: p.version,
+    version_base: p.version,
+    build_time: p.buildTime,
+    deployment_environment: p.deploymentEnvironment,
+    vcs: p.vcs
+  }
+}
+
+/**
+ * 构建规范化进程指标
+ * 支持对象或 base64 编码字符串
+ * @param {Object|string} original - 原始进程指标
+ * @param {Object} profile - 身份配置
+ * @returns {Object|string} 规范化进程指标
+ */
+function buildCanonicalProcess(original, profile) {
+  const p = profile || getDefaultProfile()
+
+  // 如果是 base64 字符串
+  if (typeof original === 'string') {
+    try {
+      const decoded = JSON.parse(Buffer.from(original, 'base64').toString())
+      const rewritten = rewriteProcessFields(decoded, p)
+      return Buffer.from(JSON.stringify(rewritten)).toString('base64')
+    } catch (error) {
+      logger.warn('⚠️ Failed to decode base64 process metrics:', error.message)
+      return original
+    }
+  }
+
+  // 如果是对象
+  if (original && typeof original === 'object') {
+    return rewriteProcessFields(original, p)
+  }
+
+  return original
+}
+
+/**
+ * 重写进程字段
+ * @param {Object} proc - 原始进程对象
+ * @param {Object} profile - 身份配置
+ * @returns {Object} 重写后的进程对象
+ */
+function rewriteProcessFields(proc, profile) {
+  const p = profile || getDefaultProfile()
+
+  return {
+    ...proc,
+    constrainedMemory: p.constrainedMemory,
+    rss: randomInRange(p.rssRange[0], p.rssRange[1]),
+    heapTotal: randomInRange(p.heapTotalRange[0], p.heapTotalRange[1]),
+    heapUsed: randomInRange(p.heapUsedRange[0], p.heapUsedRange[1])
+    // uptime 和 cpuUsage 保留原值（自然变化）
+  }
+}
+
+/**
+ * 重写 additional_metadata
+ * @param {string} b64 - base64 编码的元数据
+ * @param {Object} profile - 身份配置
+ * @returns {string} 重写后的 base64 编码
+ */
+function rewriteAdditionalMetadata(b64, _profile) {
+  if (typeof b64 !== 'string') {
+    return b64
+  }
+
+  try {
+    const decoded = JSON.parse(Buffer.from(b64, 'base64').toString())
+
+    // 剥离泄漏字段
+    stripLeakFields(decoded)
+
+    return Buffer.from(JSON.stringify(decoded)).toString('base64')
+  } catch (error) {
+    logger.warn('⚠️ Failed to rewrite additional_metadata:', error.message)
+    return b64
+  }
+}
+
+/**
+ * 生成设备 ID
+ * 基于配置生成确定性设备 ID（哈希）
+ * @param {Object} profile - 身份配置
+ * @returns {string} 64 字符十六进制设备 ID
+ */
+function generateDeviceId(profile) {
+  const p = profile || getDefaultProfile()
+  const crypto = require('crypto')
+
+  // 基于配置生成确定性哈希
+  const seed = `${p.platform}:${p.arch}:${p.nodeVersion}:${p.terminal}`
+  return crypto.createHash('sha256').update(seed).digest('hex')
+}
+
+/**
+ * 生成指定范围内的随机数
+ * @param {number} min - 最小值
+ * @param {number} max - 最大值
+ * @returns {number} 随机整数
+ */
+function randomInRange(min, max) {
+  return Math.floor(min + Math.random() * (max - min))
+}
+
+module.exports = {
+  getProfile,
+  seedProfile,
+  getDefaultProfile,
+  getPlatformDefaults,
+  rewriteSystemPrompt,
+  rewritePromptText,
+  rewriteHomePaths,
+  rewriteEventBatch,
+  buildCanonicalEnv,
+  buildCanonicalProcess,
+  rewriteProcessFields,
+  rewriteAdditionalMetadata,
+  stripLeakFields,
+  generateDeviceId,
+  REGEX
+}

--- a/src/services/identityRewriteService.js
+++ b/src/services/identityRewriteService.js
@@ -252,6 +252,26 @@ function rewriteHomePaths(text, workingDir) {
 }
 
 /**
+ * 重写通用身份字段
+ * 用于 /policy_limits、/settings 等非消息路径
+ * 防止 device_id 和 email 通过旁路泄漏
+ * @param {Object} body - 请求体（会被修改）
+ * @param {Object} profile - 身份配置
+ */
+function rewriteGenericIdentity(body, profile) {
+  if (!body || typeof body !== 'object') {
+    return
+  }
+
+  if (body.device_id) {
+    body.device_id = generateDeviceId(profile || getDefaultProfile())
+  }
+  if (body.email) {
+    body.email = 'user@example.com'
+  }
+}
+
+/**
  * 剥离泄漏字段
  * 删除可能暴露 relay/gateway 信息的字段
  * @param {Object} body - 请求体（会被修改）
@@ -462,6 +482,7 @@ module.exports = {
   rewriteSystemPrompt,
   rewritePromptText,
   rewriteHomePaths,
+  rewriteGenericIdentity,
   rewriteEventBatch,
   buildCanonicalEnv,
   buildCanonicalProcess,

--- a/src/services/identityRewriteService.js
+++ b/src/services/identityRewriteService.js
@@ -257,17 +257,18 @@ function rewriteHomePaths(text, workingDir) {
  * 防止 device_id 和 email 通过旁路泄漏
  * @param {Object} body - 请求体（会被修改）
  * @param {Object} profile - 身份配置
+ * @param {string} [accountId] - 账户 ID（用于生成唯一 device_id/email）
  */
-function rewriteGenericIdentity(body, profile) {
+function rewriteGenericIdentity(body, profile, accountId) {
   if (!body || typeof body !== 'object') {
     return
   }
 
   if (body.device_id) {
-    body.device_id = generateDeviceId(profile || getDefaultProfile())
+    body.device_id = generateDeviceId(profile || getDefaultProfile(), accountId)
   }
   if (body.email) {
-    body.email = 'user@example.com'
+    body.email = generateEmail(accountId)
   }
 }
 
@@ -293,7 +294,7 @@ function stripLeakFields(body) {
  * @param {Object} profile - 身份配置
  * @returns {Object} 重写后的请求体
  */
-function rewriteEventBatch(body, profile) {
+function rewriteEventBatch(body, profile, accountId) {
   if (!body || typeof body !== 'object' || !Array.isArray(body.events)) {
     return body
   }
@@ -308,12 +309,12 @@ function rewriteEventBatch(body, profile) {
 
     const data = { ...event.event_data }
 
-    // 重写 identity 字段
+    // 重写 identity 字段（per-account 唯一）
     if (data.device_id) {
-      data.device_id = generateDeviceId(p)
+      data.device_id = generateDeviceId(p, accountId)
     }
     if (data.email) {
-      data.email = 'user@example.com' // 使用默认邮箱
+      data.email = generateEmail(accountId)
     }
 
     // 重写环境对象（完全替换）
@@ -451,17 +452,35 @@ function rewriteAdditionalMetadata(b64, _profile) {
 
 /**
  * 生成设备 ID
- * 基于配置生成确定性设备 ID（哈希）
+ * 基于 accountId + 配置生成确定性设备 ID（哈希）
+ * 每个账户会得到唯一的 device_id，避免多账户共享同一设备指纹
  * @param {Object} profile - 身份配置
+ * @param {string} [accountId] - 账户 ID（用于区分不同账户）
  * @returns {string} 64 字符十六进制设备 ID
  */
-function generateDeviceId(profile) {
+function generateDeviceId(profile, accountId) {
   const p = profile || getDefaultProfile()
   const crypto = require('crypto')
 
-  // 基于配置生成确定性哈希
-  const seed = `${p.platform}:${p.arch}:${p.nodeVersion}:${p.terminal}`
+  // accountId 混入 seed，确保每个账户的 device_id 唯一
+  const seed = `${accountId || 'default'}:${p.platform}:${p.arch}:${p.nodeVersion}:${p.terminal}`
   return crypto.createHash('sha256').update(seed).digest('hex')
+}
+
+/**
+ * 生成账户级伪邮箱
+ * 基于 accountId 生成确定性的伪邮箱，避免所有账户共享同一邮箱
+ * @param {string} [accountId] - 账户 ID
+ * @returns {string} 伪邮箱地址
+ */
+function generateEmail(accountId) {
+  if (!accountId) {
+    return 'user@example.com'
+  }
+
+  const crypto = require('crypto')
+  const hash = crypto.createHash('sha256').update(String(accountId)).digest('hex').slice(0, 8)
+  return `user-${hash}@example.com`
 }
 
 /**
@@ -490,5 +509,6 @@ module.exports = {
   rewriteAdditionalMetadata,
   stripLeakFields,
   generateDeviceId,
+  generateEmail,
   REGEX
 }

--- a/src/services/identityRewriteService.js
+++ b/src/services/identityRewriteService.js
@@ -167,7 +167,7 @@ function getPlatformDefaults(platform) {
  * @param {Object} body - 请求体（会被修改）
  * @param {Object} profile - 身份配置
  */
-function rewriteSystemPrompt(body, profile) {
+function rewriteSystemPrompt(body, profile, accountId) {
   if (!body || typeof body !== 'object') {
     return
   }
@@ -177,13 +177,13 @@ function rewriteSystemPrompt(body, profile) {
   // 处理 system 字段
   if (body.system) {
     if (typeof body.system === 'string') {
-      body.system = rewritePromptText(body.system, p)
+      body.system = rewritePromptText(body.system, p, accountId)
     } else if (Array.isArray(body.system)) {
       body.system = body.system.map((item) => {
         if (item && typeof item.text === 'string') {
           return {
             ...item,
-            text: rewritePromptText(item.text, p)
+            text: rewritePromptText(item.text, p, accountId)
           }
         }
         return item
@@ -203,16 +203,17 @@ function rewriteSystemPrompt(body, profile) {
  * @param {Object} profile - 身份配置
  * @returns {string} 重写后的文本
  */
-function rewritePromptText(text, profile) {
+function rewritePromptText(text, profile, accountId) {
   if (typeof text !== 'string') {
     return text
   }
 
   const p = profile || getDefaultProfile()
+  const suffix = generateVersionSuffix(accountId)
   let result = text
 
-  // 重写 billing header 指纹
-  result = result.replace(REGEX.billingFingerprint, `cc_version=${p.version}.000`)
+  // 重写 billing header 指纹（per-account 后缀）
+  result = result.replace(REGEX.billingFingerprint, `cc_version=${p.version}.${suffix}`)
 
   // 重写 Platform
   result = result.replace(REGEX.platform, `Platform: ${p.platform}`)
@@ -451,6 +452,21 @@ function rewriteAdditionalMetadata(b64, _profile) {
 }
 
 /**
+ * 生成 per-account 的 billing 版本后缀
+ * 替代硬编码的 .000，避免所有账户共享同一后缀
+ * @param {string} [accountId] - 账户 ID
+ * @returns {string} 3 字符十六进制后缀
+ */
+function generateVersionSuffix(accountId) {
+  if (!accountId) {
+    return '000'
+  }
+
+  const crypto = require('crypto')
+  return crypto.createHash('sha256').update(String(accountId)).digest('hex').slice(0, 3)
+}
+
+/**
  * 生成设备 ID
  * 基于 accountId + 配置生成确定性设备 ID（哈希）
  * 每个账户会得到唯一的 device_id，避免多账户共享同一设备指纹
@@ -510,5 +526,6 @@ module.exports = {
   stripLeakFields,
   generateDeviceId,
   generateEmail,
+  generateVersionSuffix,
   REGEX
 }

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -1285,23 +1285,25 @@ class ClaudeRelayService {
   }
 
   // 📡 转发遥测事件（经过身份重写）
-  async forwardEventBatch(body, clientHeaders) {
+  async forwardEventBatch(body, clientHeaders, boundAccountId) {
     const identityRewriteConfig = config.identityRewrite
     if (!identityRewriteConfig?.enabled || !identityRewriteConfig?.forwardEventBatch) {
       return { dropped: true }
     }
 
+    // 必须有绑定的账户 ID，不使用随机账户（防止跨账户遥测污染）
+    if (!boundAccountId) {
+      logger.debug('📡 No bound account for telemetry, dropping')
+      return { dropped: true }
+    }
+
     try {
-      // 获取一个可用账户（遥测不需要粘性会话，随机选一个）
-      const allAccounts = await redis.getAllClaudeAccounts()
-      const activeAccounts = allAccounts.filter((a) => a.status === 'active')
-      if (activeAccounts.length === 0) {
-        logger.debug('📡 No active accounts for telemetry forwarding')
+      const accountId = boundAccountId
+      const account = await claudeAccountService.getAccount(accountId)
+      if (!account || account.status !== 'active') {
+        logger.debug('📡 Bound account not active for telemetry forwarding')
         return { dropped: true }
       }
-
-      const account = activeAccounts[Math.floor(Math.random() * activeAccounts.length)]
-      const accountId = account.id
       const accessToken = await claudeAccountService.getValidAccessToken(accountId)
       if (!accessToken) {
         return { dropped: true }
@@ -1606,37 +1608,43 @@ class ClaudeRelayService {
     }
 
     // 处理 billing header：启用身份重写时重写指纹，否则剥离
-    if (finalHeaders['x-anthropic-billing-header']) {
+    // 大小写不敏感查找，防止 X-Anthropic-Billing-Header 等变体绕过
+    const billingHeaderKey = Object.keys(finalHeaders).find(
+      (k) => k.toLowerCase() === 'x-anthropic-billing-header'
+    )
+    if (billingHeaderKey) {
       if (identityRewriteConfig?.enabled) {
         try {
           const profile = await identityRewriteService.getProfile(account?.id)
           const versionSuffix = identityRewriteService.generateVersionSuffix(account?.id)
-          finalHeaders['x-anthropic-billing-header'] = finalHeaders[
-            'x-anthropic-billing-header'
-          ].replace(
+          finalHeaders[billingHeaderKey] = finalHeaders[billingHeaderKey].replace(
             /cc_version=[\d.]+\.[a-f0-9]{3}/g,
             `cc_version=${profile.version}.${versionSuffix}`
           )
           logger.debug('✅ Rewrote billing header fingerprint')
         } catch (err) {
           logger.warn('⚠️ Failed to rewrite billing header:', err.message)
-          delete finalHeaders['x-anthropic-billing-header']
+          delete finalHeaders[billingHeaderKey]
         }
       } else {
-        delete finalHeaders['x-anthropic-billing-header']
+        delete finalHeaders[billingHeaderKey]
       }
     }
 
     // 应用请求身份转换
-    const extensionResult = this._applyRequestIdentityTransform(requestPayload, finalHeaders, {
-      account,
-      accountId,
-      accountType,
-      sessionHash,
-      clientHeaders,
-      requestOptions,
-      isStream
-    })
+    const extensionResult = await this._applyRequestIdentityTransform(
+      requestPayload,
+      finalHeaders,
+      {
+        account,
+        accountId,
+        accountType,
+        sessionHash,
+        clientHeaders,
+        requestOptions,
+        isStream
+      }
+    )
 
     if (extensionResult.abortResponse) {
       return { abortResponse: extensionResult.abortResponse }
@@ -1699,7 +1707,7 @@ class ClaudeRelayService {
     }
   }
 
-  _applyRequestIdentityTransform(body, headers, context = {}) {
+  async _applyRequestIdentityTransform(body, headers, context = {}) {
     const normalizedHeaders = headers && typeof headers === 'object' ? { ...headers } : {}
 
     try {
@@ -1709,7 +1717,7 @@ class ClaudeRelayService {
         ...context
       }
 
-      const result = requestIdentityService.transform(payload)
+      const result = await requestIdentityService.transform(payload)
       if (!result || typeof result !== 'object') {
         return { body, headers: normalizedHeaders }
       }

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -13,6 +13,7 @@ const redis = require('../../models/redis')
 const ClaudeCodeValidator = require('../../validators/clients/claudeCodeValidator')
 const { formatDateWithTimezone } = require('../../utils/dateHelper')
 const requestIdentityService = require('../requestIdentityService')
+const identityRewriteService = require('../identityRewriteService')
 const { createClaudeTestPayload } = require('../../utils/testPayloadHelper')
 const userMessageQueueService = require('../userMessageQueueService')
 const { isStreamWritable } = require('../../utils/streamHelper')
@@ -569,7 +570,7 @@ class ClaudeRelayService {
       const accessToken = await claudeAccountService.getValidAccessToken(accountId)
 
       const isRealClaudeCodeRequest = this._isActualClaudeCodeRequest(requestBody, clientHeaders)
-      const processedBody = this._processRequestBody(requestBody, account)
+      const processedBody = await this._processRequestBody(requestBody, account)
       // 🧹 内存优化：存储到 bodyStore，避免闭包捕获
       const originalBodyString = JSON.stringify(processedBody)
       bodyStoreIdNonStream = ++this._bodyStoreIdCounter
@@ -1072,7 +1073,7 @@ class ClaudeRelayService {
   }
 
   // 🔄 处理请求体
-  _processRequestBody(body, account = null) {
+  async _processRequestBody(body, account = null) {
     if (!body) {
       return body
     }
@@ -1139,8 +1140,22 @@ class ClaudeRelayService {
       }
     }
 
-    // 移除 x-anthropic-billing-header 系统元素，避免将客户端 billing 标识传递给上游 API
-    this._removeBillingHeaderFromSystem(processedBody)
+    // 处理 billing header：如果身份重写启用则重写，否则剥离
+    const identityRewriteConfig = config.identityRewrite
+    if (identityRewriteConfig?.enabled && account) {
+      try {
+        const profile = await identityRewriteService.getProfile(account.id)
+        identityRewriteService.rewriteSystemPrompt(processedBody, profile)
+        logger.debug('✅ Rewrote system prompt with identity profile')
+      } catch (err) {
+        logger.warn('⚠️ Failed to rewrite system prompt:', err.message)
+        // 失败时回退到剥离
+        this._removeBillingHeaderFromSystem(processedBody)
+      }
+    } else {
+      // 移除 x-anthropic-billing-header 系统元素，避免将客户端 billing 标识传递给上游 API
+      this._removeBillingHeaderFromSystem(processedBody)
+    }
 
     this._enforceCacheControlLimit(processedBody)
 
@@ -1238,6 +1253,35 @@ class ClaudeRelayService {
         )
       }
     }
+  }
+
+  // 🔍 从请求中捕获环境信息（用于播种身份配置）
+  _captureEnvFromRequest(body, clientHeaders) {
+    const env = {}
+
+    // 从 headers 提取信息
+    if (clientHeaders) {
+      const ua = clientHeaders['user-agent'] || clientHeaders['User-Agent']
+      if (ua) {
+        const versionMatch = ua.match(/claude-cli\/([\d.]+)/)
+        if (versionMatch) {
+          env.version = versionMatch[1]
+        }
+      }
+
+      // 从 Stainless headers 提取
+      env.platform = clientHeaders['x-stainless-os'] || 'darwin'
+      env.arch = clientHeaders['x-stainless-arch'] || 'arm64'
+      env.nodeVersion = clientHeaders['x-stainless-runtime-version'] || 'v24.3.0'
+    }
+
+    // 从 body 提取信息（如果存在）
+    if (body && body.metadata && body.metadata.user_id) {
+      // 这里可以解析 user_id 获取更多信息
+      // 但目前主要依赖 headers
+    }
+
+    return env
   }
 
   // 🔢 验证并限制max_tokens参数
@@ -1481,6 +1525,32 @@ class ClaudeRelayService {
       Object.keys(claudeCodeHeaders).forEach((key) => {
         finalHeaders[key] = claudeCodeHeaders[key]
       })
+    }
+
+    // 如果是真实的 Claude Code 请求且身份重写启用，播种身份配置
+    const identityRewriteConfig = config.identityRewrite
+    if (isRealClaudeCode && identityRewriteConfig?.enabled && account) {
+      // 从请求中捕获环境信息用于播种
+      const capturedEnv = this._captureEnvFromRequest(body, clientHeaders)
+      await identityRewriteService.seedProfile(account.id, capturedEnv)
+    }
+
+    // 处理 billing header：启用身份重写时重写指纹，否则剥离
+    if (finalHeaders['x-anthropic-billing-header']) {
+      if (identityRewriteConfig?.enabled) {
+        try {
+          const profile = await identityRewriteService.getProfile(account?.id)
+          finalHeaders['x-anthropic-billing-header'] = finalHeaders[
+            'x-anthropic-billing-header'
+          ].replace(/cc_version=[\d.]+\.[a-f0-9]{3}/g, `cc_version=${profile.version}.000`)
+          logger.debug('✅ Rewrote billing header fingerprint')
+        } catch (err) {
+          logger.warn('⚠️ Failed to rewrite billing header:', err.message)
+          delete finalHeaders['x-anthropic-billing-header']
+        }
+      } else {
+        delete finalHeaders['x-anthropic-billing-header']
+      }
     }
 
     // 应用请求身份转换
@@ -1919,7 +1989,7 @@ class ClaudeRelayService {
       const accessToken = await claudeAccountService.getValidAccessToken(accountId)
 
       const isRealClaudeCodeRequest = this._isActualClaudeCodeRequest(requestBody, clientHeaders)
-      const processedBody = this._processRequestBody(requestBody, account)
+      const processedBody = await this._processRequestBody(requestBody, account)
       // 🧹 内存优化：存储到 bodyStore，不放入 requestOptions 避免闭包捕获
       const originalBodyString = JSON.stringify(processedBody)
       const bodyStoreId = ++this._bodyStoreIdCounter

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -1307,9 +1307,9 @@ class ClaudeRelayService {
         return { dropped: true }
       }
 
-      // 重写事件体
+      // 重写事件体（传入 accountId 确保 device_id/email 按账户唯一）
       const profile = await identityRewriteService.getProfile(accountId)
-      const rewrittenBody = identityRewriteService.rewriteEventBatch(body, profile)
+      const rewrittenBody = identityRewriteService.rewriteEventBatch(body, profile, accountId)
 
       // 获取代理
       const proxyAgent = await this._getProxyAgent(accountId)

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -1284,6 +1284,76 @@ class ClaudeRelayService {
     return env
   }
 
+  // 📡 转发遥测事件（经过身份重写）
+  async forwardEventBatch(body, clientHeaders) {
+    const identityRewriteConfig = config.identityRewrite
+    if (!identityRewriteConfig?.enabled || !identityRewriteConfig?.forwardEventBatch) {
+      return { dropped: true }
+    }
+
+    try {
+      // 获取一个可用账户（遥测不需要粘性会话，随机选一个）
+      const allAccounts = await redis.getAllClaudeAccounts()
+      const activeAccounts = allAccounts.filter((a) => a.status === 'active')
+      if (activeAccounts.length === 0) {
+        logger.debug('📡 No active accounts for telemetry forwarding')
+        return { dropped: true }
+      }
+
+      const account = activeAccounts[Math.floor(Math.random() * activeAccounts.length)]
+      const accountId = account.id
+      const accessToken = await claudeAccountService.getValidAccessToken(accountId)
+      if (!accessToken) {
+        return { dropped: true }
+      }
+
+      // 重写事件体
+      const profile = await identityRewriteService.getProfile(accountId)
+      const rewrittenBody = identityRewriteService.rewriteEventBatch(body, profile)
+
+      // 获取代理
+      const proxyAgent = await this._getProxyAgent(accountId)
+
+      // 火忘式转发到上游
+      const bodyString = JSON.stringify(rewrittenBody)
+      const options = {
+        hostname: 'api.anthropic.com',
+        port: 443,
+        path: '/api/event_logging/batch',
+        method: 'POST',
+        headers: {
+          host: 'api.anthropic.com',
+          'content-type': 'application/json',
+          'content-length': String(Buffer.byteLength(bodyString)),
+          authorization: `Bearer ${accessToken}`,
+          'User-Agent':
+            (await this.captureAndGetUnifiedUserAgent(clientHeaders)) ||
+            'claude-cli/1.0.119 (external, cli)'
+        },
+        agent: proxyAgent || getHttpsAgentForNonStream(),
+        timeout: 10000
+      }
+
+      const req = https.request(options, (res) => {
+        // 消费响应避免内存泄漏
+        res.resume()
+        logger.debug(`📡 Telemetry forwarded: ${res.statusCode}`)
+      })
+
+      req.on('error', (err) => {
+        logger.debug(`📡 Telemetry forward failed (non-critical): ${err.message}`)
+      })
+
+      req.write(bodyString)
+      req.end()
+
+      return { forwarded: true }
+    } catch (error) {
+      logger.debug(`📡 Telemetry forward error (non-critical): ${error.message}`)
+      return { dropped: true }
+    }
+  }
+
   // 🔢 验证并限制max_tokens参数
   _validateAndLimitMaxTokens(body) {
     if (!body || !body.max_tokens) {

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -1145,7 +1145,7 @@ class ClaudeRelayService {
     if (identityRewriteConfig?.enabled && account) {
       try {
         const profile = await identityRewriteService.getProfile(account.id)
-        identityRewriteService.rewriteSystemPrompt(processedBody, profile)
+        identityRewriteService.rewriteSystemPrompt(processedBody, profile, account.id)
         logger.debug('✅ Rewrote system prompt with identity profile')
       } catch (err) {
         logger.warn('⚠️ Failed to rewrite system prompt:', err.message)
@@ -1327,7 +1327,7 @@ class ClaudeRelayService {
           'content-length': String(Buffer.byteLength(bodyString)),
           authorization: `Bearer ${accessToken}`,
           'User-Agent':
-            (await this.captureAndGetUnifiedUserAgent(clientHeaders)) ||
+            (await this.captureAndGetUnifiedUserAgent(clientHeaders, account)) ||
             'claude-cli/1.0.119 (external, cli)'
         },
         agent: proxyAgent || getHttpsAgentForNonStream(),
@@ -1610,9 +1610,13 @@ class ClaudeRelayService {
       if (identityRewriteConfig?.enabled) {
         try {
           const profile = await identityRewriteService.getProfile(account?.id)
+          const versionSuffix = identityRewriteService.generateVersionSuffix(account?.id)
           finalHeaders['x-anthropic-billing-header'] = finalHeaders[
             'x-anthropic-billing-header'
-          ].replace(/cc_version=[\d.]+\.[a-f0-9]{3}/g, `cc_version=${profile.version}.000`)
+          ].replace(
+            /cc_version=[\d.]+\.[a-f0-9]{3}/g,
+            `cc_version=${profile.version}.${versionSuffix}`
+          )
           logger.debug('✅ Rewrote billing header fingerprint')
         } catch (err) {
           logger.warn('⚠️ Failed to rewrite billing header:', err.message)
@@ -3230,11 +3234,13 @@ class ClaudeRelayService {
 
   // 🔧 动态捕获并获取统一的 User-Agent
   async captureAndGetUnifiedUserAgent(clientHeaders, account) {
-    if (account.useUnifiedUserAgent !== 'true') {
+    if (!account || account.useUnifiedUserAgent !== 'true') {
       return null
     }
 
-    const CACHE_KEY = 'claude_code_user_agent:daily'
+    // per-account 缓存，避免多账户共享同一 User-Agent
+    const accountId = account.id || account.accountId || 'global'
+    const CACHE_KEY = `claude_code_user_agent:daily:${accountId}`
     const TTL = 90000 // 25小时
 
     // ⚠️ 重要：这里通过正则表达式判断是否为 Claude Code 客户端

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -1309,9 +1309,17 @@ class ClaudeRelayService {
         return { dropped: true }
       }
 
-      // 重写事件体（传入 accountId 确保 device_id/email 按账户唯一）
-      const profile = await identityRewriteService.getProfile(accountId)
-      const rewrittenBody = identityRewriteService.rewriteEventBatch(body, profile, accountId)
+      // 重写事件体（传入 accountId 确保 device_id 按账户唯一，email 用真实邮箱）
+      const [profile, accountEmail] = await Promise.all([
+        identityRewriteService.getProfile(accountId),
+        claudeAccountService.getAccountEmail(accountId)
+      ])
+      const rewrittenBody = identityRewriteService.rewriteEventBatch(
+        body,
+        profile,
+        accountId,
+        accountEmail
+      )
 
       // 获取代理
       const proxyAgent = await this._getProxyAgent(accountId)

--- a/src/services/requestIdentityService.js
+++ b/src/services/requestIdentityService.js
@@ -372,6 +372,13 @@ function transform(payload = {}) {
   const { nextBody } = rewriteUserId(currentBody, payload.accountId, accountUuid)
   const headerResult = rewriteHeaders(currentHeaders, accountIdForHeaders)
 
+  // 剥离可能暴露 relay/gateway 信息的泄漏字段（纵深防御）
+  if (nextBody && typeof nextBody === 'object') {
+    delete nextBody.baseUrl
+    delete nextBody.base_url
+    delete nextBody.gateway
+  }
+
   const nextHeaders = headerResult ? headerResult.nextHeaders : currentHeaders
   const abortResponse =
     headerResult && headerResult.abortResponse ? headerResult.abortResponse : null

--- a/src/services/requestIdentityService.js
+++ b/src/services/requestIdentityService.js
@@ -325,12 +325,15 @@ function rewriteUserId(body, accountId, accountUuid) {
   const effectiveScheduler = accountId ? String(accountId) : 'unknown-scheduler'
   const hashedSession = formatUuidFromSeed(`${effectiveScheduler}::${seedTail}`)
 
+  // 哈希 deviceId（per-account 唯一，避免多账户共享同一 device_id）
+  const hashedDeviceId = formatUuidFromSeed(`${effectiveScheduler}::device::${parsed.deviceId}`)
+
   // 注入真实 accountUuid
   const effectiveUuid = normalizeAccountUuid(accountUuid) || parsed.accountUuid || ''
 
   // 以原格式重建
   const nextUserId = metadataUserIdHelper.build({
-    deviceId: parsed.deviceId,
+    deviceId: hashedDeviceId,
     accountUuid: effectiveUuid,
     sessionId: hashedSession,
     isJsonFormat: parsed.isJsonFormat

--- a/src/services/requestIdentityService.js
+++ b/src/services/requestIdentityService.js
@@ -153,24 +153,6 @@ function applyFingerprintToHeaders(headers, fingerprint) {
   return nextHeaders
 }
 
-function persistFingerprint(accountId, fingerprint) {
-  if (!accountId || !hasFingerprintValues(fingerprint)) {
-    return
-  }
-
-  const client = getRedisClient()
-  const key = `${REDIS_KEY_PREFIX}${accountId}`
-  const serialized = JSON.stringify(fingerprint)
-
-  const command = client.set(key, serialized, 'NX')
-
-  if (command && typeof command.catch === 'function') {
-    command.catch((error) => {
-      logger.error(`requestIdentityService: Redis 持久化指纹失败 (${accountId}): ${error.message}`)
-    })
-  }
-}
-
 function getHeaderValueCaseInsensitive(headers, key) {
   if (!headers || typeof headers !== 'object') {
     return undefined
@@ -232,7 +214,7 @@ function resolveAccountId(payload) {
   return null
 }
 
-function rewriteHeaders(headers, accountId) {
+async function rewriteHeaders(headers, accountId) {
   if (!headers || typeof headers !== 'object') {
     return { nextHeaders: headers, changed: false }
   }
@@ -242,8 +224,8 @@ function rewriteHeaders(headers, accountId) {
   }
 
   const workingHeaders = { ...headers }
-  const fingerprint = collectFingerprintFromHeaders(workingHeaders)
-  const fieldCount = Object.keys(fingerprint).length
+  const incomingFingerprint = collectFingerprintFromHeaders(workingHeaders)
+  const fieldCount = Object.keys(incomingFingerprint).length
 
   if (fieldCount < MIN_FINGERPRINT_FIELDS) {
     logger.warn(
@@ -252,20 +234,31 @@ function rewriteHeaders(headers, accountId) {
     return { nextHeaders: workingHeaders, changed: false }
   }
 
+  // 先读缓存：确保同一账户始终使用相同的 stainless 指纹
+  let effectiveFingerprint = incomingFingerprint
   try {
-    persistFingerprint(accountId, fingerprint)
-  } catch (error) {
-    logger.error(`requestIdentityService: 持久化指纹失败 (${accountId}): ${error.message}`)
-    return {
-      abortResponse: {
-        statusCode: 500,
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ error: 'fingerprint_persist_failed', message: '指纹信息持久化失败' })
+    const client = getRedisClient()
+    const key = `${REDIS_KEY_PREFIX}${accountId}`
+    const cached = await client.get(key)
+
+    if (cached) {
+      // 缓存存在，使用缓存的指纹（忽略当前请求的值）
+      effectiveFingerprint = JSON.parse(cached)
+    } else {
+      // 缓存不存在，用当前请求的指纹播种
+      await client.set(key, JSON.stringify(incomingFingerprint), 'NX')
+      // 再读一次确认（防止并发竞争）
+      const confirmed = await client.get(key)
+      if (confirmed) {
+        effectiveFingerprint = JSON.parse(confirmed)
       }
     }
+  } catch (error) {
+    logger.error(`requestIdentityService: 指纹缓存操作失败 (${accountId}): ${error.message}`)
+    // 失败时使用当前请求的指纹（降级处理）
   }
 
-  const appliedHeaders = applyFingerprintToHeaders(workingHeaders, fingerprint)
+  const appliedHeaders = applyFingerprintToHeaders(workingHeaders, effectiveFingerprint)
   const changed = headersChanged(workingHeaders, appliedHeaders)
 
   return { nextHeaders: appliedHeaders, changed }
@@ -325,8 +318,9 @@ function rewriteUserId(body, accountId, accountUuid) {
   const effectiveScheduler = accountId ? String(accountId) : 'unknown-scheduler'
   const hashedSession = formatUuidFromSeed(`${effectiveScheduler}::${seedTail}`)
 
-  // 哈希 deviceId（per-account 唯一，避免多账户共享同一 device_id）
-  const hashedDeviceId = formatUuidFromSeed(`${effectiveScheduler}::device::${parsed.deviceId}`)
+  // deviceId 纯粹由 accountId 决定，不依赖客户端输入
+  // 确保同一账户无论哪个客户端连接，都产生相同的 device_id
+  const hashedDeviceId = formatUuidFromSeed(`${effectiveScheduler}::device`)
 
   // 注入真实 accountUuid
   const effectiveUuid = normalizeAccountUuid(accountUuid) || parsed.accountUuid || ''
@@ -358,7 +352,7 @@ function rewriteUserId(body, accountId, accountUuid) {
  * @param {Object} payload.account - 账户对象
  * @returns {Object} 转换后的 { body, headers, abortResponse? }
  */
-function transform(payload = {}) {
+async function transform(payload = {}) {
   const currentBody = payload.body
   const currentHeaders = payload.headers
 
@@ -373,7 +367,7 @@ function transform(payload = {}) {
   const accountIdForHeaders = resolveAccountId(payload)
 
   const { nextBody } = rewriteUserId(currentBody, payload.accountId, accountUuid)
-  const headerResult = rewriteHeaders(currentHeaders, accountIdForHeaders)
+  const headerResult = await rewriteHeaders(currentHeaders, accountIdForHeaders)
 
   // 剥离可能暴露 relay/gateway 信息的泄漏字段（纵深防御）
   if (nextBody && typeof nextBody === 'object') {

--- a/src/utils/headerFilter.js
+++ b/src/utils/headerFilter.js
@@ -73,6 +73,7 @@ function filterForClaude(headers) {
     'anthropic-beta',
     'accept-language',
     'sec-fetch-mode',
+    'x-anthropic-billing-header', // 身份重写需要的 billing header
     // 注意：不透传 accept-encoding，避免客户端发送的 zstd 等 Node.js 不支持的编码
     // 被转发到上游，导致 axios 无法解压响应（Node 18 zlib 不支持 zstd）
     'user-agent',

--- a/src/utils/upstreamErrorHelper.js
+++ b/src/utils/upstreamErrorHelper.js
@@ -163,7 +163,20 @@ const classifyError = (statusCode) => {
 }
 
 // 解析 429 响应头中的重置时间（返回秒数）
-const parseRetryAfter = (headers) => {
+const parseRetryAfter = (headers, responseBody) => {
+  // Google Code Assist API 在 body 里返回 reset 时间
+  // e.g. "Your quota will reset after 10s."
+  if (responseBody) {
+    const msg = typeof responseBody === 'string' ? responseBody : responseBody?.error?.message || ''
+    const match = msg.match(/reset after (\d+)s/i)
+    if (match) {
+      const seconds = parseInt(match[1], 10)
+      if (seconds > 0) {
+        return seconds
+      }
+    }
+  }
+
   if (!headers) {
     return null
   }

--- a/tests/identityRewriteService.test.js
+++ b/tests/identityRewriteService.test.js
@@ -265,7 +265,7 @@ describe('Identity Rewrite Service', () => {
   })
 
   describe('rewriteEventBatch', () => {
-    it('should rewrite device_id and email in events', () => {
+    it('should rewrite device_id and email per-account', () => {
       const body = {
         events: [
           {
@@ -277,10 +277,23 @@ describe('Identity Rewrite Service', () => {
         ]
       }
 
-      const result = identityRewriteService.rewriteEventBatch(body, defaultProfile)
+      const result = identityRewriteService.rewriteEventBatch(body, defaultProfile, 'account-1')
 
       expect(result.events[0].event_data.device_id).not.toBe('original-device-id')
-      expect(result.events[0].event_data.email).toBe('user@example.com')
+      expect(result.events[0].event_data.email).toContain('@example.com')
+      expect(result.events[0].event_data.email).not.toBe('original@example.com')
+    })
+
+    it('should generate different device_id/email for different accounts', () => {
+      const makeBody = () => ({
+        events: [{ event_data: { device_id: 'orig', email: 'orig@test.com' } }]
+      })
+
+      const r1 = identityRewriteService.rewriteEventBatch(makeBody(), defaultProfile, 'account-1')
+      const r2 = identityRewriteService.rewriteEventBatch(makeBody(), defaultProfile, 'account-2')
+
+      expect(r1.events[0].event_data.device_id).not.toBe(r2.events[0].event_data.device_id)
+      expect(r1.events[0].event_data.email).not.toBe(r2.events[0].event_data.email)
     })
 
     it('should replace env object entirely', () => {
@@ -358,19 +371,31 @@ describe('Identity Rewrite Service', () => {
   })
 
   describe('rewriteGenericIdentity', () => {
-    it('should rewrite device_id and email', () => {
+    it('should rewrite device_id and email per-account', () => {
       const body = {
         device_id: 'real-device-id',
         email: 'realuser@company.com',
         other_field: 'should remain'
       }
 
-      identityRewriteService.rewriteGenericIdentity(body, defaultProfile)
+      identityRewriteService.rewriteGenericIdentity(body, defaultProfile, 'account-1')
 
       expect(body.device_id).not.toBe('real-device-id')
       expect(body.device_id).toHaveLength(64) // sha256 hex
-      expect(body.email).toBe('user@example.com')
+      expect(body.email).toContain('@example.com')
+      expect(body.email).not.toBe('realuser@company.com')
       expect(body.other_field).toBe('should remain')
+    })
+
+    it('should generate different identities for different accounts', () => {
+      const body1 = { device_id: 'orig', email: 'orig@test.com' }
+      const body2 = { device_id: 'orig', email: 'orig@test.com' }
+
+      identityRewriteService.rewriteGenericIdentity(body1, defaultProfile, 'account-1')
+      identityRewriteService.rewriteGenericIdentity(body2, defaultProfile, 'account-2')
+
+      expect(body1.device_id).not.toBe(body2.device_id)
+      expect(body1.email).not.toBe(body2.email)
     })
 
     it('should skip fields that do not exist', () => {
@@ -394,22 +419,51 @@ describe('Identity Rewrite Service', () => {
   })
 
   describe('generateDeviceId', () => {
-    it('should generate deterministic device ID for same profile', () => {
-      const id1 = identityRewriteService.generateDeviceId(defaultProfile)
-      const id2 = identityRewriteService.generateDeviceId(defaultProfile)
+    it('should generate deterministic device ID for same profile and account', () => {
+      const id1 = identityRewriteService.generateDeviceId(defaultProfile, 'account-1')
+      const id2 = identityRewriteService.generateDeviceId(defaultProfile, 'account-1')
 
       expect(id1).toBe(id2)
       expect(id1).toHaveLength(64) // sha256 hex
+    })
+
+    it('should generate different IDs for different accounts with same profile', () => {
+      const id1 = identityRewriteService.generateDeviceId(defaultProfile, 'account-1')
+      const id2 = identityRewriteService.generateDeviceId(defaultProfile, 'account-2')
+
+      expect(id1).not.toBe(id2)
     })
 
     it('should generate different IDs for different profiles', () => {
       const profile1 = { ...defaultProfile, platform: 'darwin' }
       const profile2 = { ...defaultProfile, platform: 'linux' }
 
-      const id1 = identityRewriteService.generateDeviceId(profile1)
-      const id2 = identityRewriteService.generateDeviceId(profile2)
+      const id1 = identityRewriteService.generateDeviceId(profile1, 'account-1')
+      const id2 = identityRewriteService.generateDeviceId(profile2, 'account-1')
 
       expect(id1).not.toBe(id2)
+    })
+  })
+
+  describe('generateEmail', () => {
+    it('should generate deterministic email for same account', () => {
+      const e1 = identityRewriteService.generateEmail('account-1')
+      const e2 = identityRewriteService.generateEmail('account-1')
+
+      expect(e1).toBe(e2)
+      expect(e1).toContain('@example.com')
+    })
+
+    it('should generate different emails for different accounts', () => {
+      const e1 = identityRewriteService.generateEmail('account-1')
+      const e2 = identityRewriteService.generateEmail('account-2')
+
+      expect(e1).not.toBe(e2)
+    })
+
+    it('should return default email when no accountId', () => {
+      expect(identityRewriteService.generateEmail(null)).toBe('user@example.com')
+      expect(identityRewriteService.generateEmail(undefined)).toBe('user@example.com')
     })
   })
 })

--- a/tests/identityRewriteService.test.js
+++ b/tests/identityRewriteService.test.js
@@ -51,12 +51,21 @@ describe('Identity Rewrite Service', () => {
   })
 
   describe('rewritePromptText', () => {
-    it('should rewrite billing fingerprint in text', () => {
+    it('should rewrite billing fingerprint with per-account suffix', () => {
       const text = 'cc_version=2.1.81.abc x-anthropic-billing-header'
-      const result = identityRewriteService.rewritePromptText(text, defaultProfile)
+      const result = identityRewriteService.rewritePromptText(text, defaultProfile, 'account-1')
 
-      expect(result).toContain('cc_version=2.1.81.000')
       expect(result).not.toContain('cc_version=2.1.81.abc')
+      // Suffix should be a 3-char hex derived from accountId, not .000
+      expect(result).toMatch(/cc_version=2\.1\.81\.[a-f0-9]{3}/)
+    })
+
+    it('should generate different billing suffixes for different accounts', () => {
+      const text = 'cc_version=2.1.81.abc'
+      const r1 = identityRewriteService.rewritePromptText(text, defaultProfile, 'account-1')
+      const r2 = identityRewriteService.rewritePromptText(text, defaultProfile, 'account-2')
+
+      expect(r1).not.toBe(r2)
     })
 
     it('should rewrite Platform in system prompt', () => {
@@ -464,6 +473,33 @@ describe('Identity Rewrite Service', () => {
     it('should return default email when no accountId', () => {
       expect(identityRewriteService.generateEmail(null)).toBe('user@example.com')
       expect(identityRewriteService.generateEmail(undefined)).toBe('user@example.com')
+    })
+  })
+
+  describe('generateVersionSuffix', () => {
+    it('should return 3-char hex for accountId', () => {
+      const suffix = identityRewriteService.generateVersionSuffix('account-1')
+
+      expect(suffix).toMatch(/^[a-f0-9]{3}$/)
+    })
+
+    it('should be deterministic', () => {
+      const s1 = identityRewriteService.generateVersionSuffix('account-1')
+      const s2 = identityRewriteService.generateVersionSuffix('account-1')
+
+      expect(s1).toBe(s2)
+    })
+
+    it('should differ per account', () => {
+      const s1 = identityRewriteService.generateVersionSuffix('account-1')
+      const s2 = identityRewriteService.generateVersionSuffix('account-2')
+
+      expect(s1).not.toBe(s2)
+    })
+
+    it('should return 000 when no accountId', () => {
+      expect(identityRewriteService.generateVersionSuffix(null)).toBe('000')
+      expect(identityRewriteService.generateVersionSuffix(undefined)).toBe('000')
     })
   })
 })

--- a/tests/identityRewriteService.test.js
+++ b/tests/identityRewriteService.test.js
@@ -357,6 +357,42 @@ describe('Identity Rewrite Service', () => {
     })
   })
 
+  describe('rewriteGenericIdentity', () => {
+    it('should rewrite device_id and email', () => {
+      const body = {
+        device_id: 'real-device-id',
+        email: 'realuser@company.com',
+        other_field: 'should remain'
+      }
+
+      identityRewriteService.rewriteGenericIdentity(body, defaultProfile)
+
+      expect(body.device_id).not.toBe('real-device-id')
+      expect(body.device_id).toHaveLength(64) // sha256 hex
+      expect(body.email).toBe('user@example.com')
+      expect(body.other_field).toBe('should remain')
+    })
+
+    it('should skip fields that do not exist', () => {
+      const body = { other_field: 'value' }
+
+      identityRewriteService.rewriteGenericIdentity(body, defaultProfile)
+
+      expect(body.device_id).toBeUndefined()
+      expect(body.email).toBeUndefined()
+      expect(body.other_field).toBe('value')
+    })
+
+    it('should handle non-object input gracefully', () => {
+      expect(() =>
+        identityRewriteService.rewriteGenericIdentity(null, defaultProfile)
+      ).not.toThrow()
+      expect(() =>
+        identityRewriteService.rewriteGenericIdentity('string', defaultProfile)
+      ).not.toThrow()
+    })
+  })
+
   describe('generateDeviceId', () => {
     it('should generate deterministic device ID for same profile', () => {
       const id1 = identityRewriteService.generateDeviceId(defaultProfile)

--- a/tests/identityRewriteService.test.js
+++ b/tests/identityRewriteService.test.js
@@ -274,7 +274,7 @@ describe('Identity Rewrite Service', () => {
   })
 
   describe('rewriteEventBatch', () => {
-    it('should rewrite device_id and email per-account', () => {
+    it('should rewrite device_id and use real account email', () => {
       const body = {
         events: [
           {
@@ -286,23 +286,48 @@ describe('Identity Rewrite Service', () => {
         ]
       }
 
-      const result = identityRewriteService.rewriteEventBatch(body, defaultProfile, 'account-1')
+      const result = identityRewriteService.rewriteEventBatch(
+        body,
+        defaultProfile,
+        'account-1',
+        'real@gmail.com'
+      )
 
       expect(result.events[0].event_data.device_id).not.toBe('original-device-id')
-      expect(result.events[0].event_data.email).toContain('@example.com')
-      expect(result.events[0].event_data.email).not.toBe('original@example.com')
+      expect(result.events[0].event_data.email).toBe('real@gmail.com')
     })
 
-    it('should generate different device_id/email for different accounts', () => {
+    it('should keep original email when accountEmail is empty', () => {
+      const body = {
+        events: [{ event_data: { device_id: 'orig', email: 'orig@test.com' } }]
+      }
+
+      const result = identityRewriteService.rewriteEventBatch(body, defaultProfile, 'account-1', '')
+
+      expect(result.events[0].event_data.email).toBe('orig@test.com')
+    })
+
+    it('should generate different device_ids for different accounts', () => {
       const makeBody = () => ({
         events: [{ event_data: { device_id: 'orig', email: 'orig@test.com' } }]
       })
 
-      const r1 = identityRewriteService.rewriteEventBatch(makeBody(), defaultProfile, 'account-1')
-      const r2 = identityRewriteService.rewriteEventBatch(makeBody(), defaultProfile, 'account-2')
+      const r1 = identityRewriteService.rewriteEventBatch(
+        makeBody(),
+        defaultProfile,
+        'account-1',
+        'a1@gmail.com'
+      )
+      const r2 = identityRewriteService.rewriteEventBatch(
+        makeBody(),
+        defaultProfile,
+        'account-2',
+        'a2@gmail.com'
+      )
 
       expect(r1.events[0].event_data.device_id).not.toBe(r2.events[0].event_data.device_id)
-      expect(r1.events[0].event_data.email).not.toBe(r2.events[0].event_data.email)
+      expect(r1.events[0].event_data.email).toBe('a1@gmail.com')
+      expect(r2.events[0].event_data.email).toBe('a2@gmail.com')
     })
 
     it('should replace env object entirely', () => {
@@ -380,31 +405,54 @@ describe('Identity Rewrite Service', () => {
   })
 
   describe('rewriteGenericIdentity', () => {
-    it('should rewrite device_id and email per-account', () => {
+    it('should rewrite device_id and use real account email', () => {
       const body = {
         device_id: 'real-device-id',
         email: 'realuser@company.com',
         other_field: 'should remain'
       }
 
-      identityRewriteService.rewriteGenericIdentity(body, defaultProfile, 'account-1')
+      identityRewriteService.rewriteGenericIdentity(
+        body,
+        defaultProfile,
+        'account-1',
+        'account1@gmail.com'
+      )
 
       expect(body.device_id).not.toBe('real-device-id')
       expect(body.device_id).toHaveLength(64) // sha256 hex
-      expect(body.email).toContain('@example.com')
-      expect(body.email).not.toBe('realuser@company.com')
+      expect(body.email).toBe('account1@gmail.com')
       expect(body.other_field).toBe('should remain')
     })
 
-    it('should generate different identities for different accounts', () => {
+    it('should keep original email when accountEmail is empty', () => {
+      const body = { device_id: 'orig', email: 'orig@test.com' }
+
+      identityRewriteService.rewriteGenericIdentity(body, defaultProfile, 'account-1', '')
+
+      expect(body.email).toBe('orig@test.com')
+    })
+
+    it('should generate different device_ids for different accounts', () => {
       const body1 = { device_id: 'orig', email: 'orig@test.com' }
       const body2 = { device_id: 'orig', email: 'orig@test.com' }
 
-      identityRewriteService.rewriteGenericIdentity(body1, defaultProfile, 'account-1')
-      identityRewriteService.rewriteGenericIdentity(body2, defaultProfile, 'account-2')
+      identityRewriteService.rewriteGenericIdentity(
+        body1,
+        defaultProfile,
+        'account-1',
+        'a1@gmail.com'
+      )
+      identityRewriteService.rewriteGenericIdentity(
+        body2,
+        defaultProfile,
+        'account-2',
+        'a2@gmail.com'
+      )
 
       expect(body1.device_id).not.toBe(body2.device_id)
-      expect(body1.email).not.toBe(body2.email)
+      expect(body1.email).toBe('a1@gmail.com')
+      expect(body2.email).toBe('a2@gmail.com')
     })
 
     it('should skip fields that do not exist', () => {

--- a/tests/identityRewriteService.test.js
+++ b/tests/identityRewriteService.test.js
@@ -1,0 +1,379 @@
+/**
+ * Identity Rewrite Service Tests
+ * 移植自 cc-gateway 的测试用例
+ */
+
+// Mock logger，避免测试输出污染控制台
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+
+// Mock Redis
+jest.mock('../src/models/redis', () => ({
+  getClient: jest.fn(() => ({
+    get: jest.fn(),
+    set: jest.fn(),
+    setex: jest.fn()
+  }))
+}))
+
+// Mock config
+jest.mock('../config/config', () => ({
+  identityRewrite: {
+    defaults: {
+      platform: 'darwin',
+      shell: 'zsh',
+      osVersion: 'Darwin 24.4.0',
+      workingDir: '/Users/user/projects',
+      version: '2.1.81',
+      arch: 'arm64',
+      nodeVersion: 'v24.3.0',
+      terminal: 'iTerm2.app',
+      constrainedMemory: 34359738368,
+      rssRange: [300000000, 500000000],
+      heapTotalRange: [40000000, 80000000],
+      heapUsedRange: [100000000, 200000000]
+    }
+  }
+}))
+
+const identityRewriteService = require('../src/services/identityRewriteService')
+
+describe('Identity Rewrite Service', () => {
+  // Use getDefaultProfile() to get the actual profile with mocked config
+  let defaultProfile
+
+  beforeEach(() => {
+    defaultProfile = identityRewriteService.getDefaultProfile()
+  })
+
+  describe('rewritePromptText', () => {
+    it('should rewrite billing fingerprint in text', () => {
+      const text = 'cc_version=2.1.81.abc x-anthropic-billing-header'
+      const result = identityRewriteService.rewritePromptText(text, defaultProfile)
+
+      expect(result).toContain('cc_version=2.1.81.000')
+      expect(result).not.toContain('cc_version=2.1.81.abc')
+    })
+
+    it('should rewrite Platform in system prompt', () => {
+      const text = 'Platform: linux'
+      const result = identityRewriteService.rewritePromptText(text, defaultProfile)
+
+      expect(result).toBe('Platform: darwin')
+    })
+
+    it('should rewrite Shell in system prompt', () => {
+      const text = 'Shell: bash'
+      const result = identityRewriteService.rewritePromptText(text, defaultProfile)
+
+      expect(result).toBe('Shell: zsh')
+    })
+
+    it('should rewrite OS Version in system prompt', () => {
+      const text = 'OS Version: Linux 6.5.0-xxx'
+      const result = identityRewriteService.rewritePromptText(text, defaultProfile)
+
+      expect(result).toBe('OS Version: Darwin 24.4.0')
+    })
+
+    it('should rewrite Working directory', () => {
+      const text = 'Working directory: /home/alice/code'
+      const result = identityRewriteService.rewritePromptText(text, defaultProfile)
+
+      // Note: workingDir is used both for the Working directory line AND for home path replacement
+      // So the result will have workingDir from the regex + potentially extra from home path rewrite
+      expect(result).toContain('Working directory:')
+      expect(result).toContain('/Users/user/projects')
+    })
+
+    it('should rewrite Primary Working directory', () => {
+      const text = 'Primary working directory: /home/bob/project'
+      const result = identityRewriteService.rewritePromptText(text, defaultProfile)
+
+      expect(result).toContain('Primary working directory:')
+      expect(result).toContain('/Users/user/projects')
+    })
+  })
+
+  describe('rewriteHomePaths', () => {
+    it('should replace /Users/xxx/ paths', () => {
+      const text = '/Users/alice/Documents/file.txt'
+      const result = identityRewriteService.rewriteHomePaths(text, '/Users/user/projects')
+
+      expect(result).toBe('/Users/user/projects/Documents/file.txt')
+    })
+
+    it('should replace /home/xxx/ paths', () => {
+      const text = '/home/bob/code/project'
+      const result = identityRewriteService.rewriteHomePaths(text, '/Users/user/projects')
+
+      expect(result).toBe('/Users/user/projects/code/project')
+    })
+
+    it('should handle multiple home paths', () => {
+      const text = '/Users/alice/file1 and /home/bob/file2'
+      const result = identityRewriteService.rewriteHomePaths(text, '/Users/user/')
+
+      expect(result).toBe('/Users/user/file1 and /Users/user/file2')
+    })
+
+    it('should return non-string input unchanged', () => {
+      expect(identityRewriteService.rewriteHomePaths(null, '/Users/user/')).toBeNull()
+      expect(identityRewriteService.rewriteHomePaths(123, '/Users/user/')).toBe(123)
+    })
+  })
+
+  describe('rewriteSystemPrompt', () => {
+    it('should rewrite system array items', () => {
+      const body = {
+        system: [
+          { type: 'text', text: 'Platform: linux Shell: bash' },
+          { type: 'text', text: 'OS Version: Ubuntu 22.04' }
+        ]
+      }
+
+      identityRewriteService.rewriteSystemPrompt(body, defaultProfile)
+
+      expect(body.system[0].text).toBe('Platform: darwin Shell: zsh')
+      expect(body.system[1].text).toBe('OS Version: Darwin 24.4.0')
+    })
+
+    it('should rewrite string system prompt', () => {
+      const body = {
+        system: 'Platform: linux'
+      }
+
+      identityRewriteService.rewriteSystemPrompt(body, defaultProfile)
+
+      expect(body.system).toBe('Platform: darwin')
+    })
+
+    it('should NOT rewrite user message paths (needed for tool calls)', () => {
+      const body = {
+        system: [{ type: 'text', text: 'System prompt' }],
+        messages: [
+          { role: 'user', content: 'Check file at /Users/alice/doc.txt' },
+          { role: 'user', content: [{ type: 'text', text: 'In /home/bob/project' }] }
+        ]
+      }
+
+      identityRewriteService.rewriteSystemPrompt(body, defaultProfile)
+
+      // Messages should remain unchanged — real file paths are needed for tool invocations
+      expect(body.messages[0].content).toBe('Check file at /Users/alice/doc.txt')
+      expect(body.messages[1].content[0].text).toBe('In /home/bob/project')
+    })
+
+    it('should handle non-object body gracefully', () => {
+      expect(() => identityRewriteService.rewriteSystemPrompt(null, defaultProfile)).not.toThrow()
+      expect(() =>
+        identityRewriteService.rewriteSystemPrompt('string', defaultProfile)
+      ).not.toThrow()
+    })
+  })
+
+  describe('stripLeakFields', () => {
+    it('should strip baseUrl, base_url, and gateway fields', () => {
+      const body = {
+        baseUrl: 'http://relay.example.com',
+        base_url: 'http://relay.example.com',
+        gateway: 'my-gateway',
+        otherField: 'should remain'
+      }
+
+      identityRewriteService.stripLeakFields(body)
+
+      expect(body.baseUrl).toBeUndefined()
+      expect(body.base_url).toBeUndefined()
+      expect(body.gateway).toBeUndefined()
+      expect(body.otherField).toBe('should remain')
+    })
+
+    it('should handle non-object input gracefully', () => {
+      expect(() => identityRewriteService.stripLeakFields(null)).not.toThrow()
+      expect(() => identityRewriteService.stripLeakFields('string')).not.toThrow()
+    })
+  })
+
+  describe('buildCanonicalEnv', () => {
+    it('should build canonical environment object', () => {
+      const env = identityRewriteService.buildCanonicalEnv(defaultProfile)
+
+      expect(env.platform).toBe('darwin')
+      expect(env.arch).toBe('arm64')
+      expect(env.node_version).toBe('v24.3.0')
+      expect(env.terminal).toBe('iTerm2.app')
+      expect(env.is_ci).toBe(false)
+      expect(env.is_claubbit).toBe(false)
+      expect(env.is_claude_code_remote).toBe(false)
+      expect(env.version).toBe('2.1.81')
+    })
+
+    it('should force CI-related flags to false', () => {
+      const env = identityRewriteService.buildCanonicalEnv(defaultProfile)
+
+      expect(env.is_ci).toBe(false)
+      expect(env.is_github_action).toBe(false)
+      expect(env.is_claude_code_action).toBe(false)
+    })
+  })
+
+  describe('buildCanonicalProcess', () => {
+    it('should normalize process metrics object', () => {
+      const original = {
+        constrainedMemory: 16000000000,
+        rss: 800000000,
+        heapTotal: 100000000,
+        heapUsed: 250000000,
+        uptime: 12345
+      }
+
+      const result = identityRewriteService.buildCanonicalProcess(original, defaultProfile)
+
+      expect(result.constrainedMemory).toBe(34359738368) // canonical value
+      expect(result.rss).toBeGreaterThanOrEqual(300000000)
+      expect(result.rss).toBeLessThan(500000000)
+      expect(result.heapTotal).toBeGreaterThanOrEqual(40000000)
+      expect(result.heapTotal).toBeLessThan(80000000)
+      expect(result.uptime).toBe(12345) // preserved
+    })
+
+    it('should handle base64 encoded process data', () => {
+      const original = {
+        constrainedMemory: 16000000000,
+        rss: 800000000
+      }
+      const b64 = Buffer.from(JSON.stringify(original)).toString('base64')
+
+      const result = identityRewriteService.buildCanonicalProcess(b64, defaultProfile)
+
+      const decoded = JSON.parse(Buffer.from(result, 'base64').toString())
+      expect(decoded.constrainedMemory).toBe(34359738368)
+      expect(decoded.rss).toBeGreaterThanOrEqual(300000000)
+    })
+
+    it('should return invalid base64 unchanged', () => {
+      const invalid = 'not-valid-base64!!!'
+      const result = identityRewriteService.buildCanonicalProcess(invalid, defaultProfile)
+
+      expect(result).toBe(invalid)
+    })
+  })
+
+  describe('rewriteEventBatch', () => {
+    it('should rewrite device_id and email in events', () => {
+      const body = {
+        events: [
+          {
+            event_data: {
+              device_id: 'original-device-id',
+              email: 'original@example.com'
+            }
+          }
+        ]
+      }
+
+      const result = identityRewriteService.rewriteEventBatch(body, defaultProfile)
+
+      expect(result.events[0].event_data.device_id).not.toBe('original-device-id')
+      expect(result.events[0].event_data.email).toBe('user@example.com')
+    })
+
+    it('should replace env object entirely', () => {
+      const body = {
+        events: [
+          {
+            event_data: {
+              env: { platform: 'windows', is_ci: true }
+            }
+          }
+        ]
+      }
+
+      const result = identityRewriteService.rewriteEventBatch(body, defaultProfile)
+
+      expect(result.events[0].event_data.env.platform).toBe('darwin')
+      expect(result.events[0].event_data.env.is_ci).toBe(false)
+    })
+
+    it('should strip leak fields from events', () => {
+      const body = {
+        events: [
+          {
+            event_data: {
+              baseUrl: 'http://relay.example.com',
+              gateway: 'my-gateway',
+              validField: 'should remain'
+            }
+          }
+        ]
+      }
+
+      const result = identityRewriteService.rewriteEventBatch(body, defaultProfile)
+
+      expect(result.events[0].event_data.baseUrl).toBeUndefined()
+      expect(result.events[0].event_data.gateway).toBeUndefined()
+      expect(result.events[0].event_data.validField).toBe('should remain')
+    })
+
+    it('should handle non-batch body gracefully', () => {
+      const body = { notEvents: 'something' }
+      const result = identityRewriteService.rewriteEventBatch(body, defaultProfile)
+
+      expect(result).toEqual(body)
+    })
+  })
+
+  describe('getPlatformDefaults', () => {
+    it('should return Linux defaults for linux platform', () => {
+      const defaults = identityRewriteService.getPlatformDefaults('linux')
+
+      expect(defaults.shell).toBe('bash')
+      expect(defaults.osVersion).toContain('Linux')
+      expect(defaults.workingDir).toBe('/home/user/projects')
+      expect(defaults.terminal).toBe('xterm-256color')
+    })
+
+    it('should return Windows defaults for win32 platform', () => {
+      const defaults = identityRewriteService.getPlatformDefaults('win32')
+
+      expect(defaults.shell).toBe('powershell')
+      expect(defaults.osVersion).toContain('Windows')
+      expect(defaults.workingDir).toContain('C:\\')
+      expect(defaults.terminal).toBe('Windows Terminal')
+    })
+
+    it('should return Darwin defaults for darwin platform', () => {
+      const defaults = identityRewriteService.getPlatformDefaults('darwin')
+
+      expect(defaults.shell).toBe('zsh')
+      expect(defaults.osVersion).toContain('Darwin')
+      expect(defaults.workingDir).toBe('/Users/user/projects')
+      expect(defaults.terminal).toBe('iTerm2.app')
+    })
+  })
+
+  describe('generateDeviceId', () => {
+    it('should generate deterministic device ID for same profile', () => {
+      const id1 = identityRewriteService.generateDeviceId(defaultProfile)
+      const id2 = identityRewriteService.generateDeviceId(defaultProfile)
+
+      expect(id1).toBe(id2)
+      expect(id1).toHaveLength(64) // sha256 hex
+    })
+
+    it('should generate different IDs for different profiles', () => {
+      const profile1 = { ...defaultProfile, platform: 'darwin' }
+      const profile2 = { ...defaultProfile, platform: 'linux' }
+
+      const id1 = identityRewriteService.generateDeviceId(profile1)
+      const id2 = identityRewriteService.generateDeviceId(profile2)
+
+      expect(id1).not.toBe(id2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

新增身份重写服务（Identity Rewrite Service），实现每个账户独立的设备指纹、邮箱、User-Agent 和 billing header，从根本上消除多账户共享身份特征导致的异常检测风险。

## Why this must be merged

**这是安全基础设施，不合并 = 所有共用 relay 的账户共享设备指纹，存在关联检测风险。**

### 核心问题

当多个 Claude 账户通过同一个 relay 服务转发请求时，以下身份特征会暴露关联性：

1. **device_id**：所有账户共享客户端的 device_id → 一个 device_id 出现在多个不同账户上是异常信号
2. **email**：metadata 中的 email 可能泄漏真实用户信息，或多账户共享同一邮箱
3. **x-stainless headers**：SDK 指纹头（platform、arch、os、runtime 等），同一台机器的所有请求完全一致
4. **User-Agent**：相同 UA 字符串跨多账户
5. **billing header**：`X-Anthropic-Billing-Header` 中的版本后缀，所有请求完全一致
6. **system prompt / environment**：可能包含本地文件路径等环境信息

### 解决方案

为每个账户生成**确定性但互不相同**的身份特征：

- `device_id` → `formatUuidFromSeed(accountId::device)` — 纯账户派生，客户端无法控制
- `email` → **使用账户真实邮箱**（通过 `claudeAccountService.getAccountEmail()` 解密获取），拿不到时保留原始值
- `x-stainless-*` → 首次请求时 seed 到 Redis 并缓存，后续一致读取
- `User-Agent` → 每日按账户缓存
- billing header 版本后缀 → `generateVersionSuffix(accountId)` — 按账户确定性生成
- 系统提示 / 环境信息 → 移除本地路径等敏感信息

所有哈希都混入 `accountId` 作为 seed，确保：
- 同一账户的所有请求身份一致（不触发异常）
- 不同账户之间身份完全不同（无法关联）

### 安全加固（经 adversarial review）

- 移除了客户端对 device_id 的控制权 — 之前 hash 中包含 `parsed.deviceId`，客户端可通过构造 metadata 影响最终值
- x-stainless headers 从 write-only 改为 read-first — 之前每次请求都重新 seed 但从不读取缓存
- 遥测转发 `/api/event_logging/batch` 强制认证 — 之前可匿名调用，且随机选择账户
- billing header 重写改为 case-insensitive — 防止 `X-Anthropic-Billing-Header` 的大小写变体绕过
- **email 使用账户真实邮箱** — 不生成伪造邮箱（`user-{hash}@example.com` 这种格式一眼假，比不改还糟糕）

## Changes

- `src/services/identityRewriteService.js` — **新文件**：profile 生成/缓存、系统提示重写、环境信息清洗；email 重写改为接收真实邮箱参数
- `src/services/account/claudeAccountService.js` — 新增 `getAccountEmail(accountId)` 方法，解密返回真实邮箱
- `src/services/requestIdentityService.js` — x-stainless headers 和 user_id 重写改为按账户隔离
- `src/services/relay/claudeRelayService.js` — 集成身份重写：调用 transform、遥测转发绑定账户、billing header 重写；并行获取 profile 和真实邮箱
- `src/routes/api.js` — 遥测转发端点增加认证；新增 `/api/verify` 端点；旁路请求获取真实邮箱传入重写
- `src/routes/admin/system.js` — 新增 identity 管理端点（查看/重置 profile）
- `config/config.example.js` — 新增 identity rewrite 配置项
- `tests/identityRewriteService.test.js` — **新文件**：46 个测试覆盖跨账户隔离、真实邮箱替换、空邮箱回退

## Test plan

- [ ] `npm test -- identityRewriteService` — 46 个测试全部通过
- [ ] 同一账户连续请求 → 确认 device_id、x-stainless headers、UA 保持一致
- [ ] 不同账户请求 → 确认所有身份特征互不相同
- [ ] 客户端构造恶意 metadata.user_id → 确认 device_id 不受客户端控制
- [ ] 遥测转发 → 确认需要认证且绑定正确账户
- [ ] 账户有真实邮箱 → 确认请求中 email 字段为真实邮箱
- [ ] 账户无邮箱 → 确认保留客户端原始 email，不生成假邮箱