### PR TITLE
fix: prevent stats crashes when detailed model pricing is missing

### DIFF
--- a/src/utils/costCalculator.js
+++ b/src/utils/costCalculator.js
@@ -1,4 +1,7 @@
 const pricingService = require('../services/pricingService')
+const logger = require('./logger')
+
+const warnedDetailedPricingFallbackModels = new Set()
 
 // Claude模型价格配置 (USD per 1M tokens) - 备用定价
 const MODEL_PRICING = {
@@ -72,86 +75,137 @@ const MODEL_PRICING = {
 }
 
 class CostCalculator {
-  /**
-   * 计算单次请求的费用
-   * @param {Object} usage - 使用量数据
-   * @param {number} usage.input_tokens - 输入token数量
-   * @param {number} usage.output_tokens - 输出token数量
-   * @param {number} usage.cache_creation_input_tokens - 缓存创建token数量
-   * @param {number} usage.cache_read_input_tokens - 缓存读取token数量
-   * @param {string} model - 模型名称
-   * @returns {Object} 费用详情
-   */
-  static calculateCost(usage, model = 'unknown', serviceTier = null) {
-    // 如果 usage 包含详细的 cache_creation 对象或是 1M 模型，使用 pricingService 来处理
-    if (
+  static isFiniteNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value)
+  }
+
+  static isDetailedPricingRequest(usage, model = 'unknown') {
+    return (
       (usage.cache_creation && typeof usage.cache_creation === 'object') ||
-      (model && model.includes('[1m]'))
-    ) {
-      const result = pricingService.calculateCost(usage, model)
-      // 转换 pricingService 返回的格式到 costCalculator 的格式
-      return {
-        model,
-        pricing: {
-          input: result.pricing.input * 1000000, // 转换为 per 1M tokens
-          output: result.pricing.output * 1000000,
-          cacheWrite: result.pricing.cacheCreate * 1000000,
-          cacheRead: result.pricing.cacheRead * 1000000
-        },
-        usingDynamicPricing: true,
-        isLongContextRequest: result.isLongContextRequest || false,
-        usage: {
-          inputTokens: usage.input_tokens || 0,
-          outputTokens: usage.output_tokens || 0,
-          cacheCreateTokens: usage.cache_creation_input_tokens || 0,
-          cacheReadTokens: usage.cache_read_input_tokens || 0,
-          totalTokens:
-            (usage.input_tokens || 0) +
-            (usage.output_tokens || 0) +
-            (usage.cache_creation_input_tokens || 0) +
-            (usage.cache_read_input_tokens || 0)
-        },
-        costs: {
-          input: result.inputCost,
-          output: result.outputCost,
-          cacheWrite: result.cacheCreateCost,
-          cacheRead: result.cacheReadCost,
-          total: result.totalCost
-        },
-        formatted: {
-          input: this.formatCost(result.inputCost),
-          output: this.formatCost(result.outputCost),
-          cacheWrite: this.formatCost(result.cacheCreateCost),
-          cacheRead: this.formatCost(result.cacheReadCost),
-          total: this.formatCost(result.totalCost)
-        },
-        debug: {
-          isOpenAIModel: model.includes('gpt') || model.includes('o1'),
-          hasCacheCreatePrice: !!result.pricing.cacheCreate,
-          cacheCreateTokens: usage.cache_creation_input_tokens || 0,
-          cacheWritePriceUsed: result.pricing.cacheCreate * 1000000,
-          isLongContextModel: model && model.includes('[1m]'),
-          isLongContextRequest: result.isLongContextRequest || false
-        }
-      }
+      (typeof model === 'string' && model.includes('[1m]'))
+    )
+  }
+
+  static isValidPricingServiceResult(result) {
+    return (
+      result &&
+      result.hasPricing === true &&
+      result.pricing &&
+      this.isFiniteNumber(result.pricing.input) &&
+      this.isFiniteNumber(result.pricing.output) &&
+      this.isFiniteNumber(result.pricing.cacheCreate) &&
+      this.isFiniteNumber(result.pricing.cacheRead) &&
+      this.isFiniteNumber(result.inputCost) &&
+      this.isFiniteNumber(result.outputCost) &&
+      this.isFiniteNumber(result.cacheCreateCost) &&
+      this.isFiniteNumber(result.cacheReadCost) &&
+      this.isFiniteNumber(result.totalCost)
+    )
+  }
+
+  static isOpenAIModel(model, pricingData = null) {
+    if (typeof model === 'string' && (model.includes('gpt') || model.includes('o1'))) {
+      return true
     }
 
-    // 否则使用旧的逻辑（向后兼容）
+    return pricingData?.litellm_provider === 'openai'
+  }
+
+  static getPricingSource(model, pricingData) {
+    if (pricingData) {
+      return 'dynamic'
+    }
+
+    if (MODEL_PRICING[model]) {
+      return 'static'
+    }
+
+    return 'unknown-fallback'
+  }
+
+  static logDetailedPricingFallback(model, usage, result) {
+    const warnKey = typeof model === 'string' && model ? model : 'unknown'
+
+    if (warnedDetailedPricingFallbackModels.has(warnKey)) {
+      return
+    }
+
+    warnedDetailedPricingFallbackModels.add(warnKey)
+
+    const hasDetailedCache = !!(usage.cache_creation && typeof usage.cache_creation === 'object')
+    const isLongContextModel = typeof model === 'string' && model.includes('[1m]')
+
+    logger.warn(
+      `💰 Missing detailed pricing for model ${warnKey}; using fallback pricing ` +
+        `(hasPricing=${result?.hasPricing === true}, cacheCreation=${hasDetailedCache}, longContext=${isLongContextModel})`
+    )
+  }
+
+  static buildDetailedPricingResult(usage, model, result) {
+    return {
+      model,
+      pricing: {
+        input: result.pricing.input * 1000000, // 转换为 per 1M tokens
+        output: result.pricing.output * 1000000,
+        cacheWrite: result.pricing.cacheCreate * 1000000,
+        cacheRead: result.pricing.cacheRead * 1000000
+      },
+      usingDynamicPricing: true,
+      isLongContextRequest: result.isLongContextRequest || false,
+      usage: {
+        inputTokens: usage.input_tokens || 0,
+        outputTokens: usage.output_tokens || 0,
+        cacheCreateTokens: usage.cache_creation_input_tokens || 0,
+        cacheReadTokens: usage.cache_read_input_tokens || 0,
+        totalTokens:
+          (usage.input_tokens || 0) +
+          (usage.output_tokens || 0) +
+          (usage.cache_creation_input_tokens || 0) +
+          (usage.cache_read_input_tokens || 0)
+      },
+      costs: {
+        input: result.inputCost,
+        output: result.outputCost,
+        cacheWrite: result.cacheCreateCost,
+        cacheRead: result.cacheReadCost,
+        total: result.totalCost
+      },
+      formatted: {
+        input: this.formatCost(result.inputCost),
+        output: this.formatCost(result.outputCost),
+        cacheWrite: this.formatCost(result.cacheCreateCost),
+        cacheRead: this.formatCost(result.cacheReadCost),
+        total: this.formatCost(result.totalCost)
+      },
+      debug: {
+        isOpenAIModel: this.isOpenAIModel(model),
+        hasCacheCreatePrice: !!result.pricing.cacheCreate,
+        cacheCreateTokens: usage.cache_creation_input_tokens || 0,
+        cacheWritePriceUsed: result.pricing.cacheCreate * 1000000,
+        isLongContextModel: typeof model === 'string' && model.includes('[1m]'),
+        isLongContextRequest: result.isLongContextRequest || false,
+        usedFallbackPricing: false,
+        pricingSource: 'dynamic'
+      }
+    }
+  }
+
+  static buildLegacyCostResult(usage, model = 'unknown', serviceTier = null, options = {}) {
+    const safeModel = typeof model === 'string' && model ? model : 'unknown'
+
     const inputTokens = usage.input_tokens || 0
     const outputTokens = usage.output_tokens || 0
     const cacheCreateTokens = usage.cache_creation_input_tokens || 0
     const cacheReadTokens = usage.cache_read_input_tokens || 0
 
-    // 优先使用动态价格服务
-    const pricingData = pricingService.getModelPricing(model)
+    const pricingData = pricingService.getModelPricing(safeModel)
+    const pricingSource = this.getPricingSource(safeModel, pricingData)
     let pricing
     let usingDynamicPricing = false
 
     if (pricingData) {
-      // 检查是否使用 priority 定价
       const usePriority = serviceTier === 'priority' && pricingData.supports_service_tier
 
-      // 转换动态价格格式为内部格式（priority 定价时使用 *_priority 字段，回退到标准价格）
       const inputPrice =
         ((usePriority && pricingData.input_cost_per_token_priority) ||
           pricingData.input_cost_per_token ||
@@ -165,17 +219,13 @@ class CostCalculator {
           pricingData.cache_read_input_token_cost ||
           0) * 1000000
 
-      // OpenAI 模型的特殊处理：
-      // - 如果没有 cache_creation_input_token_cost，缓存创建按普通 input 价格计费
-      // - Claude 模型有专门的 cache_creation_input_token_cost
       let cacheWritePrice = (pricingData.cache_creation_input_token_cost || 0) * 1000000
 
-      // 检测是否为 OpenAI 模型（通过模型名或 litellm_provider）
-      const isOpenAIModel =
-        model.includes('gpt') || model.includes('o1') || pricingData.litellm_provider === 'openai'
-
-      if (isOpenAIModel && !pricingData.cache_creation_input_token_cost && cacheCreateTokens > 0) {
-        // OpenAI 模型：缓存创建按普通 input 价格计费
+      if (
+        this.isOpenAIModel(safeModel, pricingData) &&
+        !pricingData.cache_creation_input_token_cost &&
+        cacheCreateTokens > 0
+      ) {
         cacheWritePrice = inputPrice
       }
 
@@ -187,11 +237,9 @@ class CostCalculator {
       }
       usingDynamicPricing = true
     } else {
-      // 回退到静态价格
-      pricing = MODEL_PRICING[model] || MODEL_PRICING['unknown']
+      pricing = MODEL_PRICING[safeModel] || MODEL_PRICING['unknown']
     }
 
-    // 计算各类型token的费用 (USD)
     const inputCost = (inputTokens / 1000000) * pricing.input
     const outputCost = (outputTokens / 1000000) * pricing.output
     const cacheWriteCost = (cacheCreateTokens / 1000000) * pricing.cacheWrite
@@ -200,7 +248,7 @@ class CostCalculator {
     const totalCost = inputCost + outputCost + cacheWriteCost + cacheReadCost
 
     return {
-      model,
+      model: safeModel,
       pricing,
       usingDynamicPricing,
       usage: {
@@ -217,7 +265,6 @@ class CostCalculator {
         cacheRead: cacheReadCost,
         total: totalCost
       },
-      // 格式化的费用字符串
       formatted: {
         input: this.formatCost(inputCost),
         output: this.formatCost(outputCost),
@@ -225,14 +272,46 @@ class CostCalculator {
         cacheRead: this.formatCost(cacheReadCost),
         total: this.formatCost(totalCost)
       },
-      // 添加调试信息
       debug: {
-        isOpenAIModel: model.includes('gpt') || model.includes('o1'),
+        isOpenAIModel: this.isOpenAIModel(safeModel, pricingData),
         hasCacheCreatePrice: !!pricingData?.cache_creation_input_token_cost,
         cacheCreateTokens,
-        cacheWritePriceUsed: pricing.cacheWrite
+        cacheWritePriceUsed: pricing.cacheWrite,
+        isLongContextModel: typeof safeModel === 'string' && safeModel.includes('[1m]'),
+        isLongContextRequest: false,
+        usedFallbackPricing:
+          options.usedFallbackPricing === true || pricingSource === 'unknown-fallback',
+        pricingSource
       }
     }
+  }
+
+  /**
+   * 计算单次请求的费用
+   * @param {Object} usage - 使用量数据
+   * @param {number} usage.input_tokens - 输入token数量
+   * @param {number} usage.output_tokens - 输出token数量
+   * @param {number} usage.cache_creation_input_tokens - 缓存创建token数量
+   * @param {number} usage.cache_read_input_tokens - 缓存读取token数量
+   * @param {string} model - 模型名称
+   * @returns {Object} 费用详情
+   */
+  static calculateCost(usage, model = 'unknown', serviceTier = null) {
+    // 如果 usage 包含详细的 cache_creation 对象或是 1M 模型，优先使用 pricingService
+    if (this.isDetailedPricingRequest(usage, model)) {
+      const result = pricingService.calculateCost(usage, model)
+      if (this.isValidPricingServiceResult(result)) {
+        return this.buildDetailedPricingResult(usage, model, result)
+      }
+
+      this.logDetailedPricingFallback(model, usage, result)
+
+      return this.buildLegacyCostResult(usage, model, serviceTier, {
+        usedFallbackPricing: true
+      })
+    }
+
+    return this.buildLegacyCostResult(usage, model, serviceTier)
   }
 
   /**

--- a/tests/costCalculator.test.js
+++ b/tests/costCalculator.test.js
@@ -1,0 +1,158 @@
+jest.mock('../src/services/pricingService', () => ({
+  calculateCost: jest.fn(),
+  getModelPricing: jest.fn()
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  success: jest.fn(),
+  database: jest.fn(),
+  api: jest.fn(),
+  security: jest.fn()
+}))
+
+describe('CostCalculator', () => {
+  let CostCalculator
+  let pricingService
+  let logger
+
+  beforeEach(() => {
+    jest.resetModules()
+
+    pricingService = require('../src/services/pricingService')
+    logger = require('../src/utils/logger')
+    CostCalculator = require('../src/utils/costCalculator')
+
+    jest.clearAllMocks()
+    pricingService.calculateCost.mockReset()
+    pricingService.getModelPricing.mockReset()
+  })
+
+  it('uses detailed pricing when pricingService returns a complete result', () => {
+    pricingService.calculateCost.mockReturnValue({
+      hasPricing: true,
+      isLongContextRequest: false,
+      inputCost: 0.003,
+      outputCost: 0.0075,
+      cacheCreateCost: 0.00075,
+      cacheReadCost: 0.00003,
+      totalCost: 0.01128,
+      pricing: {
+        input: 0.000003,
+        output: 0.000015,
+        cacheCreate: 0.00000375,
+        cacheRead: 0.0000003
+      }
+    })
+
+    const result = CostCalculator.calculateCost(
+      {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 100,
+        cache_creation: {
+          ephemeral_5m_input_tokens: 200,
+          ephemeral_1h_input_tokens: 0
+        }
+      },
+      'claude-sonnet-4-20250514'
+    )
+
+    expect(result.usingDynamicPricing).toBe(true)
+    expect(result.pricing.input).toBe(3)
+    expect(result.pricing.cacheWrite).toBe(3.75)
+    expect(result.costs.total).toBeCloseTo(0.01128, 10)
+    expect(result.debug.usedFallbackPricing).toBe(false)
+    expect(result.debug.pricingSource).toBe('dynamic')
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('falls back to unknown pricing for detailed-cache requests with missing model pricing', () => {
+    pricingService.calculateCost.mockReturnValue({
+      hasPricing: false,
+      totalCost: 0,
+      isLongContextRequest: false
+    })
+    pricingService.getModelPricing.mockReturnValue(null)
+
+    const usage = {
+      input_tokens: 1000,
+      output_tokens: 500,
+      cache_creation_input_tokens: 200,
+      cache_read_input_tokens: 100,
+      cache_creation: {
+        ephemeral_5m_input_tokens: 100,
+        ephemeral_1h_input_tokens: 100
+      }
+    }
+
+    const first = CostCalculator.calculateCost(usage, 'kimi-k2.5')
+    const second = CostCalculator.calculateCost(usage, 'kimi-k2.5')
+
+    expect(first.usingDynamicPricing).toBe(false)
+    expect(first.pricing.input).toBe(3)
+    expect(first.pricing.cacheWrite).toBe(3.75)
+    expect(first.costs.total).toBeCloseTo(0.01128, 10)
+    expect(first.debug.usedFallbackPricing).toBe(true)
+    expect(first.debug.pricingSource).toBe('unknown-fallback')
+    expect(second.costs.total).toBeCloseTo(first.costs.total, 10)
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn.mock.calls[0][0]).toContain('kimi-k2.5')
+  })
+
+  it('falls back instead of throwing for unknown long-context models', () => {
+    pricingService.calculateCost.mockReturnValue({
+      hasPricing: false,
+      totalCost: 0,
+      isLongContextRequest: false
+    })
+    pricingService.getModelPricing.mockReturnValue(null)
+
+    const result = CostCalculator.calculateCost(
+      {
+        input_tokens: 250000,
+        output_tokens: 1000,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      },
+      'mystery-model[1m]'
+    )
+
+    expect(result.usingDynamicPricing).toBe(false)
+    expect(result.costs.total).toBeCloseTo(0.765, 10)
+    expect(result.debug.usedFallbackPricing).toBe(true)
+    expect(result.debug.isLongContextModel).toBe(true)
+    expect(result.debug.pricingSource).toBe('unknown-fallback')
+  })
+
+  it('keeps the legacy dynamic-pricing path for regular requests', () => {
+    pricingService.getModelPricing.mockReturnValue({
+      input_cost_per_token: 0.000002,
+      output_cost_per_token: 0.000008,
+      cache_creation_input_token_cost: 0.0000025,
+      cache_read_input_token_cost: 0.0000002
+    })
+
+    const result = CostCalculator.calculateCost(
+      {
+        input_tokens: 2000,
+        output_tokens: 1000,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 250
+      },
+      'glm-5'
+    )
+
+    expect(pricingService.calculateCost).not.toHaveBeenCalled()
+    expect(result.usingDynamicPricing).toBe(true)
+    expect(result.pricing.input).toBe(2)
+    expect(result.pricing.output).toBe(8)
+    expect(result.costs.total).toBeCloseTo(0.0133, 10)
+    expect(result.debug.usedFallbackPricing).toBe(false)
+    expect(result.debug.pricingSource).toBe('dynamic')
+  })
+})


### PR DESCRIPTION
## Summary
- prevent admin stats endpoints from crashing when a model uses the detailed pricing path but is missing from `model_pricing.json`
- fall back to legacy `unknown` pricing instead of dereferencing a missing `result.pricing`
- add regression coverage for missing-pricing and unknown `[1m]` scenarios

## Root cause
`pricingService.calculateCost()` can return `hasPricing=false` without a `pricing` object for models that are not present in `model_pricing.json`.
`CostCalculator.calculateCost()` used to access `result.pricing.input` unconditionally on the detailed-pricing path, which caused `TypeError: Cannot read properties of undefined (reading 'input')` and broke `/admin/model-stats`, `/admin/usage-trend`, `/admin/usage-costs`, and related stats endpoints.

## What changed
- validate detailed-pricing results before dereferencing `result.pricing`
- reuse the legacy pricing path when detailed pricing is unavailable
- mark fallback usage in debug metadata and emit a one-time warning per missing model
- add targeted Jest coverage for the regression and unaffected dynamic-pricing behavior

## Tests
Passed locally:

```bash
npx jest --runInBand tests/costCalculator.test.js tests/pricingService.test.js
```
Covered scenarios:

- detailed pricing still works when pricingService returns a complete pricing result
- unknown models with detailed cache pricing fall back safely instead of throwing
- unknown [1m] models no longer crash the stats calculation path
- the regular dynamic-pricing path remains unchanged for supported models

## Notes
- missing official model prices still use the approximate `unknown` fallback rates (`input $3 / 1M`, `output $15 / 1M`, `cacheWrite $3.75 / 1M`, `cacheRead $0.3 / 1M`)
- Close to PR #1133, but this version preserves approximate `unknown` fallback costs instead of forcing a zero-cost fallback