### PR TITLE
feat: add admin request details tracing view

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "docker:down": "docker-compose down",
     "migrate:apikey-expiry": "node scripts/migrate-apikey-expiry.js",
     "migrate:apikey-expiry:dry": "node scripts/migrate-apikey-expiry.js --dry-run",
+    "migrate:request-detail-retention-hours": "node scripts/reset-request-detail-retention-hours.js",
     "migrate:fix-usage-stats": "node scripts/fix-usage-stats.js",
     "data:export": "node scripts/data-transfer.js export",
     "data:import": "node scripts/data-transfer.js import",

--- a/scripts/reset-request-detail-retention-hours.js
+++ b/scripts/reset-request-detail-retention-hours.js
@@ -74,8 +74,7 @@ async function resetRequestDetailRetentionHours() {
       port: Number.parseInt(process.env.REDIS_PORT, 10) || 6379,
       password: process.env.REDIS_PASSWORD || undefined,
       db: Number.parseInt(process.env.REDIS_DB, 10) || 0,
-      tls:
-        process.env.REDIS_ENABLE_TLS === 'true' || process.env.REDIS_TLS === 'true' ? {} : false,
+      tls: process.env.REDIS_ENABLE_TLS === 'true' || process.env.REDIS_TLS === 'true' ? {} : false,
       lazyConnect: true
     })
     await client.connect()

--- a/scripts/reset-request-detail-retention-hours.js
+++ b/scripts/reset-request-detail-retention-hours.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+let dotenvLoaded = false
+try {
+  require('dotenv').config()
+  dotenvLoaded = true
+} catch (_error) {
+  dotenvLoaded = false
+}
+
+const Redis = require('ioredis')
+
+const CONFIG_KEY = 'claude_relay_config'
+const REQUEST_DETAIL_KEY_PATTERN = 'request_detail:*'
+const DEFAULT_RETENTION_HOURS = 6
+const MAX_RETENTION_HOURS = 720
+const SCAN_COUNT = 200
+
+const args = process.argv.slice(2)
+const params = {}
+args.forEach((arg) => {
+  const [key, value] = arg.split('=')
+  params[key.replace(/^--/, '')] = value ?? true
+})
+
+const isDryRun = params['dry-run'] === true
+const requestedHours = Number.parseInt(params.hours, 10)
+const targetHours = Number.isFinite(requestedHours) ? requestedHours : DEFAULT_RETENTION_HOURS
+
+if (!Number.isInteger(targetHours) || targetHours < 1 || targetHours > MAX_RETENTION_HOURS) {
+  console.error(
+    `requestDetailRetentionHours must be an integer between 1 and ${MAX_RETENTION_HOURS}`
+  )
+  process.exit(1)
+}
+
+async function scanRequestDetailKeys(client) {
+  let cursor = '0'
+  const keys = []
+
+  do {
+    const [nextCursor, batch] = await client.scan(
+      cursor,
+      'MATCH',
+      REQUEST_DETAIL_KEY_PATTERN,
+      'COUNT',
+      SCAN_COUNT
+    )
+    cursor = nextCursor
+    if (Array.isArray(batch) && batch.length > 0) {
+      keys.push(...batch)
+    }
+  } while (cursor !== '0')
+
+  return keys
+}
+
+async function resetRequestDetailRetentionHours() {
+  let client = null
+
+  try {
+    console.log('🔄 Resetting request detail retention configuration...')
+    console.log(`🕒 Target request detail retention: ${targetHours} hour(s)`)
+    if (isDryRun) {
+      console.log('📝 DRY RUN mode enabled; no data will be modified')
+    }
+
+    if (dotenvLoaded) {
+      console.log('📄 Loaded .env configuration')
+    }
+
+    client = new Redis({
+      host: process.env.REDIS_HOST || '127.0.0.1',
+      port: Number.parseInt(process.env.REDIS_PORT, 10) || 6379,
+      password: process.env.REDIS_PASSWORD || undefined,
+      db: Number.parseInt(process.env.REDIS_DB, 10) || 0,
+      tls:
+        process.env.REDIS_ENABLE_TLS === 'true' || process.env.REDIS_TLS === 'true' ? {} : false,
+      lazyConnect: true
+    })
+    await client.connect()
+
+    const rawConfig = await client.get(CONFIG_KEY)
+    const currentConfig = rawConfig ? JSON.parse(rawConfig) : {}
+    const requestDetailKeys = await scanRequestDetailKeys(client)
+
+    console.log(`📦 Found ${requestDetailKeys.length} request detail Redis key(s)`)
+    console.log(
+      `⚙️ Current config: requestDetailRetentionDays=${currentConfig.requestDetailRetentionDays ?? 'unset'}, requestDetailRetentionHours=${currentConfig.requestDetailRetentionHours ?? 'unset'}`
+    )
+
+    const nextConfig = {
+      ...currentConfig,
+      requestDetailRetentionHours: targetHours,
+      updatedAt: new Date().toISOString(),
+      updatedBy: 'request-detail-retention-hours-reset-script'
+    }
+    delete nextConfig.requestDetailRetentionDays
+
+    if (!isDryRun) {
+      if (requestDetailKeys.length > 0) {
+        for (let index = 0; index < requestDetailKeys.length; index += SCAN_COUNT) {
+          const batch = requestDetailKeys.slice(index, index + SCAN_COUNT)
+          // Use UNLINK to avoid blocking Redis with a large DEL.
+          await client.unlink(...batch)
+        }
+      }
+
+      await client.set(CONFIG_KEY, JSON.stringify(nextConfig))
+    }
+
+    console.log(
+      `${isDryRun ? '📝 Would delete' : '🧹 Deleted'} ${requestDetailKeys.length} request detail key(s)`
+    )
+    console.log(
+      `${isDryRun ? '📝 Would write' : '✅ Wrote'} requestDetailRetentionHours=${targetHours} and removed requestDetailRetentionDays`
+    )
+  } catch (error) {
+    console.error('❌ Failed to reset request detail retention configuration:', error)
+    process.exitCode = 1
+  } finally {
+    if (client) {
+      await client.quit()
+    }
+  }
+}
+
+resetRequestDetailRetentionHours()

--- a/src/handlers/geminiHandlers.js
+++ b/src/handlers/geminiHandlers.js
@@ -21,6 +21,7 @@ const axios = require('axios')
 const { getSafeMessage } = require('../utils/errorSanitizer')
 const ProxyHelper = require('../utils/proxyHelper')
 const upstreamErrorHelper = require('../utils/upstreamErrorHelper')
+const { createRequestDetailMeta } = require('../utils/requestDetailHelper')
 
 // 处理 Gemini 上游错误，标记账户为临时不可用
 const handleGeminiUpstreamError = async (
@@ -586,7 +587,13 @@ async function handleMessages(req, res) {
               0,
               model,
               accountId,
-              'gemini'
+              'gemini',
+              null,
+              createRequestDetailMeta(req, {
+                requestBody: req.body,
+                stream,
+                statusCode: res.statusCode || 200
+              })
             )
           }
         }
@@ -616,7 +623,11 @@ async function handleMessages(req, res) {
           apiKeyId: apiKeyData.id,
           signal: abortController.signal,
           projectId: effectiveProjectId,
-          accountId: account.id
+          accountId: account.id,
+          requestMeta: createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream
+          })
         })
       } else {
         geminiResponse = await sendGeminiRequest({
@@ -630,7 +641,11 @@ async function handleMessages(req, res) {
           apiKeyId: apiKeyData.id,
           signal: abortController.signal,
           projectId: effectiveProjectId,
-          accountId: account.id
+          accountId: account.id,
+          requestMeta: createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream
+          })
         })
       }
     }
@@ -703,7 +718,13 @@ async function handleMessages(req, res) {
                 0,
                 model,
                 accountId,
-                'gemini'
+                'gemini',
+                null,
+                createRequestDetailMeta(req, {
+                  requestBody: req.body,
+                  stream: true,
+                  statusCode: res.statusCode
+                })
               )
               .then(() => {
                 logger.info(
@@ -1720,7 +1741,13 @@ async function handleGenerateContent(req, res) {
           0,
           model,
           account.id,
-          'gemini'
+          'gemini',
+          null,
+          createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream: false,
+            statusCode: res.statusCode || 200
+          })
         )
         logger.info(
           `📊 Recorded Gemini usage - Input: ${usage.promptTokenCount}, Output: ${usage.candidatesTokenCount}, Total: ${usage.totalTokenCount}`
@@ -2070,7 +2097,13 @@ async function handleStreamGenerateContent(req, res) {
             0,
             model,
             account.id,
-            'gemini'
+            'gemini',
+            null,
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: true,
+              statusCode: res.statusCode
+            })
           )
           .then((costs) =>
             applyRateLimitTracking(
@@ -2424,7 +2457,13 @@ async function handleStandardGenerateContent(req, res) {
           0,
           model,
           accountId,
-          'gemini'
+          'gemini',
+          null,
+          createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream: false,
+            statusCode: res.statusCode || 200
+          })
         )
         logger.info(
           `📊 Recorded Gemini usage - Input: ${usage.promptTokenCount}, Output: ${usage.candidatesTokenCount}, Total: ${usage.totalTokenCount}`
@@ -2866,7 +2905,13 @@ async function handleStandardStreamGenerateContent(req, res) {
             0,
             model,
             accountId,
-            'gemini'
+            'gemini',
+            null,
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: true,
+              statusCode: res.statusCode
+            })
           )
           .then(() => {
             logger.info(

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1765,6 +1765,7 @@ const requestLogger = (req, res, next) => {
 
   // 添加请求ID到请求对象
   req.requestId = requestId
+  req.requestStartedAt = start
   res.setHeader('X-Request-ID', requestId)
 
   // 获取客户端信息

--- a/src/routes/admin/claudeRelayConfig.js
+++ b/src/routes/admin/claudeRelayConfig.js
@@ -49,7 +49,7 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       concurrentRequestQueueMaxSizeMultiplier,
       concurrentRequestQueueTimeoutMs,
       requestDetailCaptureEnabled,
-      requestDetailRetentionDays
+      requestDetailRetentionHours
     } = req.body
 
     // 验证输入
@@ -171,15 +171,15 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       return res.status(400).json({ error: 'requestDetailCaptureEnabled must be a boolean' })
     }
 
-    if (requestDetailRetentionDays !== undefined) {
+    if (requestDetailRetentionHours !== undefined) {
       if (
-        typeof requestDetailRetentionDays !== 'number' ||
-        !Number.isInteger(requestDetailRetentionDays) ||
-        requestDetailRetentionDays < 1 ||
-        requestDetailRetentionDays > 30
+        typeof requestDetailRetentionHours !== 'number' ||
+        !Number.isInteger(requestDetailRetentionHours) ||
+        requestDetailRetentionHours < 1 ||
+        requestDetailRetentionHours > 720
       ) {
         return res.status(400).json({
-          error: 'requestDetailRetentionDays must be an integer between 1 and 30'
+          error: 'requestDetailRetentionHours must be an integer between 1 and 720'
         })
       }
     }
@@ -221,8 +221,8 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
     if (requestDetailCaptureEnabled !== undefined) {
       updateData.requestDetailCaptureEnabled = requestDetailCaptureEnabled
     }
-    if (requestDetailRetentionDays !== undefined) {
-      updateData.requestDetailRetentionDays = requestDetailRetentionDays
+    if (requestDetailRetentionHours !== undefined) {
+      updateData.requestDetailRetentionHours = requestDetailRetentionHours
     }
 
     const updatedConfig = await claudeRelayConfigService.updateConfig(

--- a/src/routes/admin/claudeRelayConfig.js
+++ b/src/routes/admin/claudeRelayConfig.js
@@ -6,6 +6,7 @@
 const express = require('express')
 const { authenticateAdmin } = require('../../middleware/auth')
 const claudeRelayConfigService = require('../../services/claudeRelayConfigService')
+const requestDetailService = require('../../services/requestDetailService')
 const logger = require('../../utils/logger')
 
 const router = express.Router()
@@ -49,7 +50,9 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       concurrentRequestQueueMaxSizeMultiplier,
       concurrentRequestQueueTimeoutMs,
       requestDetailCaptureEnabled,
-      requestDetailRetentionHours
+      requestDetailRetentionHours,
+      requestDetailBodyPreviewEnabled,
+      purgeRequestDetailBodySnapshots
     } = req.body
 
     // 验证输入
@@ -184,6 +187,20 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       }
     }
 
+    if (
+      requestDetailBodyPreviewEnabled !== undefined &&
+      typeof requestDetailBodyPreviewEnabled !== 'boolean'
+    ) {
+      return res.status(400).json({ error: 'requestDetailBodyPreviewEnabled must be a boolean' })
+    }
+
+    if (
+      purgeRequestDetailBodySnapshots !== undefined &&
+      typeof purgeRequestDetailBodySnapshots !== 'boolean'
+    ) {
+      return res.status(400).json({ error: 'purgeRequestDetailBodySnapshots must be a boolean' })
+    }
+
     const updateData = {}
     if (claudeCodeOnlyEnabled !== undefined) {
       updateData.claudeCodeOnlyEnabled = claudeCodeOnlyEnabled
@@ -224,16 +241,32 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
     if (requestDetailRetentionHours !== undefined) {
       updateData.requestDetailRetentionHours = requestDetailRetentionHours
     }
+    if (requestDetailBodyPreviewEnabled !== undefined) {
+      updateData.requestDetailBodyPreviewEnabled = requestDetailBodyPreviewEnabled
+    }
 
     const updatedConfig = await claudeRelayConfigService.updateConfig(
       updateData,
       req.admin?.username || 'unknown'
     )
 
+    let warning = null
+    let requestDetailBodyPreviewPurge = null
+    if (requestDetailBodyPreviewEnabled === false && purgeRequestDetailBodySnapshots === true) {
+      try {
+        requestDetailBodyPreviewPurge = await requestDetailService.purgeRequestBodySnapshots()
+      } catch (purgeError) {
+        logger.error('❌ Failed to purge request body previews after config update:', purgeError)
+        warning = `配置已保存，但历史请求体预览清理失败：${purgeError.message}`
+      }
+    }
+
     return res.json({
       success: true,
       message: 'Configuration updated successfully',
-      config: updatedConfig
+      config: updatedConfig,
+      warning,
+      requestDetailBodyPreviewPurge
     })
   } catch (error) {
     logger.error('❌ Failed to update Claude relay config:', error)

--- a/src/routes/admin/claudeRelayConfig.js
+++ b/src/routes/admin/claudeRelayConfig.js
@@ -47,7 +47,9 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       concurrentRequestQueueEnabled,
       concurrentRequestQueueMaxSize,
       concurrentRequestQueueMaxSizeMultiplier,
-      concurrentRequestQueueTimeoutMs
+      concurrentRequestQueueTimeoutMs,
+      requestDetailCaptureEnabled,
+      requestDetailRetentionDays
     } = req.body
 
     // 验证输入
@@ -162,6 +164,26 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       }
     }
 
+    if (
+      requestDetailCaptureEnabled !== undefined &&
+      typeof requestDetailCaptureEnabled !== 'boolean'
+    ) {
+      return res.status(400).json({ error: 'requestDetailCaptureEnabled must be a boolean' })
+    }
+
+    if (requestDetailRetentionDays !== undefined) {
+      if (
+        typeof requestDetailRetentionDays !== 'number' ||
+        !Number.isInteger(requestDetailRetentionDays) ||
+        requestDetailRetentionDays < 1 ||
+        requestDetailRetentionDays > 30
+      ) {
+        return res.status(400).json({
+          error: 'requestDetailRetentionDays must be an integer between 1 and 30'
+        })
+      }
+    }
+
     const updateData = {}
     if (claudeCodeOnlyEnabled !== undefined) {
       updateData.claudeCodeOnlyEnabled = claudeCodeOnlyEnabled
@@ -195,6 +217,12 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
     }
     if (concurrentRequestQueueTimeoutMs !== undefined) {
       updateData.concurrentRequestQueueTimeoutMs = concurrentRequestQueueTimeoutMs
+    }
+    if (requestDetailCaptureEnabled !== undefined) {
+      updateData.requestDetailCaptureEnabled = requestDetailCaptureEnabled
+    }
+    if (requestDetailRetentionDays !== undefined) {
+      updateData.requestDetailRetentionDays = requestDetailRetentionDays
     }
 
     const updatedConfig = await claudeRelayConfigService.updateConfig(

--- a/src/routes/admin/claudeRelayConfig.js
+++ b/src/routes/admin/claudeRelayConfig.js
@@ -261,6 +261,22 @@ router.put('/claude-relay-config', authenticateAdmin, async (req, res) => {
       }
     }
 
+    if (
+      requestDetailBodyPreviewEnabled !== undefined ||
+      purgeRequestDetailBodySnapshots !== undefined
+    ) {
+      logger.info('🧾 Request body preview config updated', {
+        requestDetailBodyPreviewEnabled:
+          requestDetailBodyPreviewEnabled !== undefined
+            ? requestDetailBodyPreviewEnabled
+            : updatedConfig.requestDetailBodyPreviewEnabled,
+        purgeRequestDetailBodySnapshots: purgeRequestDetailBodySnapshots === true,
+        purgedSnapshots:
+          requestDetailBodyPreviewPurge?.updatedRecords ??
+          requestDetailBodyPreviewPurge?.matchedRecords
+      })
+    }
+
     return res.json({
       success: true,
       message: 'Configuration updated successfully',

--- a/src/routes/admin/index.js
+++ b/src/routes/admin/index.js
@@ -29,6 +29,7 @@ const syncRoutes = require('./sync')
 const serviceRatesRoutes = require('./serviceRates')
 const quotaCardsRoutes = require('./quotaCards')
 const errorHistoryRoutes = require('./errorHistory')
+const requestDetailsRoutes = require('./requestDetails')
 
 // 挂载所有子路由
 // 使用完整路径的模块（直接挂载到根路径）
@@ -49,6 +50,7 @@ router.use('/', syncRoutes)
 router.use('/', serviceRatesRoutes)
 router.use('/', quotaCardsRoutes)
 router.use('/', errorHistoryRoutes)
+router.use('/', requestDetailsRoutes)
 
 // 使用相对路径的模块（需要指定基础路径前缀）
 router.use('/account-groups', accountGroupsRoutes)

--- a/src/routes/admin/requestDetails.js
+++ b/src/routes/admin/requestDetails.js
@@ -1,0 +1,59 @@
+const express = require('express')
+const { authenticateAdmin } = require('../../middleware/auth')
+const requestDetailService = require('../../services/requestDetailService')
+const logger = require('../../utils/logger')
+
+const router = express.Router()
+
+router.get('/request-details', authenticateAdmin, async (req, res) => {
+  try {
+    const data = await requestDetailService.listRequestDetails(req.query || {})
+    return res.json({
+      success: true,
+      data
+    })
+  } catch (error) {
+    if (error?.statusCode === 400) {
+      return res.status(400).json({
+        success: false,
+        error: 'Invalid request detail query',
+        message: error.message
+      })
+    }
+
+    logger.error('❌ Failed to list request details:', error)
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to list request details',
+      message: error.message
+    })
+  }
+})
+
+router.get('/request-details/:requestId', authenticateAdmin, async (req, res) => {
+  try {
+    const { requestId } = req.params
+    const data = await requestDetailService.getRequestDetail(requestId)
+
+    if (!data.record) {
+      return res.status(404).json({
+        success: false,
+        error: 'Request detail not found'
+      })
+    }
+
+    return res.json({
+      success: true,
+      data
+    })
+  } catch (error) {
+    logger.error('❌ Failed to get request detail:', error)
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to get request detail',
+      message: error.message
+    })
+  }
+})
+
+module.exports = router

--- a/src/routes/admin/requestDetails.js
+++ b/src/routes/admin/requestDetails.js
@@ -47,6 +47,24 @@ router.get('/request-details/body-preview-stats', authenticateAdmin, async (_req
   }
 })
 
+router.post('/request-details/body-preview-purge', authenticateAdmin, async (_req, res) => {
+  try {
+    const data = await requestDetailService.purgeRequestBodySnapshots()
+    return res.json({
+      success: true,
+      message: '清理完毕',
+      data
+    })
+  } catch (error) {
+    logger.error('❌ Failed to purge request body previews:', error)
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to purge request body previews',
+      message: error.message
+    })
+  }
+})
+
 router.get('/request-details/:requestId', authenticateAdmin, async (req, res) => {
   try {
     const { requestId } = req.params

--- a/src/routes/admin/requestDetails.js
+++ b/src/routes/admin/requestDetails.js
@@ -30,6 +30,23 @@ router.get('/request-details', authenticateAdmin, async (req, res) => {
   }
 })
 
+router.get('/request-details/body-preview-stats', authenticateAdmin, async (_req, res) => {
+  try {
+    const data = await requestDetailService.getRequestBodyPreviewStats()
+    return res.json({
+      success: true,
+      data
+    })
+  } catch (error) {
+    logger.error('❌ Failed to get request body preview stats:', error)
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to get request body preview stats',
+      message: error.message
+    })
+  }
+})
+
 router.get('/request-details/:requestId', authenticateAdmin, async (req, res) => {
   try {
     const { requestId } = req.params

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -21,6 +21,7 @@ const {
 } = require('../utils/warmupInterceptor')
 const { sanitizeUpstreamError } = require('../utils/errorSanitizer')
 const { dumpAnthropicMessagesRequest } = require('../utils/anthropicRequestDump')
+const { createRequestDetailMeta } = require('../utils/requestDetailHelper')
 const {
   handleAnthropicMessagesToGemini,
   handleAnthropicCountTokensToGemini
@@ -499,7 +500,18 @@ async function handleMessagesRequest(req, res) {
               }
 
               apiKeyService
-                .recordUsageWithDetails(_apiKeyId, usageObject, model, usageAccountId, accountType)
+                .recordUsageWithDetails(
+                  _apiKeyId,
+                  usageObject,
+                  model,
+                  usageAccountId,
+                  accountType,
+                  createRequestDetailMeta(req, {
+                    requestBody: _requestBody,
+                    stream: true,
+                    statusCode: res.statusCode
+                  })
+                )
                 .then((costs) => {
                   queueRateLimitUpdate(
                     _rateLimitInfo,
@@ -630,7 +642,12 @@ async function handleMessagesRequest(req, res) {
                   usageObject,
                   model,
                   usageAccountId,
-                  'claude-console'
+                  'claude-console',
+                  createRequestDetailMeta(req, {
+                    requestBody: _requestBodyConsole,
+                    stream: true,
+                    statusCode: res.statusCode
+                  })
                 )
                 .then((costs) => {
                   queueRateLimitUpdate(
@@ -711,7 +728,13 @@ async function handleMessagesRequest(req, res) {
                 0,
                 result.model,
                 accountId,
-                'bedrock'
+                'bedrock',
+                null,
+                createRequestDetailMeta(req, {
+                  requestBody: _requestBodyBedrock,
+                  stream: true,
+                  statusCode: res.statusCode
+                })
               )
               .then((costs) => {
                 queueRateLimitUpdate(
@@ -838,7 +861,18 @@ async function handleMessagesRequest(req, res) {
               }
 
               apiKeyService
-                .recordUsageWithDetails(_apiKeyIdCcr, usageObject, model, usageAccountId, 'ccr')
+                .recordUsageWithDetails(
+                  _apiKeyIdCcr,
+                  usageObject,
+                  model,
+                  usageAccountId,
+                  'ccr',
+                  createRequestDetailMeta(req, {
+                    requestBody: _requestBodyCcr,
+                    stream: true,
+                    statusCode: res.statusCode
+                  })
+                )
                 .then((costs) => {
                   queueRateLimitUpdate(
                     _rateLimitInfoCcr,
@@ -1264,7 +1298,12 @@ async function handleMessagesRequest(req, res) {
             usageObject,
             model,
             responseAccountId,
-            accountType
+            accountType,
+            createRequestDetailMeta(req, {
+              requestBody: _requestBodyNonStream,
+              stream: false,
+              statusCode: response.statusCode
+            })
           )
 
           await queueRateLimitUpdate(

--- a/src/routes/azureOpenaiRoutes.js
+++ b/src/routes/azureOpenaiRoutes.js
@@ -69,7 +69,14 @@ class AtomicUsageReporter {
     }
   }
 
-  async _performReport(requestId, usageData, apiKeyId, modelToRecord, accountId, requestMeta = null) {
+  async _performReport(
+    requestId,
+    usageData,
+    apiKeyId,
+    modelToRecord,
+    accountId,
+    requestMeta = null
+  ) {
     try {
       const inputTokens = usageData.prompt_tokens || usageData.input_tokens || 0
       const outputTokens = usageData.completion_tokens || usageData.output_tokens || 0

--- a/src/routes/azureOpenaiRoutes.js
+++ b/src/routes/azureOpenaiRoutes.js
@@ -7,6 +7,7 @@ const azureOpenaiRelayService = require('../services/relay/azureOpenaiRelayServi
 const apiKeyService = require('../services/apiKeyService')
 const crypto = require('crypto')
 const upstreamErrorHelper = require('../utils/upstreamErrorHelper')
+const { createRequestDetailMeta } = require('../utils/requestDetailHelper')
 
 // 支持的模型列表 - 基于真实的 Azure OpenAI 模型
 const ALLOWED_MODELS = {
@@ -36,7 +37,7 @@ class AtomicUsageReporter {
     this.pendingReports = new Map()
   }
 
-  async reportOnce(requestId, usageData, apiKeyId, modelToRecord, accountId) {
+  async reportOnce(requestId, usageData, apiKeyId, modelToRecord, accountId, requestMeta = null) {
     if (this.reportedUsage.has(requestId)) {
       logger.debug(`Usage already reported for request: ${requestId}`)
       return false
@@ -52,7 +53,8 @@ class AtomicUsageReporter {
       usageData,
       apiKeyId,
       modelToRecord,
-      accountId
+      accountId,
+      requestMeta
     )
     this.pendingReports.set(requestId, reportPromise)
 
@@ -67,7 +69,7 @@ class AtomicUsageReporter {
     }
   }
 
-  async _performReport(requestId, usageData, apiKeyId, modelToRecord, accountId) {
+  async _performReport(requestId, usageData, apiKeyId, modelToRecord, accountId, requestMeta = null) {
     try {
       const inputTokens = usageData.prompt_tokens || usageData.input_tokens || 0
       const outputTokens = usageData.completion_tokens || usageData.output_tokens || 0
@@ -88,7 +90,9 @@ class AtomicUsageReporter {
         cacheReadTokens,
         modelToRecord,
         accountId,
-        'azure-openai'
+        'azure-openai',
+        null,
+        requestMeta
       )
 
       // 同步更新 Azure 账户的 lastUsedAt 和累计使用量
@@ -222,7 +226,12 @@ router.post('/chat/completions', authenticateApiKey, async (req, res) => {
               usageData,
               req.apiKey.id,
               modelToRecord,
-              account.id
+              account.id,
+              createRequestDetailMeta(req, {
+                requestBody: req.body,
+                stream: true,
+                statusCode: res.statusCode
+              })
             )
           }
         },
@@ -244,7 +253,12 @@ router.post('/chat/completions', authenticateApiKey, async (req, res) => {
           usageData,
           req.apiKey.id,
           modelToRecord,
-          account.id
+          account.id,
+          createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream: false,
+            statusCode: response.status
+          })
         )
       }
     }
@@ -343,7 +357,12 @@ router.post('/responses', authenticateApiKey, async (req, res) => {
               usageData,
               req.apiKey.id,
               modelToRecord,
-              account.id
+              account.id,
+              createRequestDetailMeta(req, {
+                requestBody: req.body,
+                stream: true,
+                statusCode: res.statusCode
+              })
             )
           }
         },
@@ -365,7 +384,12 @@ router.post('/responses', authenticateApiKey, async (req, res) => {
           usageData,
           req.apiKey.id,
           modelToRecord,
-          account.id
+          account.id,
+          createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream: false,
+            statusCode: response.status
+          })
         )
       }
     }
@@ -460,7 +484,18 @@ router.post('/embeddings', authenticateApiKey, async (req, res) => {
 
     if (usageData) {
       const modelToRecord = actualModel || req.body.model || 'unknown'
-      await usageReporter.reportOnce(requestId, usageData, req.apiKey.id, modelToRecord, account.id)
+      await usageReporter.reportOnce(
+        requestId,
+        usageData,
+        req.apiKey.id,
+        modelToRecord,
+        account.id,
+        createRequestDetailMeta(req, {
+          requestBody: req.body,
+          stream: false,
+          statusCode: response.status
+        })
+      )
     }
   } catch (error) {
     logger.error(`Azure OpenAI embeddings request failed ${requestId}:`, error)

--- a/src/routes/openaiClaudeRoutes.js
+++ b/src/routes/openaiClaudeRoutes.js
@@ -18,6 +18,7 @@ const sessionHelper = require('../utils/sessionHelper')
 const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
 const pricingService = require('../services/pricingService')
 const { getEffectiveModel } = require('../utils/modelHelper')
+const { createRequestDetailMeta } = require('../utils/requestDetailHelper')
 
 // 🔧 辅助函数：检查 API Key 权限
 function checkPermissions(apiKeyData, requiredPermission = 'claude') {
@@ -305,7 +306,12 @@ async function handleChatCompletion(req, res, apiKeyData) {
               usageWithRequestMeta, // 传递 usage + 请求模式元信息（beta/speed）
               model,
               accountId,
-              accountType
+              accountType,
+              createRequestDetailMeta(req, {
+                requestBody: req.body,
+                stream: true,
+                statusCode: res.statusCode
+              })
             )
             .then((costs) => {
               queueRateLimitUpdate(
@@ -458,7 +464,12 @@ async function handleChatCompletion(req, res, apiKeyData) {
             usageWithRequestMeta, // 传递 usage + 请求模式元信息（beta/speed）
             claudeRequest.model,
             accountId,
-            accountType
+            accountType,
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: false,
+              statusCode: res.statusCode
+            })
           )
           .then((costs) => {
             queueRateLimitUpdate(

--- a/src/routes/openaiGeminiRoutes.js
+++ b/src/routes/openaiGeminiRoutes.js
@@ -7,6 +7,7 @@ const unifiedGeminiScheduler = require('../services/scheduler/unifiedGeminiSched
 const { getAvailableModels } = require('../services/relay/geminiRelayService')
 const crypto = require('crypto')
 const apiKeyService = require('../services/apiKeyService')
+const { createRequestDetailMeta } = require('../utils/requestDetailHelper')
 
 // 生成会话哈希
 function generateSessionHash(req) {
@@ -540,7 +541,13 @@ router.post('/v1/chat/completions', authenticateApiKey, async (req, res) => {
               0, // cacheReadTokens
               model,
               account.id,
-              'gemini'
+              'gemini',
+              null,
+              createRequestDetailMeta(req, {
+                requestBody: req.body,
+                stream: true,
+                statusCode: res.statusCode
+              })
             )
             logger.info(
               `📊 Recorded Gemini stream usage - Input: ${totalUsage.promptTokenCount}, Output: ${totalUsage.candidatesTokenCount}, Total: ${totalUsage.totalTokenCount}`
@@ -642,7 +649,13 @@ router.post('/v1/chat/completions', authenticateApiKey, async (req, res) => {
             0, // cacheReadTokens
             model,
             account.id,
-            'gemini'
+            'gemini',
+            null,
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: false,
+              statusCode: res.statusCode || 200
+            })
           )
           logger.info(
             `📊 Recorded Gemini usage - Input: ${openaiResponse.usage.prompt_tokens}, Output: ${openaiResponse.usage.completion_tokens}, Total: ${openaiResponse.usage.total_tokens}`

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -15,6 +15,10 @@ const ProxyHelper = require('../utils/proxyHelper')
 const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
 const { IncrementalSSEParser } = require('../utils/sseParser')
 const { getSafeMessage } = require('../utils/errorSanitizer')
+const {
+  createRequestDetailMeta,
+  extractOpenAICacheReadTokens
+} = require('../utils/requestDetailHelper')
 
 // Codex CLI 系统提示词（非 Codex CLI 客户端请求时注入，统一端点也使用）
 const CODEX_CLI_INSTRUCTIONS =
@@ -623,7 +627,7 @@ const handleResponses = async (req, res) => {
         if (usageData) {
           const totalInputTokens = usageData.input_tokens || usageData.prompt_tokens || 0
           const outputTokens = usageData.output_tokens || usageData.completion_tokens || 0
-          const cacheReadTokens = usageData.input_tokens_details?.cached_tokens || 0
+          const cacheReadTokens = extractOpenAICacheReadTokens(usageData)
           // 计算实际输入token（总输入减去缓存部分）
           const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
 
@@ -636,7 +640,12 @@ const handleResponses = async (req, res) => {
             actualModel,
             accountId,
             'openai',
-            req._serviceTier
+            req._serviceTier,
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: false,
+              statusCode: upstream.status
+            })
           )
 
           logger.info(
@@ -738,7 +747,7 @@ const handleResponses = async (req, res) => {
         try {
           const totalInputTokens = usageData.input_tokens || 0
           const outputTokens = usageData.output_tokens || 0
-          const cacheReadTokens = usageData.input_tokens_details?.cached_tokens || 0
+          const cacheReadTokens = extractOpenAICacheReadTokens(usageData)
           // 计算实际输入token（总输入减去缓存部分）
           const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
 
@@ -754,7 +763,12 @@ const handleResponses = async (req, res) => {
             modelToRecord,
             accountId,
             'openai',
-            req._serviceTier
+            req._serviceTier,
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: true,
+              statusCode: res.statusCode
+            })
           )
 
           logger.info(

--- a/src/services/anthropicGeminiBridgeService.js
+++ b/src/services/anthropicGeminiBridgeService.js
@@ -34,6 +34,7 @@ const fs = require('fs')
 const path = require('path')
 const logger = require('../utils/logger')
 const { getProjectRoot } = require('../utils/projectPaths')
+const { createRequestDetailMeta } = require('../utils/requestDetailHelper')
 const geminiAccountService = require('./account/geminiAccountService')
 const unifiedGeminiScheduler = require('./scheduler/unifiedGeminiScheduler')
 const sessionHelper = require('../utils/sessionHelper')
@@ -2145,7 +2146,13 @@ async function handleAnthropicMessagesToGemini(req, res, { vendor, baseModel }) 
           0,
           effectiveModel,
           accountId,
-          'gemini'
+          'gemini',
+          null,
+          createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream: false,
+            statusCode: 200
+          })
         )
         await applyRateLimitTracking(
           req.rateLimitInfo,
@@ -2686,7 +2693,13 @@ async function handleAnthropicMessagesToGemini(req, res, { vendor, baseModel }) 
           0,
           effectiveModel,
           accountId,
-          'gemini'
+          'gemini',
+          null,
+          createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream: true,
+            statusCode: res.statusCode
+          })
         )
         await applyRateLimitTracking(
           req.rateLimitInfo,

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -6,6 +6,7 @@ const logger = require('../utils/logger')
 const serviceRatesService = require('./serviceRatesService')
 const requestDetailService = require('./requestDetailService')
 const { isClaudeFamilyModel } = require('../utils/modelHelper')
+const { finalizeRequestDetailMeta } = require('../utils/requestDetailHelper')
 
 const ACCOUNT_TYPE_CONFIG = {
   claude: { prefix: 'claude:account:' },
@@ -1541,6 +1542,7 @@ class ApiKeyService {
     requestMeta = null
   ) {
     try {
+      const finalizedRequestMeta = finalizeRequestDetailMeta(requestMeta)
       const totalTokens = inputTokens + outputTokens + cacheCreateTokens + cacheReadTokens
 
       // 计算费用
@@ -1646,12 +1648,12 @@ class ApiKeyService {
         model,
         accountId: accountId || null,
         accountType: accountType || null,
-        requestId: requestMeta?.requestId || null,
-        endpoint: requestMeta?.endpoint || null,
-        method: requestMeta?.method || null,
-        statusCode: requestMeta?.statusCode || null,
-        stream: requestMeta?.stream === true,
-        durationMs: requestMeta?.durationMs ?? null,
+        requestId: finalizedRequestMeta?.requestId || null,
+        endpoint: finalizedRequestMeta?.endpoint || null,
+        method: finalizedRequestMeta?.method || null,
+        statusCode: finalizedRequestMeta?.statusCode || null,
+        stream: finalizedRequestMeta?.stream === true,
+        durationMs: finalizedRequestMeta?.durationMs ?? null,
         inputTokens,
         outputTokens,
         cacheCreateTokens,
@@ -1665,7 +1667,7 @@ class ApiKeyService {
       }
 
       await redis.addUsageRecord(keyId, usageRecord)
-      this._captureRequestDetail(keyId, usageRecord, requestMeta).catch((captureError) => {
+      this._captureRequestDetail(keyId, usageRecord, finalizedRequestMeta).catch((captureError) => {
         logger.warn(`⚠️ Failed to schedule request detail capture: ${captureError.message}`)
       })
 
@@ -1729,6 +1731,7 @@ class ApiKeyService {
     requestMeta = null
   ) {
     try {
+      const finalizedRequestMeta = finalizeRequestDetailMeta(requestMeta)
       // 提取 token 数量
       const inputTokens = usageObject.input_tokens || 0
       const outputTokens = usageObject.output_tokens || 0
@@ -1904,12 +1907,12 @@ class ApiKeyService {
         model,
         accountId: accountId || null,
         accountType: accountType || null,
-        requestId: requestMeta?.requestId || null,
-        endpoint: requestMeta?.endpoint || null,
-        method: requestMeta?.method || null,
-        statusCode: requestMeta?.statusCode || null,
-        stream: requestMeta?.stream === true,
-        durationMs: requestMeta?.durationMs ?? null,
+        requestId: finalizedRequestMeta?.requestId || null,
+        endpoint: finalizedRequestMeta?.endpoint || null,
+        method: finalizedRequestMeta?.method || null,
+        statusCode: finalizedRequestMeta?.statusCode || null,
+        stream: finalizedRequestMeta?.stream === true,
+        durationMs: finalizedRequestMeta?.durationMs ?? null,
         inputTokens,
         outputTokens,
         cacheCreateTokens,
@@ -1931,7 +1934,7 @@ class ApiKeyService {
       }
 
       await redis.addUsageRecord(keyId, usageRecord)
-      this._captureRequestDetail(keyId, usageRecord, requestMeta).catch((captureError) => {
+      this._captureRequestDetail(keyId, usageRecord, finalizedRequestMeta).catch((captureError) => {
         logger.warn(`⚠️ Failed to schedule request detail capture: ${captureError.message}`)
       })
 

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -4,6 +4,7 @@ const config = require('../../config/config')
 const redis = require('../models/redis')
 const logger = require('../utils/logger')
 const serviceRatesService = require('./serviceRatesService')
+const requestDetailService = require('./requestDetailService')
 const { isClaudeFamilyModel } = require('../utils/modelHelper')
 
 const ACCOUNT_TYPE_CONFIG = {
@@ -1536,7 +1537,8 @@ class ApiKeyService {
     model = 'unknown',
     accountId = null,
     accountType = null,
-    serviceTier = null
+    serviceTier = null,
+    requestMeta = null
   ) {
     try {
       const totalTokens = inputTokens + outputTokens + cacheCreateTokens + cacheReadTokens
@@ -1639,11 +1641,17 @@ class ApiKeyService {
       }
 
       // 记录单次请求的使用详情（同时保存真实成本和倍率成本）
-      await redis.addUsageRecord(keyId, {
+      const usageRecord = {
         timestamp: new Date().toISOString(),
         model,
         accountId: accountId || null,
         accountType: accountType || null,
+        requestId: requestMeta?.requestId || null,
+        endpoint: requestMeta?.endpoint || null,
+        method: requestMeta?.method || null,
+        statusCode: requestMeta?.statusCode || null,
+        stream: requestMeta?.stream === true,
+        durationMs: requestMeta?.durationMs ?? null,
         inputTokens,
         outputTokens,
         cacheCreateTokens,
@@ -1651,7 +1659,14 @@ class ApiKeyService {
         totalTokens,
         cost: Number(ratedCost.toFixed(6)),
         realCost: Number(realCost.toFixed(6)),
-        realCostBreakdown: costInfo && costInfo.costs ? costInfo.costs : undefined
+        costBreakdown: costInfo?.costs || undefined,
+        realCostBreakdown: costInfo?.costs || undefined,
+        isLongContext: isLongContextRequest
+      }
+
+      await redis.addUsageRecord(keyId, usageRecord)
+      this._captureRequestDetail(keyId, usageRecord, requestMeta).catch((captureError) => {
+        logger.warn(`⚠️ Failed to schedule request detail capture: ${captureError.message}`)
       })
 
       const logParts = [`Model: ${model}`, `Input: ${inputTokens}`, `Output: ${outputTokens}`]
@@ -1710,7 +1725,8 @@ class ApiKeyService {
     usageObject,
     model = 'unknown',
     accountId = null,
-    accountType = null
+    accountType = null,
+    requestMeta = null
   ) {
     try {
       // 提取 token 数量
@@ -1888,6 +1904,12 @@ class ApiKeyService {
         model,
         accountId: accountId || null,
         accountType: accountType || null,
+        requestId: requestMeta?.requestId || null,
+        endpoint: requestMeta?.endpoint || null,
+        method: requestMeta?.method || null,
+        statusCode: requestMeta?.statusCode || null,
+        stream: requestMeta?.stream === true,
+        durationMs: requestMeta?.durationMs ?? null,
         inputTokens,
         outputTokens,
         cacheCreateTokens,
@@ -1909,6 +1931,9 @@ class ApiKeyService {
       }
 
       await redis.addUsageRecord(keyId, usageRecord)
+      this._captureRequestDetail(keyId, usageRecord, requestMeta).catch((captureError) => {
+        logger.warn(`⚠️ Failed to schedule request detail capture: ${captureError.message}`)
+      })
 
       const logParts = [`Model: ${model}`, `Input: ${inputTokens}`, `Output: ${outputTokens}`]
       if (cacheCreateTokens > 0) {
@@ -1969,6 +1994,39 @@ class ApiKeyService {
       logger.error('❌ Failed to record usage:', error)
       return { realCost: 0, ratedCost: 0 }
     }
+  }
+
+  async _captureRequestDetail(keyId, usageRecord, requestMeta = null) {
+    if (!usageRecord) {
+      return
+    }
+
+    await requestDetailService.captureRequestDetail({
+      requestId: requestMeta?.requestId || usageRecord.requestId || null,
+      timestamp: usageRecord.timestamp,
+      requestStartedAt: requestMeta?.requestStartedAt || null,
+      endpoint: requestMeta?.endpoint || usageRecord.endpoint || null,
+      method: requestMeta?.method || usageRecord.method || null,
+      statusCode: requestMeta?.statusCode ?? usageRecord.statusCode ?? 200,
+      stream: requestMeta?.stream === true || usageRecord.stream === true,
+      durationMs: requestMeta?.durationMs ?? usageRecord.durationMs ?? null,
+      requestBody: requestMeta?.requestBody,
+      apiKeyId: keyId,
+      accountId: usageRecord.accountId || null,
+      accountType: usageRecord.accountType || null,
+      model: usageRecord.model || 'unknown',
+      inputTokens: usageRecord.inputTokens || 0,
+      outputTokens: usageRecord.outputTokens || 0,
+      cacheReadTokens: usageRecord.cacheReadTokens || 0,
+      cacheCreateTokens: usageRecord.cacheCreateTokens || 0,
+      totalTokens: usageRecord.totalTokens || 0,
+      cost: usageRecord.cost || 0,
+      realCost: usageRecord.realCost || usageRecord.cost || 0,
+      costBreakdown: usageRecord.costBreakdown || null,
+      realCostBreakdown: usageRecord.realCostBreakdown || usageRecord.costBreakdown || null,
+      isLongContextRequest:
+        usageRecord.isLongContext === true || usageRecord.isLongContextRequest === true
+    })
   }
 
   async _fetchAccountInfo(accountId, accountType, cache, client) {

--- a/src/services/claudeRelayConfigService.js
+++ b/src/services/claudeRelayConfigService.js
@@ -27,6 +27,8 @@ const DEFAULT_CONFIG = {
   concurrentRequestQueueMaxSizeMultiplier: 0, // 并发数的倍数（默认0，仅使用固定值）
   concurrentRequestQueueTimeoutMs: 10000, // 排队超时（毫秒，默认10秒）
   concurrentRequestQueueMaxRedisFailCount: 5, // 连续 Redis 失败阈值（默认5次）
+  requestDetailCaptureEnabled: false, // 是否启用请求明细采集
+  requestDetailRetentionDays: 7, // 请求明细保留天数
   // 排队健康检查配置
   concurrentRequestQueueHealthCheckEnabled: true, // 是否启用排队健康检查（默认开启）
   concurrentRequestQueueHealthThreshold: 0.8, // 健康检查阈值（P90 >= 超时 × 阈值时拒绝新请求）

--- a/src/services/claudeRelayConfigService.js
+++ b/src/services/claudeRelayConfigService.js
@@ -28,7 +28,7 @@ const DEFAULT_CONFIG = {
   concurrentRequestQueueTimeoutMs: 10000, // 排队超时（毫秒，默认10秒）
   concurrentRequestQueueMaxRedisFailCount: 5, // 连续 Redis 失败阈值（默认5次）
   requestDetailCaptureEnabled: false, // 是否启用请求明细采集
-  requestDetailRetentionDays: 7, // 请求明细保留天数
+  requestDetailRetentionHours: 6, // 请求明细保留时间（小时）
   // 排队健康检查配置
   concurrentRequestQueueHealthCheckEnabled: true, // 是否启用排队健康检查（默认开启）
   concurrentRequestQueueHealthThreshold: 0.8, // 健康检查阈值（P90 >= 超时 × 阈值时拒绝新请求）

--- a/src/services/claudeRelayConfigService.js
+++ b/src/services/claudeRelayConfigService.js
@@ -29,6 +29,7 @@ const DEFAULT_CONFIG = {
   concurrentRequestQueueMaxRedisFailCount: 5, // 连续 Redis 失败阈值（默认5次）
   requestDetailCaptureEnabled: false, // 是否启用请求明细采集
   requestDetailRetentionHours: 6, // 请求明细保留时间（小时）
+  requestDetailBodyPreviewEnabled: false, // 是否保存请求体预览快照
   // 排队健康检查配置
   concurrentRequestQueueHealthCheckEnabled: true, // 是否启用排队健康检查（默认开启）
   concurrentRequestQueueHealthThreshold: 0.8, // 健康检查阈值（P90 >= 超时 × 阈值时拒绝新请求）

--- a/src/services/relay/antigravityRelayService.js
+++ b/src/services/relay/antigravityRelayService.js
@@ -29,7 +29,7 @@ function buildRequestData({ messages, model, temperature, maxTokens, sessionId }
   return requestData
 }
 
-async function* handleStreamResponse(response, model, apiKeyId, accountId) {
+async function* handleStreamResponse(response, model, apiKeyId, accountId, requestMeta = null) {
   let buffer = ''
   let totalUsage = {
     promptTokenCount: 0,
@@ -83,7 +83,9 @@ async function* handleStreamResponse(response, model, apiKeyId, accountId) {
                   0,
                   model,
                   accountId,
-                  'gemini'
+                  'gemini',
+                  null,
+                  requestMeta
                 )
                 usageRecorded = true
               }
@@ -105,7 +107,9 @@ async function* handleStreamResponse(response, model, apiKeyId, accountId) {
         0,
         model,
         accountId,
-        'gemini'
+        'gemini',
+        null,
+        requestMeta
       )
     }
   }
@@ -122,7 +126,8 @@ async function sendAntigravityRequest({
   apiKeyId,
   signal,
   projectId,
-  accountId = null
+  accountId = null,
+  requestMeta = null
 }) {
   const requestedModel = normalizeAntigravityModelInput(model)
 
@@ -146,7 +151,7 @@ async function sendAntigravityRequest({
   })
 
   if (stream) {
-    return handleStreamResponse(response, requestedModel, apiKeyId, accountId)
+    return handleStreamResponse(response, requestedModel, apiKeyId, accountId, requestMeta)
   }
 
   const payload = response.data?.response || response.data
@@ -161,7 +166,9 @@ async function sendAntigravityRequest({
       0,
       requestedModel,
       accountId,
-      'gemini'
+      'gemini',
+      null,
+      requestMeta
     )
   }
 

--- a/src/services/relay/droidRelayService.js
+++ b/src/services/relay/droidRelayService.js
@@ -9,6 +9,7 @@ const { updateRateLimitCounters } = require('../../utils/rateLimitHelper')
 const logger = require('../../utils/logger')
 const runtimeAddon = require('../../utils/runtimeAddon')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
+const { createRequestDetailMeta } = require('../../utils/requestDetailHelper')
 
 const SYSTEM_PROMPT = 'You are Droid, an AI software engineering agent built by Factory.'
 const RUNTIME_EVENT_FMT_PAYLOAD = 'fmtPayload'
@@ -628,7 +629,12 @@ class DroidRelayService {
               currentUsageData,
               apiKeyData,
               account,
-              model
+              model,
+              createRequestDetailMeta(clientRequest, {
+                requestBody,
+                stream: true,
+                statusCode: clientResponse.statusCode
+              })
             )
 
             const usageSummary = {
@@ -878,9 +884,9 @@ class DroidRelayService {
   /**
    * 记录从流中解析的 usage 数据
    */
-  async _recordUsageFromStreamData(usageData, apiKeyData, account, model) {
+  async _recordUsageFromStreamData(usageData, apiKeyData, account, model, requestMeta = null) {
     const normalizedUsage = this._normalizeUsageSnapshot(usageData)
-    const costs = await this._recordUsage(apiKeyData, account, model, normalizedUsage)
+    const costs = await this._recordUsage(apiKeyData, account, model, normalizedUsage, requestMeta)
     return { normalizedUsage, costs }
   }
 
@@ -1243,7 +1249,17 @@ class DroidRelayService {
     const normalizedUsage = this._normalizeUsageSnapshot(usage)
 
     if (!skipUsageRecord) {
-      const droidCosts = await this._recordUsage(apiKeyData, account, model, normalizedUsage)
+      const droidCosts = await this._recordUsage(
+        apiKeyData,
+        account,
+        model,
+        normalizedUsage,
+        createRequestDetailMeta(clientRequest, {
+          requestBody,
+          stream: false,
+          statusCode: response.status || 200
+        })
+      )
 
       const totalTokens = this._getTotalTokens(normalizedUsage)
 
@@ -1288,7 +1304,7 @@ class DroidRelayService {
   /**
    * 记录使用统计
    */
-  async _recordUsage(apiKeyData, account, model, usageObject = {}) {
+  async _recordUsage(apiKeyData, account, model, usageObject = {}, requestMeta = null) {
     const totalTokens = this._getTotalTokens(usageObject)
 
     if (totalTokens <= 0) {
@@ -1307,7 +1323,8 @@ class DroidRelayService {
           usageObject,
           model,
           accountId,
-          'droid'
+          'droid',
+          requestMeta
         )
       } else if (accountId) {
         await redis.incrementAccountUsage(

--- a/src/services/relay/geminiRelayService.js
+++ b/src/services/relay/geminiRelayService.js
@@ -106,7 +106,7 @@ function convertGeminiResponse(geminiResponse, model, stream = false) {
 }
 
 // 处理流式响应
-async function* handleStreamResponse(response, model, apiKeyId, accountId = null) {
+async function* handleStreamResponse(response, model, apiKeyId, accountId = null, requestMeta = null) {
   let buffer = ''
   let totalUsage = {
     promptTokenCount: 0,
@@ -164,7 +164,9 @@ async function* handleStreamResponse(response, model, apiKeyId, accountId = null
                   0, // cacheReadTokens (Gemini 没有这个概念)
                   model,
                   accountId,
-                  'gemini'
+                  'gemini',
+                  null,
+                  requestMeta
                 )
                 .catch((error) => {
                   logger.error('❌ Failed to record Gemini usage:', error)
@@ -230,7 +232,8 @@ async function sendGeminiRequest({
   signal,
   projectId,
   location = 'us-central1',
-  accountId = null
+  accountId = null,
+  requestMeta = null
 }) {
   // 确保模型名称格式正确
   if (!model.startsWith('models/')) {
@@ -303,7 +306,7 @@ async function sendGeminiRequest({
     const response = await axios(axiosConfig)
 
     if (stream) {
-      return handleStreamResponse(response, model, apiKeyId, accountId)
+      return handleStreamResponse(response, model, apiKeyId, accountId, requestMeta)
     } else {
       // 非流式响应
       const openaiResponse = convertGeminiResponse(response.data, model, false)
@@ -319,7 +322,9 @@ async function sendGeminiRequest({
             0, // cacheReadTokens
             model,
             accountId,
-            'gemini'
+            'gemini',
+            null,
+            requestMeta
           )
           .catch((error) => {
             logger.error('❌ Failed to record Gemini usage:', error)

--- a/src/services/relay/geminiRelayService.js
+++ b/src/services/relay/geminiRelayService.js
@@ -106,7 +106,13 @@ function convertGeminiResponse(geminiResponse, model, stream = false) {
 }
 
 // 处理流式响应
-async function* handleStreamResponse(response, model, apiKeyId, accountId = null, requestMeta = null) {
+async function* handleStreamResponse(
+  response,
+  model,
+  apiKeyId,
+  accountId = null,
+  requestMeta = null
+) {
   let buffer = ''
   let totalUsage = {
     promptTokenCount: 0,

--- a/src/services/relay/openaiResponsesRelayService.js
+++ b/src/services/relay/openaiResponsesRelayService.js
@@ -9,6 +9,10 @@ const config = require('../../../config/config')
 const crypto = require('crypto')
 const LRUCache = require('../../utils/lruCache')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
+const {
+  createRequestDetailMeta,
+  extractOpenAICacheReadTokens
+} = require('../../utils/requestDetailHelper')
 
 // lastUsedAt 更新节流（每账户 60 秒内最多更新一次，使用 LRU 防止内存泄漏）
 const lastUsedAtThrottle = new LRUCache(1000) // 最多缓存 1000 个账户
@@ -349,7 +353,7 @@ class OpenAIResponsesRelayService {
       }
 
       // 处理非流式响应
-      return this._handleNormalResponse(response, res, account, apiKeyData, req.body?.model)
+      return this._handleNormalResponse(response, res, account, apiKeyData, req.body?.model, req)
     } catch (error) {
       // 清理 AbortController
       if (abortController && !abortController.signal.aborted) {
@@ -593,7 +597,7 @@ class OpenAIResponsesRelayService {
           const outputTokens = usageData.output_tokens || usageData.completion_tokens || 0
 
           // 提取缓存相关的 tokens（如果存在）
-          const cacheReadTokens = usageData.input_tokens_details?.cached_tokens || 0
+          const cacheReadTokens = extractOpenAICacheReadTokens(usageData)
           const cacheCreateTokens = extractCacheCreationTokens(usageData)
           // 计算实际输入token（总输入减去缓存部分）
           const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
@@ -612,7 +616,12 @@ class OpenAIResponsesRelayService {
             modelToRecord,
             account.id,
             'openai-responses',
-            serviceTier
+            serviceTier,
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: true,
+              statusCode: res.statusCode
+            })
           )
 
           logger.info(
@@ -709,7 +718,7 @@ class OpenAIResponsesRelayService {
   }
 
   // 处理非流式响应
-  async _handleNormalResponse(response, res, account, apiKeyData, requestedModel) {
+  async _handleNormalResponse(response, res, account, apiKeyData, requestedModel, req) {
     const responseData = response.data
 
     // 提取 usage 数据和实际 model
@@ -726,7 +735,7 @@ class OpenAIResponsesRelayService {
         const outputTokens = usageData.output_tokens || usageData.completion_tokens || 0
 
         // 提取缓存相关的 tokens（如果存在）
-        const cacheReadTokens = usageData.input_tokens_details?.cached_tokens || 0
+        const cacheReadTokens = extractOpenAICacheReadTokens(usageData)
         const cacheCreateTokens = extractCacheCreationTokens(usageData)
         // 计算实际输入token（总输入减去缓存部分）
         const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
@@ -744,7 +753,12 @@ class OpenAIResponsesRelayService {
           actualModel,
           account.id,
           'openai-responses',
-          serviceTier
+          serviceTier,
+          createRequestDetailMeta(req, {
+            requestBody: req?.body,
+            stream: false,
+            statusCode: response.status
+          })
         )
 
         logger.info(

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -194,6 +194,59 @@ function updateAvailableFilterAccumulator(accumulator, record) {
   }
 }
 
+function updateAvailableFilterAccumulatorRaw(accumulator, record) {
+  if (record.apiKeyId && !accumulator.apiKeyMap.has(record.apiKeyId)) {
+    accumulator.apiKeyMap.set(record.apiKeyId, {
+      id: record.apiKeyId,
+      name: record.apiKeyId
+    })
+  }
+
+  if (record.accountId && !accumulator.accountMap.has(record.accountId)) {
+    accumulator.accountMap.set(record.accountId, {
+      id: record.accountId,
+      name: record.accountId,
+      accountType: record.accountType || 'unknown',
+      accountTypeName: accountTypeNames[record.accountType] || accountTypeNames.unknown
+    })
+  }
+
+  if (record.model) {
+    accumulator.modelSet.add(record.model)
+  }
+
+  if (record.endpoint) {
+    accumulator.endpointSet.add(record.endpoint)
+  }
+
+  const ts = toMillis(record.timestamp)
+  if (ts !== null) {
+    if (accumulator.earliest === null || ts < accumulator.earliest) {
+      accumulator.earliest = ts
+    }
+    if (accumulator.latest === null || ts > accumulator.latest) {
+      accumulator.latest = ts
+    }
+  }
+}
+
+function restoreRecordTimestamp(record, fallbackTimestampMs) {
+  if (!record) {
+    return null
+  }
+
+  if (toMillis(record.timestamp) !== null) {
+    return record
+  }
+
+  const timestampMs = Number(fallbackTimestampMs)
+  if (Number.isFinite(timestampMs)) {
+    record.timestamp = new Date(timestampMs).toISOString()
+  }
+
+  return record
+}
+
 function finalizeAvailableFilters(accumulator) {
   return {
     apiKeys: Array.from(accumulator.apiKeyMap.values()).sort((a, b) =>
@@ -577,7 +630,10 @@ class RequestDetailService {
 
     for (const [type, service] of servicesToTry) {
       try {
-        const account = await service.getAccount(accountId)
+        let account = await service.getAccount(accountId)
+        if (account && typeof account === 'object' && 'success' in account) {
+          account = account.success ? account.data : null
+        }
         if (account) {
           const info = {
             accountId,
@@ -601,6 +657,87 @@ class RequestDetailService {
     }
     cache.set(cacheKey, fallback)
     return fallback
+  }
+
+  async _resolveFilterDisplayNames(accumulator) {
+    const apiKeyCache = new Map()
+    const accountCache = new Map()
+
+    for (const [keyId, entry] of accumulator.apiKeyMap) {
+      const name = await this._getApiKeyName(keyId, apiKeyCache)
+      if (name) {
+        entry.name = name
+      }
+    }
+
+    for (const [accountId, entry] of accumulator.accountMap) {
+      const accountInfo = await this._resolveAccountInfo(accountId, entry.accountType, accountCache)
+      if (accountInfo) {
+        entry.name = accountInfo.accountName
+        entry.accountTypeName = accountInfo.accountTypeName
+      }
+    }
+  }
+
+  async _findRequestTimestampInRange(requestId, startDate, endDate, client = redis.getClient()) {
+    if (!requestId || !client) {
+      return null
+    }
+
+    const dayKeys = listDayKeys(startDate, endDate)
+    if (dayKeys.length === 0) {
+      return null
+    }
+
+    const startMs = startDate.getTime()
+    const endMs = endDate.getTime()
+
+    if (typeof client.pipeline === 'function') {
+      const pipeline = client.pipeline()
+      dayKeys.forEach((dayKey) => {
+        pipeline.zscore(dayKey, requestId)
+      })
+
+      const results = await pipeline.exec()
+      if (Array.isArray(results)) {
+        for (let index = 0; index < results.length; index += 1) {
+          const [error, score] = results[index] || []
+          if (error) {
+            logger.debug(
+              `⚠️ Failed to resolve request detail timestamp from ${dayKeys[index]}: ${error.message}`
+            )
+            continue
+          }
+
+          const timestampMs = Number(score)
+          if (Number.isFinite(timestampMs) && timestampMs >= startMs && timestampMs <= endMs) {
+            return timestampMs
+          }
+        }
+      }
+
+      return null
+    }
+
+    if (typeof client.zscore !== 'function') {
+      return null
+    }
+
+    for (const dayKey of dayKeys) {
+      try {
+        const score = await client.zscore(dayKey, requestId)
+        const timestampMs = Number(score)
+        if (Number.isFinite(timestampMs) && timestampMs >= startMs && timestampMs <= endMs) {
+          return timestampMs
+        }
+      } catch (error) {
+        logger.debug(
+          `⚠️ Failed to resolve request detail timestamp from ${dayKey}: ${error.message}`
+        )
+      }
+    }
+
+    return null
   }
 
   async _enrichRecords(records = [], apiKeyCache = new Map(), accountCache = new Map()) {
@@ -712,69 +849,129 @@ class RequestDetailService {
 
     const availableFilterAccumulator = createAvailableFilterAccumulator()
     const summaryAccumulator = createSummaryAccumulator()
-    const apiKeyCache = new Map()
-    const accountCache = new Map()
     const client = redis.getClient()
     const requestedPageStart = (page - 1) * pageSize
     const requestedPageEnd = requestedPageStart + pageSize
     const pageRecords = []
     let totalRecords = 0
 
-    for (
-      let startIndex = 0;
-      startIndex < requestPointers.length;
-      startIndex += REQUEST_DETAIL_QUERY_BATCH_SIZE
-    ) {
-      const pointerBatch = requestPointers.slice(
-        startIndex,
-        startIndex + REQUEST_DETAIL_QUERY_BATCH_SIZE
-      )
-      const itemKeys = pointerBatch.map(
-        ({ requestId }) => `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
-      )
-      const rawItems = await client.mget(itemKeys)
-      const parsedBatch = rawItems
-        .map((rawItem, index) => {
-          const parsed = safeJsonParse(rawItem)
-          if (parsed && !parsed.timestamp) {
-            parsed.timestamp = new Date(pointerBatch[index].timestampMs).toISOString()
+    const hasKeyword = Boolean(filters.keyword?.trim())
+
+    if (hasKeyword) {
+      // keyword 搜索需要 enriched 字段（apiKeyName, accountName），走全量 enrichment 路径
+      const apiKeyCache = new Map()
+      const accountCache = new Map()
+
+      for (
+        let startIndex = 0;
+        startIndex < requestPointers.length;
+        startIndex += REQUEST_DETAIL_QUERY_BATCH_SIZE
+      ) {
+        const pointerBatch = requestPointers.slice(
+          startIndex,
+          startIndex + REQUEST_DETAIL_QUERY_BATCH_SIZE
+        )
+        const itemKeys = pointerBatch.map(
+          ({ requestId }) => `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
+        )
+        const rawItems = await client.mget(itemKeys)
+        const parsedBatch = rawItems
+          .map((rawItem, index) =>
+            restoreRecordTimestamp(safeJsonParse(rawItem), pointerBatch[index].timestampMs)
+          )
+          .filter(Boolean)
+
+        const enrichedBatch = await this._enrichRecords(parsedBatch, apiKeyCache, accountCache)
+
+        for (const record of enrichedBatch) {
+          updateAvailableFilterAccumulator(availableFilterAccumulator, record)
+
+          if (filters.apiKeyId && record.apiKeyId !== filters.apiKeyId) {
+            continue
           }
-          return parsed
-        })
-        .filter(Boolean)
+          if (filters.accountId && record.accountId !== filters.accountId) {
+            continue
+          }
+          if (filters.model && record.model !== filters.model) {
+            continue
+          }
+          if (filters.endpoint && record.endpoint !== filters.endpoint) {
+            continue
+          }
+          if (!this._matchesKeyword(record, filters.keyword)) {
+            continue
+          }
 
-      const enrichedBatch = await this._enrichRecords(parsedBatch, apiKeyCache, accountCache)
+          updateSummaryAccumulator(summaryAccumulator, record)
 
-      for (const record of enrichedBatch) {
-        updateAvailableFilterAccumulator(availableFilterAccumulator, record)
+          if (totalRecords >= requestedPageStart && totalRecords < requestedPageEnd) {
+            pageRecords.push({
+              ...record,
+              requestBodySnapshot: undefined
+            })
+          }
 
-        if (filters.apiKeyId && record.apiKeyId !== filters.apiKeyId) {
-          continue
+          totalRecords += 1
         }
-        if (filters.accountId && record.accountId !== filters.accountId) {
-          continue
-        }
-        if (filters.model && record.model !== filters.model) {
-          continue
-        }
-        if (filters.endpoint && record.endpoint !== filters.endpoint) {
-          continue
-        }
-        if (!this._matchesKeyword(record, filters.keyword)) {
-          continue
-        }
-
-        updateSummaryAccumulator(summaryAccumulator, record)
-
-        if (totalRecords >= requestedPageStart && totalRecords < requestedPageEnd) {
-          pageRecords.push({
-            ...record,
-            requestBodySnapshot: undefined
-          })
-        }
-
-        totalRecords += 1
       }
+    } else {
+      // 无 keyword：延迟 enrichment，只对当前页记录做 enrichment
+      const pageRawRecords = []
+
+      for (
+        let startIndex = 0;
+        startIndex < requestPointers.length;
+        startIndex += REQUEST_DETAIL_QUERY_BATCH_SIZE
+      ) {
+        const pointerBatch = requestPointers.slice(
+          startIndex,
+          startIndex + REQUEST_DETAIL_QUERY_BATCH_SIZE
+        )
+        const itemKeys = pointerBatch.map(
+          ({ requestId }) => `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
+        )
+        const rawItems = await client.mget(itemKeys)
+        const parsedBatch = rawItems
+          .map((rawItem, index) =>
+            restoreRecordTimestamp(safeJsonParse(rawItem), pointerBatch[index].timestampMs)
+          )
+          .filter(Boolean)
+
+        for (const record of parsedBatch) {
+          updateAvailableFilterAccumulatorRaw(availableFilterAccumulator, record)
+
+          if (filters.apiKeyId && record.apiKeyId !== filters.apiKeyId) {
+            continue
+          }
+          if (filters.accountId && record.accountId !== filters.accountId) {
+            continue
+          }
+          if (filters.model && record.model !== filters.model) {
+            continue
+          }
+          if (filters.endpoint && record.endpoint !== filters.endpoint) {
+            continue
+          }
+
+          updateSummaryAccumulator(summaryAccumulator, record)
+
+          if (totalRecords >= requestedPageStart && totalRecords < requestedPageEnd) {
+            pageRawRecords.push(record)
+          }
+
+          totalRecords += 1
+        }
+      }
+
+      const enrichedPageRecords = await this._enrichRecords(pageRawRecords)
+      for (const record of enrichedPageRecords) {
+        pageRecords.push({
+          ...record,
+          requestBodySnapshot: undefined
+        })
+      }
+
+      await this._resolveFilterDisplayNames(availableFilterAccumulator)
     }
 
     const totalPages = totalRecords > 0 ? Math.ceil(totalRecords / pageSize) : 0
@@ -830,6 +1027,32 @@ class RequestDetailService {
     const raw = await client.get(`${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`)
     const parsed = safeJsonParse(raw)
     if (!parsed) {
+      return {
+        captureEnabled: settings.captureEnabled,
+        retentionHours: settings.retentionHours,
+        bodyPreviewEnabled: settings.bodyPreviewEnabled,
+        record: null
+      }
+    }
+
+    const now = new Date()
+    const retentionStart = new Date(now.getTime() - settings.retentionHours * 3600 * 1000)
+    let recordMs = toMillis(parsed.timestamp)
+    if (recordMs === null) {
+      recordMs = await this._findRequestTimestampInRange(requestId, retentionStart, now, client)
+      if (recordMs === null) {
+        return {
+          captureEnabled: settings.captureEnabled,
+          retentionHours: settings.retentionHours,
+          bodyPreviewEnabled: settings.bodyPreviewEnabled,
+          record: null
+        }
+      }
+
+      parsed.timestamp = new Date(recordMs).toISOString()
+    }
+
+    if (recordMs < retentionStart.getTime()) {
       return {
         captureEnabled: settings.captureEnabled,
         retentionHours: settings.retentionHours,

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -80,8 +80,12 @@ function formatDayKey(date) {
 
 function listDayKeys(startDate, endDate) {
   const keys = []
-  const cursor = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate()))
-  const endCursor = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate()))
+  const cursor = new Date(
+    Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate())
+  )
+  const endCursor = new Date(
+    Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate())
+  )
 
   while (cursor <= endCursor) {
     keys.push(`${REQUEST_DETAIL_DAY_INDEX_PREFIX}${formatDayKey(cursor)}`)
@@ -192,13 +196,16 @@ function updateAvailableFilterAccumulator(accumulator, record) {
 
 function finalizeAvailableFilters(accumulator) {
   return {
-    apiKeys: Array.from(accumulator.apiKeyMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
-    accounts: Array.from(accumulator.accountMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    apiKeys: Array.from(accumulator.apiKeyMap.values()).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    ),
+    accounts: Array.from(accumulator.accountMap.values()).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    ),
     models: Array.from(accumulator.modelSet).sort((a, b) => a.localeCompare(b)),
     endpoints: Array.from(accumulator.endpointSet).sort((a, b) => a.localeCompare(b)),
     dateRange: {
-      earliest:
-        accumulator.earliest !== null ? new Date(accumulator.earliest).toISOString() : null,
+      earliest: accumulator.earliest !== null ? new Date(accumulator.earliest).toISOString() : null,
       latest: accumulator.latest !== null ? new Date(accumulator.latest).toISOString() : null
     }
   }
@@ -330,7 +337,8 @@ class RequestDetailService {
     const cacheReadTokens = normalizeNumber(detail.cacheReadTokens)
     const cacheCreateTokens = normalizeNumber(detail.cacheCreateTokens)
     const totalTokens =
-      normalizeNumber(detail.totalTokens) || inputTokens + outputTokens + cacheReadTokens + cacheCreateTokens
+      normalizeNumber(detail.totalTokens) ||
+      inputTokens + outputTokens + cacheReadTokens + cacheCreateTokens
     const statusCode = normalizeNumber(detail.statusCode)
     const cost = normalizeNumber(detail.cost, 6)
     const realCost = normalizeNumber(detail.realCost, 6)
@@ -561,7 +569,10 @@ class RequestDetailService {
 
     const preferredService = accountServices[normalizedType]
     const servicesToTry = preferredService
-      ? [[normalizedType, preferredService], ...Object.entries(accountServices).filter(([type]) => type !== normalizedType)]
+      ? [
+          [normalizedType, preferredService],
+          ...Object.entries(accountServices).filter(([type]) => type !== normalizedType)
+        ]
       : Object.entries(accountServices)
 
     for (const [type, service] of servicesToTry) {
@@ -599,14 +610,21 @@ class RequestDetailService {
       const cacheMetrics = getRequestDetailCacheMetrics(record)
       const reasoningInfo = resolveRequestDetailReasoning(record)
       const apiKeyName = await this._getApiKeyName(record.apiKeyId, apiKeyCache)
-      const accountInfo = await this._resolveAccountInfo(record.accountId, record.accountType, accountCache)
+      const accountInfo = await this._resolveAccountInfo(
+        record.accountId,
+        record.accountType,
+        accountCache
+      )
 
       enriched.push({
         ...record,
         apiKeyName: apiKeyName || record.apiKeyId || '未知 Key',
         accountName: accountInfo?.accountName || record.accountId || '未知账户',
         accountType: accountInfo?.accountType || record.accountType || 'unknown',
-        accountTypeName: accountInfo?.accountTypeName || accountTypeNames[record.accountType] || accountTypeNames.unknown,
+        accountTypeName:
+          accountInfo?.accountTypeName ||
+          accountTypeNames[record.accountType] ||
+          accountTypeNames.unknown,
         isOpenAIRelated: cacheMetrics.isOpenAIRelated,
         cacheCreateNotApplicable: cacheMetrics.cacheCreateNotApplicable,
         cacheHitRate: cacheMetrics.rate,
@@ -641,7 +659,11 @@ class RequestDetailService {
       record.method
     ]
 
-    return haystacks.some((value) => String(value || '').toLowerCase().includes(normalizedKeyword))
+    return haystacks.some((value) =>
+      String(value || '')
+        .toLowerCase()
+        .includes(normalizedKeyword)
+    )
   }
 
   async listRequestDetails(filters = {}) {

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -20,8 +20,8 @@ const {
 
 const REQUEST_DETAIL_ITEM_PREFIX = 'request_detail:item:'
 const REQUEST_DETAIL_DAY_INDEX_PREFIX = 'request_detail:index:day:'
-const DEFAULT_RETENTION_DAYS = 7
-const MAX_RETENTION_DAYS = 30
+const DEFAULT_RETENTION_HOURS = 6
+const MAX_RETENTION_HOURS = 30 * 24
 const REQUEST_DETAIL_QUERY_BATCH_SIZE = 200
 
 const accountTypeNames = {
@@ -52,12 +52,12 @@ const accountServices = {
   bedrock: bedrockAccountService
 }
 
-function clampRetentionDays(value) {
+function clampRetentionHours(value) {
   const parsed = Number.parseInt(value, 10)
   if (!Number.isFinite(parsed)) {
-    return DEFAULT_RETENTION_DAYS
+    return DEFAULT_RETENTION_HOURS
   }
-  return Math.min(Math.max(parsed, 1), MAX_RETENTION_DAYS)
+  return Math.min(Math.max(parsed, 1), MAX_RETENTION_HOURS)
 }
 
 function normalizeNumber(value, digits = null) {
@@ -266,14 +266,14 @@ class RequestDetailService {
     const config = await claudeRelayConfigService.getConfig()
     return {
       captureEnabled: config.requestDetailCaptureEnabled === true,
-      retentionDays: clampRetentionDays(config.requestDetailRetentionDays)
+      retentionHours: clampRetentionHours(config.requestDetailRetentionHours)
     }
   }
 
   _emptyListResult(settings, filters = {}) {
     return {
       captureEnabled: settings.captureEnabled,
-      retentionDays: settings.retentionDays,
+      retentionHours: settings.retentionHours,
       records: [],
       pagination: {
         currentPage: 1,
@@ -380,7 +380,7 @@ class RequestDetailService {
       const timestampMs = toMillis(normalized.timestamp) || Date.now()
       const itemKey = `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
       const dayKey = `${REQUEST_DETAIL_DAY_INDEX_PREFIX}${formatDayKey(new Date(timestampMs))}`
-      const ttlSeconds = Math.max(3600, settings.retentionDays * 86400)
+      const ttlSeconds = Math.max(3600, settings.retentionHours * 3600)
       const indexTtlSeconds = ttlSeconds + 86400
 
       await client
@@ -558,7 +558,7 @@ class RequestDetailService {
     const emptyResult = this._emptyListResult(settings, filters)
 
     const now = new Date()
-    const retentionStart = new Date(now.getTime() - settings.retentionDays * 86400 * 1000)
+    const retentionStart = new Date(now.getTime() - settings.retentionHours * 3600 * 1000)
     const startDate = filters.startDate ? new Date(filters.startDate) : retentionStart
     const endDate = filters.endDate ? new Date(filters.endDate) : now
 
@@ -582,7 +582,7 @@ class RequestDetailService {
       return {
         ...emptyResult,
         captureEnabled: settings.captureEnabled,
-        retentionDays: settings.retentionDays,
+        retentionHours: settings.retentionHours,
         filters: {
           ...emptyResult.filters,
           startDate: effectiveStart.toISOString(),
@@ -674,7 +674,7 @@ class RequestDetailService {
 
     return {
       captureEnabled: settings.captureEnabled,
-      retentionDays: settings.retentionDays,
+      retentionHours: settings.retentionHours,
       records: pageRecords,
       pagination: {
         currentPage: totalPages > 0 ? Math.min(page, totalPages) : 1,
@@ -706,7 +706,7 @@ class RequestDetailService {
     if (!client) {
       return {
         captureEnabled: settings.captureEnabled,
-        retentionDays: settings.retentionDays,
+        retentionHours: settings.retentionHours,
         record: null
       }
     }
@@ -716,7 +716,7 @@ class RequestDetailService {
     if (!parsed) {
       return {
         captureEnabled: settings.captureEnabled,
-        retentionDays: settings.retentionDays,
+        retentionHours: settings.retentionHours,
         record: null
       }
     }
@@ -724,7 +724,7 @@ class RequestDetailService {
     const [enrichedRecord] = await this._enrichRecords([parsed])
     return {
       captureEnabled: settings.captureEnabled,
-      retentionDays: settings.retentionDays,
+      retentionHours: settings.retentionHours,
       record: enrichedRecord || null
     }
   }

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -1,0 +1,735 @@
+const redis = require('../models/redis')
+const logger = require('../utils/logger')
+const claudeRelayConfigService = require('./claudeRelayConfigService')
+const claudeAccountService = require('./account/claudeAccountService')
+const claudeConsoleAccountService = require('./account/claudeConsoleAccountService')
+const ccrAccountService = require('./account/ccrAccountService')
+const geminiAccountService = require('./account/geminiAccountService')
+const geminiApiAccountService = require('./account/geminiApiAccountService')
+const openaiAccountService = require('./account/openaiAccountService')
+const openaiResponsesAccountService = require('./account/openaiResponsesAccountService')
+const azureOpenaiAccountService = require('./account/azureOpenaiAccountService')
+const droidAccountService = require('./account/droidAccountService')
+const bedrockAccountService = require('./account/bedrockAccountService')
+const {
+  sanitizeRequestBodySnapshot,
+  getRequestDetailCacheMetrics,
+  extractRequestReasoningInfo,
+  resolveRequestDetailReasoning
+} = require('../utils/requestDetailHelper')
+
+const REQUEST_DETAIL_ITEM_PREFIX = 'request_detail:item:'
+const REQUEST_DETAIL_DAY_INDEX_PREFIX = 'request_detail:index:day:'
+const DEFAULT_RETENTION_DAYS = 7
+const MAX_RETENTION_DAYS = 30
+const REQUEST_DETAIL_QUERY_BATCH_SIZE = 200
+
+const accountTypeNames = {
+  claude: 'Claude官方',
+  'claude-official': 'Claude官方',
+  'claude-console': 'Claude Console',
+  ccr: 'Claude Console Relay',
+  openai: 'OpenAI',
+  'openai-responses': 'OpenAI Responses',
+  'azure-openai': 'Azure OpenAI',
+  gemini: 'Gemini',
+  'gemini-api': 'Gemini API',
+  droid: 'Droid',
+  bedrock: 'AWS Bedrock',
+  unknown: '未知渠道'
+}
+
+const accountServices = {
+  claude: claudeAccountService,
+  'claude-console': claudeConsoleAccountService,
+  ccr: ccrAccountService,
+  openai: openaiAccountService,
+  'openai-responses': openaiResponsesAccountService,
+  'azure-openai': azureOpenaiAccountService,
+  gemini: geminiAccountService,
+  'gemini-api': geminiApiAccountService,
+  droid: droidAccountService,
+  bedrock: bedrockAccountService
+}
+
+function clampRetentionDays(value) {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_RETENTION_DAYS
+  }
+  return Math.min(Math.max(parsed, 1), MAX_RETENTION_DAYS)
+}
+
+function normalizeNumber(value, digits = null) {
+  const num = Number(value)
+  if (!Number.isFinite(num)) {
+    return 0
+  }
+
+  if (digits === null) {
+    return num
+  }
+
+  return Number(num.toFixed(digits))
+}
+
+function formatDayKey(date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function listDayKeys(startDate, endDate) {
+  const keys = []
+  const cursor = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate()))
+  const endCursor = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate()))
+
+  while (cursor <= endCursor) {
+    keys.push(`${REQUEST_DETAIL_DAY_INDEX_PREFIX}${formatDayKey(cursor)}`)
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+
+  return keys
+}
+
+function toIsoString(value) {
+  if (!value) {
+    return null
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toISOString()
+}
+
+function toMillis(value) {
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.getTime()
+}
+
+function safeJsonParse(value) {
+  if (!value) {
+    return null
+  }
+
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    logger.warn(`⚠️ Failed to parse request detail record: ${error.message}`)
+    return null
+  }
+}
+
+function makeRequestDetailId() {
+  return `rd_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
+}
+
+class RequestDetailValidationError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'RequestDetailValidationError'
+    this.statusCode = 400
+  }
+}
+
+function createAvailableFilterAccumulator() {
+  return {
+    apiKeyMap: new Map(),
+    accountMap: new Map(),
+    modelSet: new Set(),
+    endpointSet: new Set(),
+    earliest: null,
+    latest: null
+  }
+}
+
+function updateAvailableFilterAccumulator(accumulator, record) {
+  if (record.apiKeyId) {
+    accumulator.apiKeyMap.set(record.apiKeyId, {
+      id: record.apiKeyId,
+      name: record.apiKeyName || record.apiKeyId
+    })
+  }
+
+  if (record.accountId) {
+    accumulator.accountMap.set(record.accountId, {
+      id: record.accountId,
+      name: record.accountName || record.accountId,
+      accountType: record.accountType || 'unknown',
+      accountTypeName:
+        record.accountTypeName || accountTypeNames[record.accountType] || accountTypeNames.unknown
+    })
+  }
+
+  if (record.model) {
+    accumulator.modelSet.add(record.model)
+  }
+
+  if (record.endpoint) {
+    accumulator.endpointSet.add(record.endpoint)
+  }
+
+  const ts = toMillis(record.timestamp)
+  if (ts !== null) {
+    if (accumulator.earliest === null || ts < accumulator.earliest) {
+      accumulator.earliest = ts
+    }
+    if (accumulator.latest === null || ts > accumulator.latest) {
+      accumulator.latest = ts
+    }
+  }
+}
+
+function finalizeAvailableFilters(accumulator) {
+  return {
+    apiKeys: Array.from(accumulator.apiKeyMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    accounts: Array.from(accumulator.accountMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    models: Array.from(accumulator.modelSet).sort((a, b) => a.localeCompare(b)),
+    endpoints: Array.from(accumulator.endpointSet).sort((a, b) => a.localeCompare(b)),
+    dateRange: {
+      earliest:
+        accumulator.earliest !== null ? new Date(accumulator.earliest).toISOString() : null,
+      latest: accumulator.latest !== null ? new Date(accumulator.latest).toISOString() : null
+    }
+  }
+}
+
+function createSummaryAccumulator() {
+  return {
+    totalRequests: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreateTokens: 0,
+    totalCost: 0,
+    totalDurationMs: 0,
+    cacheHitNumerator: 0,
+    cacheHitDenominator: 0,
+    openAIRelatedRequests: 0
+  }
+}
+
+function updateSummaryAccumulator(accumulator, record) {
+  const cacheMetrics = getRequestDetailCacheMetrics(record)
+
+  accumulator.totalRequests += 1
+  accumulator.inputTokens += normalizeNumber(record.inputTokens)
+  accumulator.outputTokens += normalizeNumber(record.outputTokens)
+  accumulator.cacheReadTokens += normalizeNumber(record.cacheReadTokens)
+  if (!cacheMetrics.cacheCreateNotApplicable) {
+    accumulator.cacheCreateTokens += normalizeNumber(record.cacheCreateTokens)
+  }
+  accumulator.totalCost += normalizeNumber(record.cost)
+  accumulator.totalDurationMs += normalizeNumber(record.durationMs)
+  accumulator.cacheHitNumerator += cacheMetrics.numerator
+  accumulator.cacheHitDenominator += cacheMetrics.denominator
+  if (cacheMetrics.isOpenAIRelated) {
+    accumulator.openAIRelatedRequests += 1
+  }
+}
+
+function finalizeSummary(accumulator) {
+  return {
+    totalRequests: accumulator.totalRequests,
+    inputTokens: accumulator.inputTokens,
+    outputTokens: accumulator.outputTokens,
+    cacheReadTokens: accumulator.cacheReadTokens,
+    cacheCreateTokens: accumulator.cacheCreateTokens,
+    totalCost: Number(accumulator.totalCost.toFixed(6)),
+    avgDurationMs:
+      accumulator.totalRequests > 0
+        ? Math.round(accumulator.totalDurationMs / accumulator.totalRequests)
+        : 0,
+    cacheHitRate:
+      accumulator.cacheHitDenominator > 0
+        ? Number(
+            ((accumulator.cacheHitNumerator / accumulator.cacheHitDenominator) * 100).toFixed(2)
+          )
+        : 0,
+    cacheCreateNotApplicable:
+      accumulator.totalRequests > 0 &&
+      accumulator.openAIRelatedRequests === accumulator.totalRequests
+  }
+}
+
+class RequestDetailService {
+  async getSettings() {
+    const config = await claudeRelayConfigService.getConfig()
+    return {
+      captureEnabled: config.requestDetailCaptureEnabled === true,
+      retentionDays: clampRetentionDays(config.requestDetailRetentionDays)
+    }
+  }
+
+  _emptyListResult(settings, filters = {}) {
+    return {
+      captureEnabled: settings.captureEnabled,
+      retentionDays: settings.retentionDays,
+      records: [],
+      pagination: {
+        currentPage: 1,
+        pageSize: Number.parseInt(filters.pageSize, 10) || 50,
+        totalRecords: 0,
+        totalPages: 0,
+        hasNextPage: false,
+        hasPreviousPage: false
+      },
+      filters: {
+        startDate: filters.startDate || null,
+        endDate: filters.endDate || null,
+        keyword: filters.keyword || null,
+        apiKeyId: filters.apiKeyId || null,
+        accountId: filters.accountId || null,
+        model: filters.model || null,
+        endpoint: filters.endpoint || null,
+        hasCustomDateRange: Boolean(filters.startDate || filters.endDate),
+        sortOrder: filters.sortOrder === 'asc' ? 'asc' : 'desc'
+      },
+      availableFilters: {
+        apiKeys: [],
+        accounts: [],
+        models: [],
+        endpoints: [],
+        dateRange: {
+          earliest: null,
+          latest: null
+        }
+      },
+      summary: {
+        totalRequests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreateTokens: 0,
+        totalCost: 0,
+        avgDurationMs: 0,
+        cacheHitRate: 0,
+        cacheCreateNotApplicable: false
+      }
+    }
+  }
+
+  _normalizeRecord(detail, requestId) {
+    const timestamp = toIsoString(detail.timestamp) || new Date().toISOString()
+    const durationMs = normalizeNumber(detail.durationMs)
+    const inputTokens = normalizeNumber(detail.inputTokens)
+    const outputTokens = normalizeNumber(detail.outputTokens)
+    const cacheReadTokens = normalizeNumber(detail.cacheReadTokens)
+    const cacheCreateTokens = normalizeNumber(detail.cacheCreateTokens)
+    const totalTokens =
+      normalizeNumber(detail.totalTokens) || inputTokens + outputTokens + cacheReadTokens + cacheCreateTokens
+    const statusCode = normalizeNumber(detail.statusCode)
+    const cost = normalizeNumber(detail.cost, 6)
+    const realCost = normalizeNumber(detail.realCost, 6)
+    const reasoningInfo = extractRequestReasoningInfo(
+      detail.requestBodySnapshot ?? detail.requestBody
+    )
+
+    return {
+      requestId,
+      timestamp,
+      requestStartedAt: toIsoString(detail.requestStartedAt),
+      endpoint: detail.endpoint || null,
+      method: detail.method || null,
+      statusCode,
+      stream: detail.stream === true,
+      apiKeyId: detail.apiKeyId || null,
+      accountId: detail.accountId || null,
+      accountType: detail.accountType || 'unknown',
+      model: detail.model || 'unknown',
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreateTokens,
+      totalTokens,
+      cost,
+      realCost,
+      costBreakdown: detail.costBreakdown || null,
+      realCostBreakdown: detail.realCostBreakdown || null,
+      durationMs,
+      isLongContextRequest: detail.isLongContextRequest === true,
+      requestBodySnapshot: sanitizeRequestBodySnapshot(detail.requestBodySnapshot ?? detail.requestBody),
+      reasoningDisplay: detail.reasoningDisplay || reasoningInfo.reasoningDisplay || null,
+      reasoningSource: detail.reasoningSource || reasoningInfo.reasoningSource || null
+    }
+  }
+
+  async captureRequestDetail(detail = {}) {
+    try {
+      const settings = await this.getSettings()
+      if (!settings.captureEnabled) {
+        return { captured: false, reason: 'disabled' }
+      }
+
+      const client = redis.getClient()
+      if (!client) {
+        return { captured: false, reason: 'redis_unavailable' }
+      }
+
+      const requestId = detail.requestId || makeRequestDetailId()
+      const normalized = this._normalizeRecord(detail, requestId)
+      const timestampMs = toMillis(normalized.timestamp) || Date.now()
+      const itemKey = `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
+      const dayKey = `${REQUEST_DETAIL_DAY_INDEX_PREFIX}${formatDayKey(new Date(timestampMs))}`
+      const ttlSeconds = Math.max(3600, settings.retentionDays * 86400)
+      const indexTtlSeconds = ttlSeconds + 86400
+
+      await client
+        .multi()
+        .set(itemKey, JSON.stringify(normalized), 'EX', ttlSeconds)
+        .zadd(dayKey, timestampMs, requestId)
+        .expire(dayKey, indexTtlSeconds)
+        .exec()
+
+      return { captured: true, requestId }
+    } catch (error) {
+      logger.warn(`⚠️ Failed to capture request detail: ${error.message}`)
+      return { captured: false, reason: 'error', message: error.message }
+    }
+  }
+
+  async _loadRequestPointersInRange(startDate, endDate) {
+    const client = redis.getClient()
+    if (!client) {
+      return []
+    }
+
+    const startMs = startDate.getTime()
+    const endMs = endDate.getTime()
+    const dayKeys = listDayKeys(startDate, endDate)
+    const requestIds = []
+
+    for (const dayKey of dayKeys) {
+      try {
+        const entries = await client.zrangebyscore(dayKey, startMs, endMs, 'WITHSCORES')
+        if (Array.isArray(entries) && entries.length > 0) {
+          for (let index = 0; index < entries.length; index += 2) {
+            const requestId = entries[index]
+            const timestampMs = Number(entries[index + 1])
+            if (requestId && Number.isFinite(timestampMs)) {
+              requestIds.push({ requestId, timestampMs })
+            }
+          }
+        }
+      } catch (error) {
+        logger.warn(`⚠️ Failed to load request detail index ${dayKey}: ${error.message}`)
+      }
+    }
+
+    const uniqueRequestIds = new Map()
+    for (const item of requestIds) {
+      uniqueRequestIds.set(item.requestId, item.timestampMs)
+    }
+
+    return Array.from(uniqueRequestIds.entries()).map(([requestId, timestampMs]) => ({
+      requestId,
+      timestampMs
+    }))
+  }
+
+  async _getApiKeyName(keyId, cache) {
+    if (!keyId) {
+      return null
+    }
+
+    if (cache.has(keyId)) {
+      return cache.get(keyId)
+    }
+
+    try {
+      const keyData = await redis.getApiKey(keyId)
+      const keyName = keyData?.name || keyData?.label || keyId
+      cache.set(keyId, keyName)
+      return keyName
+    } catch (error) {
+      logger.debug(`⚠️ Failed to resolve API key ${keyId}: ${error.message}`)
+      cache.set(keyId, keyId)
+      return keyId
+    }
+  }
+
+  async _resolveAccountInfo(accountId, accountType, cache) {
+    if (!accountId) {
+      return null
+    }
+
+    const normalizedType = accountType || 'unknown'
+    const cacheKey = `${normalizedType}:${accountId}`
+    if (cache.has(cacheKey)) {
+      return cache.get(cacheKey)
+    }
+
+    const preferredService = accountServices[normalizedType]
+    const servicesToTry = preferredService
+      ? [[normalizedType, preferredService], ...Object.entries(accountServices).filter(([type]) => type !== normalizedType)]
+      : Object.entries(accountServices)
+
+    for (const [type, service] of servicesToTry) {
+      try {
+        const account = await service.getAccount(accountId)
+        if (account) {
+          const info = {
+            accountId,
+            accountName: account.name || account.email || accountId,
+            accountType: type,
+            accountTypeName: accountTypeNames[type] || accountTypeNames.unknown
+          }
+          cache.set(cacheKey, info)
+          return info
+        }
+      } catch (error) {
+        logger.debug(`⚠️ Failed to resolve account ${accountId} from ${type}: ${error.message}`)
+      }
+    }
+
+    const fallback = {
+      accountId,
+      accountName: accountId,
+      accountType: normalizedType,
+      accountTypeName: accountTypeNames[normalizedType] || accountTypeNames.unknown
+    }
+    cache.set(cacheKey, fallback)
+    return fallback
+  }
+
+  async _enrichRecords(records = [], apiKeyCache = new Map(), accountCache = new Map()) {
+    const enriched = []
+
+    for (const record of records) {
+      const cacheMetrics = getRequestDetailCacheMetrics(record)
+      const reasoningInfo = resolveRequestDetailReasoning(record)
+      const apiKeyName = await this._getApiKeyName(record.apiKeyId, apiKeyCache)
+      const accountInfo = await this._resolveAccountInfo(record.accountId, record.accountType, accountCache)
+
+      enriched.push({
+        ...record,
+        apiKeyName: apiKeyName || record.apiKeyId || '未知 Key',
+        accountName: accountInfo?.accountName || record.accountId || '未知账户',
+        accountType: accountInfo?.accountType || record.accountType || 'unknown',
+        accountTypeName: accountInfo?.accountTypeName || accountTypeNames[record.accountType] || accountTypeNames.unknown,
+        isOpenAIRelated: cacheMetrics.isOpenAIRelated,
+        cacheCreateNotApplicable: cacheMetrics.cacheCreateNotApplicable,
+        cacheHitRate: cacheMetrics.rate,
+        hasRequestBodySnapshot: Boolean(record.requestBodySnapshot),
+        reasoningDisplay: reasoningInfo.reasoningDisplay,
+        reasoningSource: reasoningInfo.reasoningSource
+      })
+    }
+
+    return enriched
+  }
+
+  _matchesKeyword(record, keyword) {
+    if (!keyword) {
+      return true
+    }
+
+    const normalizedKeyword = String(keyword).trim().toLowerCase()
+    if (!normalizedKeyword) {
+      return true
+    }
+
+    const haystacks = [
+      record.requestId,
+      record.apiKeyId,
+      record.apiKeyName,
+      record.accountId,
+      record.accountName,
+      record.accountTypeName,
+      record.model,
+      record.endpoint,
+      record.method
+    ]
+
+    return haystacks.some((value) => String(value || '').toLowerCase().includes(normalizedKeyword))
+  }
+
+  async listRequestDetails(filters = {}) {
+    const settings = await this.getSettings()
+    const emptyResult = this._emptyListResult(settings, filters)
+
+    const now = new Date()
+    const retentionStart = new Date(now.getTime() - settings.retentionDays * 86400 * 1000)
+    const startDate = filters.startDate ? new Date(filters.startDate) : retentionStart
+    const endDate = filters.endDate ? new Date(filters.endDate) : now
+
+    const effectiveStart = startDate < retentionStart ? retentionStart : startDate
+    const effectiveEnd = endDate > now ? now : endDate
+
+    if (Number.isNaN(effectiveStart.getTime()) || Number.isNaN(effectiveEnd.getTime())) {
+      throw new RequestDetailValidationError('Invalid date range')
+    }
+
+    if (effectiveStart > effectiveEnd) {
+      throw new RequestDetailValidationError('Start date must be before or equal to end date')
+    }
+
+    const page = Math.max(Number.parseInt(filters.page, 10) || 1, 1)
+    const pageSize = Math.min(Math.max(Number.parseInt(filters.pageSize, 10) || 50, 1), 200)
+    const sortOrder = filters.sortOrder === 'asc' ? 'asc' : 'desc'
+
+    const requestPointers = await this._loadRequestPointersInRange(effectiveStart, effectiveEnd)
+    if (requestPointers.length === 0) {
+      return {
+        ...emptyResult,
+        captureEnabled: settings.captureEnabled,
+        retentionDays: settings.retentionDays,
+        filters: {
+          ...emptyResult.filters,
+          startDate: effectiveStart.toISOString(),
+          endDate: effectiveEnd.toISOString(),
+          hasCustomDateRange: Boolean(filters.startDate || filters.endDate)
+        }
+      }
+    }
+
+    requestPointers.sort((a, b) =>
+      sortOrder === 'asc' ? a.timestampMs - b.timestampMs : b.timestampMs - a.timestampMs
+    )
+
+    const availableFilterAccumulator = createAvailableFilterAccumulator()
+    const summaryAccumulator = createSummaryAccumulator()
+    const apiKeyCache = new Map()
+    const accountCache = new Map()
+    const client = redis.getClient()
+    const requestedPageStart = (page - 1) * pageSize
+    const requestedPageEnd = requestedPageStart + pageSize
+    const pageRecords = []
+    let totalRecords = 0
+
+    for (
+      let startIndex = 0;
+      startIndex < requestPointers.length;
+      startIndex += REQUEST_DETAIL_QUERY_BATCH_SIZE
+    ) {
+      const pointerBatch = requestPointers.slice(
+        startIndex,
+        startIndex + REQUEST_DETAIL_QUERY_BATCH_SIZE
+      )
+      const itemKeys = pointerBatch.map(
+        ({ requestId }) => `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
+      )
+      const rawItems = await client.mget(itemKeys)
+      const parsedBatch = rawItems
+        .map((rawItem, index) => {
+          const parsed = safeJsonParse(rawItem)
+          if (parsed && !parsed.timestamp) {
+            parsed.timestamp = new Date(pointerBatch[index].timestampMs).toISOString()
+          }
+          return parsed
+        })
+        .filter(Boolean)
+
+      const enrichedBatch = await this._enrichRecords(parsedBatch, apiKeyCache, accountCache)
+
+      for (const record of enrichedBatch) {
+        updateAvailableFilterAccumulator(availableFilterAccumulator, record)
+
+        if (filters.apiKeyId && record.apiKeyId !== filters.apiKeyId) {
+          continue
+        }
+        if (filters.accountId && record.accountId !== filters.accountId) {
+          continue
+        }
+        if (filters.model && record.model !== filters.model) {
+          continue
+        }
+        if (filters.endpoint && record.endpoint !== filters.endpoint) {
+          continue
+        }
+        if (!this._matchesKeyword(record, filters.keyword)) {
+          continue
+        }
+
+        updateSummaryAccumulator(summaryAccumulator, record)
+
+        if (totalRecords >= requestedPageStart && totalRecords < requestedPageEnd) {
+          pageRecords.push({
+            ...record,
+            requestBodySnapshot: undefined
+          })
+        }
+
+        totalRecords += 1
+      }
+    }
+
+    const totalPages = totalRecords > 0 ? Math.ceil(totalRecords / pageSize) : 0
+    if (totalPages > 0 && page > totalPages) {
+      return this.listRequestDetails({
+        ...filters,
+        page: totalPages,
+        pageSize
+      })
+    }
+
+    return {
+      captureEnabled: settings.captureEnabled,
+      retentionDays: settings.retentionDays,
+      records: pageRecords,
+      pagination: {
+        currentPage: totalPages > 0 ? Math.min(page, totalPages) : 1,
+        pageSize,
+        totalRecords,
+        totalPages,
+        hasNextPage: totalPages > 0 && page < totalPages,
+        hasPreviousPage: totalPages > 0 && page > 1
+      },
+      filters: {
+        startDate: effectiveStart.toISOString(),
+        endDate: effectiveEnd.toISOString(),
+        keyword: filters.keyword || null,
+        apiKeyId: filters.apiKeyId || null,
+        accountId: filters.accountId || null,
+        model: filters.model || null,
+        endpoint: filters.endpoint || null,
+        hasCustomDateRange: Boolean(filters.startDate || filters.endDate),
+        sortOrder
+      },
+      availableFilters: finalizeAvailableFilters(availableFilterAccumulator),
+      summary: finalizeSummary(summaryAccumulator)
+    }
+  }
+
+  async getRequestDetail(requestId) {
+    const settings = await this.getSettings()
+    const client = redis.getClient()
+    if (!client) {
+      return {
+        captureEnabled: settings.captureEnabled,
+        retentionDays: settings.retentionDays,
+        record: null
+      }
+    }
+
+    const raw = await client.get(`${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`)
+    const parsed = safeJsonParse(raw)
+    if (!parsed) {
+      return {
+        captureEnabled: settings.captureEnabled,
+        retentionDays: settings.retentionDays,
+        record: null
+      }
+    }
+
+    const [enrichedRecord] = await this._enrichRecords([parsed])
+    return {
+      captureEnabled: settings.captureEnabled,
+      retentionDays: settings.retentionDays,
+      record: enrichedRecord || null
+    }
+  }
+}
+
+module.exports = new RequestDetailService()
+module.exports.REQUEST_DETAIL_ITEM_PREFIX = REQUEST_DETAIL_ITEM_PREFIX
+module.exports.REQUEST_DETAIL_DAY_INDEX_PREFIX = REQUEST_DETAIL_DAY_INDEX_PREFIX

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -23,6 +23,7 @@ const REQUEST_DETAIL_DAY_INDEX_PREFIX = 'request_detail:index:day:'
 const DEFAULT_RETENTION_HOURS = 6
 const MAX_RETENTION_HOURS = 30 * 24
 const REQUEST_DETAIL_QUERY_BATCH_SIZE = 200
+const REQUEST_DETAIL_SCAN_BATCH_SIZE = 200
 
 const accountTypeNames = {
   claude: 'Claude官方',
@@ -266,7 +267,8 @@ class RequestDetailService {
     const config = await claudeRelayConfigService.getConfig()
     return {
       captureEnabled: config.requestDetailCaptureEnabled === true,
-      retentionHours: clampRetentionHours(config.requestDetailRetentionHours)
+      retentionHours: clampRetentionHours(config.requestDetailRetentionHours),
+      bodyPreviewEnabled: config.requestDetailBodyPreviewEnabled === true
     }
   }
 
@@ -274,6 +276,7 @@ class RequestDetailService {
     return {
       captureEnabled: settings.captureEnabled,
       retentionHours: settings.retentionHours,
+      bodyPreviewEnabled: settings.bodyPreviewEnabled,
       records: [],
       pagination: {
         currentPage: 1,
@@ -318,7 +321,8 @@ class RequestDetailService {
     }
   }
 
-  _normalizeRecord(detail, requestId) {
+  _normalizeRecord(detail, requestId, options = {}) {
+    const requestBodySource = detail.requestBodySnapshot ?? detail.requestBody
     const timestamp = toIsoString(detail.timestamp) || new Date().toISOString()
     const durationMs = normalizeNumber(detail.durationMs)
     const inputTokens = normalizeNumber(detail.inputTokens)
@@ -330,11 +334,8 @@ class RequestDetailService {
     const statusCode = normalizeNumber(detail.statusCode)
     const cost = normalizeNumber(detail.cost, 6)
     const realCost = normalizeNumber(detail.realCost, 6)
-    const reasoningInfo = extractRequestReasoningInfo(
-      detail.requestBodySnapshot ?? detail.requestBody
-    )
-
-    return {
+    const reasoningInfo = extractRequestReasoningInfo(requestBodySource)
+    const normalized = {
       requestId,
       timestamp,
       requestStartedAt: toIsoString(detail.requestStartedAt),
@@ -357,10 +358,15 @@ class RequestDetailService {
       realCostBreakdown: detail.realCostBreakdown || null,
       durationMs,
       isLongContextRequest: detail.isLongContextRequest === true,
-      requestBodySnapshot: sanitizeRequestBodySnapshot(detail.requestBodySnapshot ?? detail.requestBody),
       reasoningDisplay: detail.reasoningDisplay || reasoningInfo.reasoningDisplay || null,
       reasoningSource: detail.reasoningSource || reasoningInfo.reasoningSource || null
     }
+
+    if (options.bodyPreviewEnabled && requestBodySource !== undefined) {
+      normalized.requestBodySnapshot = sanitizeRequestBodySnapshot(requestBodySource)
+    }
+
+    return normalized
   }
 
   async captureRequestDetail(detail = {}) {
@@ -376,7 +382,9 @@ class RequestDetailService {
       }
 
       const requestId = detail.requestId || makeRequestDetailId()
-      const normalized = this._normalizeRecord(detail, requestId)
+      const normalized = this._normalizeRecord(detail, requestId, {
+        bodyPreviewEnabled: settings.bodyPreviewEnabled
+      })
       const timestampMs = toMillis(normalized.timestamp) || Date.now()
       const itemKey = `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
       const dayKey = `${REQUEST_DETAIL_DAY_INDEX_PREFIX}${formatDayKey(new Date(timestampMs))}`
@@ -434,6 +442,89 @@ class RequestDetailService {
       requestId,
       timestampMs
     }))
+  }
+
+  async _scanRequestDetailItemKeys(visitor) {
+    const client = redis.getClient()
+    if (!client) {
+      return
+    }
+
+    let cursor = '0'
+    do {
+      const [nextCursor, keys] = await client.scan(
+        cursor,
+        'MATCH',
+        `${REQUEST_DETAIL_ITEM_PREFIX}*`,
+        'COUNT',
+        REQUEST_DETAIL_SCAN_BATCH_SIZE
+      )
+      cursor = nextCursor
+      if (Array.isArray(keys) && keys.length > 0) {
+        await visitor(keys, client)
+      }
+    } while (cursor !== '0')
+  }
+
+  async getRequestBodyPreviewStats() {
+    const settings = await this.getSettings()
+    let snapshotCount = 0
+
+    await this._scanRequestDetailItemKeys(async (keys, client) => {
+      const rawItems = await client.mget(keys)
+      for (const rawItem of rawItems) {
+        const parsed = safeJsonParse(rawItem)
+        if (
+          parsed &&
+          Object.prototype.hasOwnProperty.call(parsed, 'requestBodySnapshot') &&
+          parsed.requestBodySnapshot !== undefined
+        ) {
+          snapshotCount += 1
+        }
+      }
+    })
+
+    return {
+      captureEnabled: settings.captureEnabled,
+      retentionHours: settings.retentionHours,
+      bodyPreviewEnabled: settings.bodyPreviewEnabled,
+      snapshotCount,
+      hasSnapshots: snapshotCount > 0
+    }
+  }
+
+  async purgeRequestBodySnapshots() {
+    let updatedRecords = 0
+
+    await this._scanRequestDetailItemKeys(async (keys, client) => {
+      const rawItems = await client.mget(keys)
+      const pipeline = typeof client.pipeline === 'function' ? client.pipeline() : client.multi()
+      let hasMutations = false
+
+      rawItems.forEach((rawItem, index) => {
+        const parsed = safeJsonParse(rawItem)
+        if (
+          !parsed ||
+          !Object.prototype.hasOwnProperty.call(parsed, 'requestBodySnapshot') ||
+          parsed.requestBodySnapshot === undefined
+        ) {
+          return
+        }
+
+        delete parsed.requestBodySnapshot
+        pipeline.set(keys[index], JSON.stringify(parsed), 'KEEPTTL')
+        hasMutations = true
+        updatedRecords += 1
+      })
+
+      if (hasMutations) {
+        await pipeline.exec()
+      }
+    })
+
+    return {
+      updatedRecords
+    }
   }
 
   async _getApiKeyName(keyId, cache) {
@@ -583,6 +674,7 @@ class RequestDetailService {
         ...emptyResult,
         captureEnabled: settings.captureEnabled,
         retentionHours: settings.retentionHours,
+        bodyPreviewEnabled: settings.bodyPreviewEnabled,
         filters: {
           ...emptyResult.filters,
           startDate: effectiveStart.toISOString(),
@@ -675,6 +767,7 @@ class RequestDetailService {
     return {
       captureEnabled: settings.captureEnabled,
       retentionHours: settings.retentionHours,
+      bodyPreviewEnabled: settings.bodyPreviewEnabled,
       records: pageRecords,
       pagination: {
         currentPage: totalPages > 0 ? Math.min(page, totalPages) : 1,
@@ -707,6 +800,7 @@ class RequestDetailService {
       return {
         captureEnabled: settings.captureEnabled,
         retentionHours: settings.retentionHours,
+        bodyPreviewEnabled: settings.bodyPreviewEnabled,
         record: null
       }
     }
@@ -717,6 +811,7 @@ class RequestDetailService {
       return {
         captureEnabled: settings.captureEnabled,
         retentionHours: settings.retentionHours,
+        bodyPreviewEnabled: settings.bodyPreviewEnabled,
         record: null
       }
     }
@@ -725,6 +820,7 @@ class RequestDetailService {
     return {
       captureEnabled: settings.captureEnabled,
       retentionHours: settings.retentionHours,
+      bodyPreviewEnabled: settings.bodyPreviewEnabled,
       record: enrichedRecord || null
     }
   }

--- a/src/utils/requestDetailHelper.js
+++ b/src/utils/requestDetailHelper.js
@@ -1,4 +1,5 @@
-const SENSITIVE_KEY_PATTERN = /(authorization|proxy-authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|cookie|set-cookie|client_secret|private[_-]?key|proxy)/i
+const SENSITIVE_KEY_PATTERN =
+  /(authorization|proxy-authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|cookie|set-cookie|client_secret|private[_-]?key|proxy)/i
 const DEFAULT_MAX_STRING_CHARS = 80
 const DEFAULT_MAX_ARRAY_ITEMS = 24
 const DEFAULT_MAX_DEPTH = 6
@@ -6,6 +7,7 @@ const DEFAULT_MAX_TOTAL_CHARS = 12000
 const ENCRYPTED_CONTENT_KEY = 'encrypted_content'
 const TOOLS_KEY = 'tools'
 const PREVIEW_TRUNCATION_SUFFIX_PATTERN = /\.\.\.\[(?:truncated )?(\d+) chars\]$/
+const OPENAI_RELATED_ACCOUNT_TYPES = new Set(['openai', 'openai-responses', 'azure-openai'])
 
 function toFiniteNumber(value) {
   if (value === undefined || value === null || value === '') {
@@ -451,9 +453,7 @@ function sanitizeValue(value, ctx) {
 
       if (key === TOOLS_KEY) {
         if (Array.isArray(childValue)) {
-          result[key] = childValue
-            .slice(0, maxArrayItems)
-            .map((item) => summarizeToolEntry(item))
+          result[key] = childValue.slice(0, maxArrayItems).map((item) => summarizeToolEntry(item))
 
           if (childValue.length > maxArrayItems) {
             result[key].push(`...[${childValue.length - maxArrayItems} more items]`)
@@ -543,6 +543,25 @@ function getRequestEndpoint(req) {
   return queryIndex >= 0 ? originalUrl.slice(0, queryIndex) : originalUrl
 }
 
+function toTimestampMs(value) {
+  const numericValue = toFiniteNumber(value)
+  if (numericValue !== null) {
+    return numericValue
+  }
+
+  if (value instanceof Date) {
+    const dateValue = value.getTime()
+    return Number.isFinite(dateValue) ? dateValue : null
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 function createRequestDetailMeta(req, overrides = {}) {
   const nowMs = Date.now()
   const statusCode = toFiniteNumber(overrides.statusCode)
@@ -564,6 +583,23 @@ function createRequestDetailMeta(req, overrides = {}) {
     durationMs: durationMs ?? (effectiveStart ? Math.max(0, nowMs - effectiveStart) : null),
     requestStartedAt: effectiveStart ? new Date(effectiveStart).toISOString() : null,
     requestBody
+  }
+}
+
+function finalizeRequestDetailMeta(requestMeta = null) {
+  if (!requestMeta || typeof requestMeta !== 'object') {
+    return null
+  }
+
+  const requestStartedAtMs = toTimestampMs(requestMeta.requestStartedAt)
+  const durationMs =
+    requestStartedAtMs !== null
+      ? Math.max(0, Date.now() - requestStartedAtMs)
+      : toFiniteNumber(requestMeta.durationMs)
+
+  return {
+    ...requestMeta,
+    durationMs
   }
 }
 
@@ -594,14 +630,32 @@ function extractOpenAICacheReadTokens(usage = {}) {
 }
 
 function isOpenAIRelatedEndpoint(endpoint) {
-  return typeof endpoint === 'string' && endpoint.startsWith('/openai/')
+  if (typeof endpoint !== 'string') {
+    return false
+  }
+
+  if (endpoint.startsWith('/azure/') || endpoint.startsWith('/droid/openai/')) {
+    return true
+  }
+
+  if (!endpoint.startsWith('/openai/')) {
+    return false
+  }
+
+  return !(
+    endpoint === '/openai/claude' ||
+    endpoint === '/openai/gemini' ||
+    endpoint.startsWith('/openai/claude/') ||
+    endpoint.startsWith('/openai/gemini/')
+  )
 }
 
 function getRequestDetailCacheMetrics(detail = {}) {
   const read = Math.max(0, Number(detail.cacheReadTokens) || 0)
   const create = Math.max(0, Number(detail.cacheCreateTokens) || 0)
   const input = Math.max(0, Number(detail.inputTokens) || 0)
-  const isOpenAIRelated = isOpenAIRelatedEndpoint(detail.endpoint)
+  const isOpenAIRelated =
+    OPENAI_RELATED_ACCOUNT_TYPES.has(detail.accountType) || isOpenAIRelatedEndpoint(detail.endpoint)
   const denominator = isOpenAIRelated ? input + read : read + create
 
   if (denominator <= 0) {
@@ -623,13 +677,13 @@ function getRequestDetailCacheMetrics(detail = {}) {
   }
 }
 
-function calculateCacheHitRate(inputOrDetail = 0, cacheReadTokens = 0, cacheCreateTokens = 0) {
-  if (typeof inputOrDetail === 'object' && inputOrDetail !== null) {
-    return getRequestDetailCacheMetrics(inputOrDetail).rate
+function calculateCacheHitRate(cacheReadTokensOrDetail = 0, cacheCreateTokens = 0) {
+  if (typeof cacheReadTokensOrDetail === 'object' && cacheReadTokensOrDetail !== null) {
+    return getRequestDetailCacheMetrics(cacheReadTokensOrDetail).rate
   }
 
-  const read = Math.max(0, Number(inputOrDetail) || 0)
-  const create = Math.max(0, Number(cacheReadTokens) || 0)
+  const read = Math.max(0, Number(cacheReadTokensOrDetail) || 0)
+  const create = Math.max(0, Number(cacheCreateTokens) || 0)
   const denominator = read + create
 
   if (denominator <= 0) {
@@ -644,6 +698,7 @@ module.exports = {
   extractRequestReasoningInfo,
   resolveRequestDetailReasoning,
   createRequestDetailMeta,
+  finalizeRequestDetailMeta,
   extractOpenAICacheReadTokens,
   isOpenAIRelatedEndpoint,
   getRequestDetailCacheMetrics,

--- a/src/utils/requestDetailHelper.js
+++ b/src/utils/requestDetailHelper.js
@@ -1,0 +1,651 @@
+const SENSITIVE_KEY_PATTERN = /(authorization|proxy-authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|cookie|set-cookie|client_secret|private[_-]?key|proxy)/i
+const DEFAULT_MAX_STRING_CHARS = 80
+const DEFAULT_MAX_ARRAY_ITEMS = 24
+const DEFAULT_MAX_DEPTH = 6
+const DEFAULT_MAX_TOTAL_CHARS = 12000
+const ENCRYPTED_CONTENT_KEY = 'encrypted_content'
+const TOOLS_KEY = 'tools'
+const PREVIEW_TRUNCATION_SUFFIX_PATTERN = /\.\.\.\[(?:truncated )?(\d+) chars\]$/
+
+function toFiniteNumber(value) {
+  if (value === undefined || value === null || value === '') {
+    return null
+  }
+
+  const num = Number(value)
+  if (!Number.isFinite(num)) {
+    return null
+  }
+
+  return num
+}
+
+function maskSensitiveValue(value) {
+  if (value === null || value === undefined) {
+    return value
+  }
+
+  const str = String(value)
+  if (str.length <= 8) {
+    return '[REDACTED]'
+  }
+
+  return `${str.slice(0, 3)}***${str.slice(-3)}`
+}
+
+function truncateString(value, maxChars = DEFAULT_MAX_STRING_CHARS) {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  if (value.length <= maxChars) {
+    return value
+  }
+
+  return `${value.slice(0, maxChars)}...[${value.length - maxChars} chars]`
+}
+
+function getValueCharLength(value) {
+  if (value === null || value === undefined) {
+    return 0
+  }
+
+  if (typeof value === 'string') {
+    return value.length
+  }
+
+  try {
+    const json = JSON.stringify(value)
+    if (typeof json === 'string') {
+      return json.length
+    }
+  } catch (error) {
+    // Fall back to String(value) below when JSON serialization fails.
+  }
+
+  return String(value).length
+}
+
+function createOmittedValue(value) {
+  return `...[${getValueCharLength(value)} chars]`
+}
+
+function normalizeNonEmptyString(value) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+function normalizeInteger(value) {
+  const num = toFiniteNumber(value)
+  if (num === null) {
+    return null
+  }
+
+  return Math.trunc(num)
+}
+
+function formatReasoningBudget(value) {
+  return `budget:${value}`
+}
+
+function createReasoningInfo(reasoningDisplay = null, reasoningSource = null) {
+  return {
+    reasoningDisplay: reasoningDisplay || null,
+    reasoningSource: reasoningSource || null
+  }
+}
+
+function summarizeToolEntry(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return sanitizeValue(value, {
+      seen: new WeakSet(),
+      keyPath: '',
+      depth: 0
+    })
+  }
+
+  const summary = {}
+  if (typeof value.type === 'string' && value.type) {
+    summary.type = value.type
+  }
+
+  const name =
+    typeof value.name === 'string'
+      ? value.name
+      : typeof value.function?.name === 'string'
+        ? value.function.name
+        : null
+
+  if (name) {
+    summary.name = name
+  }
+
+  return summary
+}
+
+function extractOpenAIReasoningInfo(payload) {
+  const effort = normalizeNonEmptyString(payload?.reasoning?.effort)
+  if (effort) {
+    return createReasoningInfo(effort, 'reasoning.effort')
+  }
+
+  const rootEffort = normalizeNonEmptyString(payload?.reasoning_effort)
+  if (rootEffort) {
+    return createReasoningInfo(rootEffort, 'reasoning_effort')
+  }
+
+  return createReasoningInfo()
+}
+
+function extractAnthropicReasoningInfo(payload) {
+  const outputEffort = normalizeNonEmptyString(payload?.output_config?.effort)
+  if (outputEffort) {
+    return createReasoningInfo(outputEffort, 'output_config.effort')
+  }
+
+  const thinking = payload?.thinking
+
+  if (thinking === true) {
+    return createReasoningInfo('enabled', 'thinking')
+  }
+
+  const thinkingString = normalizeNonEmptyString(thinking)
+  if (thinkingString) {
+    return createReasoningInfo(thinkingString, 'thinking')
+  }
+
+  if (!thinking || typeof thinking !== 'object' || Array.isArray(thinking)) {
+    return createReasoningInfo()
+  }
+
+  const thinkingType = normalizeNonEmptyString(thinking.type)
+  const thinkingEnabled = typeof thinking.enabled === 'boolean' ? thinking.enabled : null
+  const thinkingBudget = normalizeInteger(thinking.budget_tokens)
+
+  if (thinkingType === 'disabled' || thinkingType === 'none' || thinkingEnabled === false) {
+    return createReasoningInfo('none', 'thinking')
+  }
+
+  if (thinkingType && thinkingBudget !== null) {
+    return createReasoningInfo(
+      `${thinkingType} / ${formatReasoningBudget(thinkingBudget)}`,
+      'thinking.type,thinking.budget_tokens'
+    )
+  }
+
+  if (thinkingType) {
+    return createReasoningInfo(thinkingType, 'thinking.type')
+  }
+
+  if (thinkingEnabled === true && thinkingBudget !== null) {
+    return createReasoningInfo(
+      `enabled / ${formatReasoningBudget(thinkingBudget)}`,
+      'thinking.enabled,thinking.budget_tokens'
+    )
+  }
+
+  if (thinkingEnabled === true) {
+    return createReasoningInfo('enabled', 'thinking.enabled')
+  }
+
+  if (thinkingBudget !== null) {
+    return createReasoningInfo(formatReasoningBudget(thinkingBudget), 'thinking.budget_tokens')
+  }
+
+  return createReasoningInfo()
+}
+
+function extractGeminiReasoningInfo(payload) {
+  const thinkingConfig = payload?.generationConfig?.thinkingConfig
+  if (!thinkingConfig || typeof thinkingConfig !== 'object' || Array.isArray(thinkingConfig)) {
+    return createReasoningInfo()
+  }
+
+  const thinkingLevel = normalizeNonEmptyString(
+    thinkingConfig.thinkingLevel || thinkingConfig.thinking_level
+  )
+  if (thinkingLevel) {
+    return createReasoningInfo(thinkingLevel, 'generationConfig.thinkingConfig.thinkingLevel')
+  }
+
+  const thinkingBudget = normalizeInteger(
+    thinkingConfig.thinkingBudget ?? thinkingConfig.thinking_budget
+  )
+  if (thinkingBudget === -1) {
+    return createReasoningInfo('dynamic', 'generationConfig.thinkingConfig.thinkingBudget')
+  }
+
+  if (thinkingBudget === 0) {
+    return createReasoningInfo('none', 'generationConfig.thinkingConfig.thinkingBudget')
+  }
+
+  if (thinkingBudget !== null) {
+    return createReasoningInfo(
+      formatReasoningBudget(thinkingBudget),
+      'generationConfig.thinkingConfig.thinkingBudget'
+    )
+  }
+
+  if (thinkingConfig.includeThoughts === false || thinkingConfig.include_thoughts === false) {
+    return createReasoningInfo('none', 'generationConfig.thinkingConfig.includeThoughts')
+  }
+
+  return createReasoningInfo()
+}
+
+function extractRequestReasoningInfo(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return createReasoningInfo()
+  }
+
+  const extractors = [
+    extractOpenAIReasoningInfo,
+    extractAnthropicReasoningInfo,
+    extractGeminiReasoningInfo
+  ]
+
+  for (const extractor of extractors) {
+    const result = extractor(payload)
+    if (result.reasoningDisplay) {
+      return result
+    }
+  }
+
+  return createReasoningInfo()
+}
+
+function parsePreviewJson(preview) {
+  if (typeof preview !== 'string' || !preview) {
+    return null
+  }
+
+  const directCandidate = preview.trim()
+  try {
+    return JSON.parse(directCandidate)
+  } catch (error) {
+    // fall through to suffix stripping below
+  }
+
+  const suffixMatch = directCandidate.match(PREVIEW_TRUNCATION_SUFFIX_PATTERN)
+  if (!suffixMatch) {
+    return null
+  }
+
+  const withoutSuffix = directCandidate.slice(0, -suffixMatch[0].length)
+  try {
+    return JSON.parse(withoutSuffix)
+  } catch (error) {
+    return null
+  }
+}
+
+function extractPreviewReasoningInfo(preview) {
+  if (typeof preview !== 'string' || !preview) {
+    return createReasoningInfo()
+  }
+
+  const parsed = parsePreviewJson(preview)
+  if (parsed) {
+    return extractRequestReasoningInfo(parsed)
+  }
+
+  const openAIEffort = preview.match(/"reasoning"\s*:\s*\{[\s\S]{0,240}?"effort"\s*:\s*"([^"]+)"/)
+  if (openAIEffort?.[1]) {
+    return createReasoningInfo(openAIEffort[1], 'reasoning.effort')
+  }
+
+  const legacyOpenAIEffort = preview.match(/"reasoning_effort"\s*:\s*"([^"]+)"/)
+  if (legacyOpenAIEffort?.[1]) {
+    return createReasoningInfo(legacyOpenAIEffort[1], 'reasoning_effort')
+  }
+
+  const anthropicOutputEffort = preview.match(
+    /"output_config"\s*:\s*\{[\s\S]{0,240}?"effort"\s*:\s*"([^"]+)"/
+  )
+  if (anthropicOutputEffort?.[1]) {
+    return createReasoningInfo(anthropicOutputEffort[1], 'output_config.effort')
+  }
+
+  const thinkingSegmentIndex = preview.indexOf('"thinking"')
+  if (thinkingSegmentIndex >= 0) {
+    const thinkingSegment = preview.slice(thinkingSegmentIndex, thinkingSegmentIndex + 320)
+    const thinkingType = thinkingSegment.match(/"type"\s*:\s*"([^"]+)"/)?.[1] || null
+    const thinkingBudget = thinkingSegment.match(/"budget_tokens"\s*:\s*(-?\d+)/)?.[1] || null
+
+    if (thinkingType && thinkingBudget !== null) {
+      return createReasoningInfo(
+        `${thinkingType} / ${formatReasoningBudget(Number(thinkingBudget))}`,
+        'thinking.type,thinking.budget_tokens'
+      )
+    }
+    if (thinkingType) {
+      return createReasoningInfo(thinkingType, 'thinking.type')
+    }
+    if (thinkingBudget !== null) {
+      return createReasoningInfo(
+        formatReasoningBudget(Number(thinkingBudget)),
+        'thinking.budget_tokens'
+      )
+    }
+  }
+
+  const geminiSegmentIndex = preview.indexOf('"thinkingConfig"')
+  if (geminiSegmentIndex >= 0) {
+    const geminiSegment = preview.slice(geminiSegmentIndex, geminiSegmentIndex + 320)
+    const thinkingLevel = geminiSegment.match(/"thinkingLevel"\s*:\s*"([^"]+)"/)?.[1] || null
+    const thinkingBudget = geminiSegment.match(/"thinkingBudget"\s*:\s*(-?\d+)/)?.[1] || null
+
+    if (thinkingLevel) {
+      return createReasoningInfo(thinkingLevel, 'generationConfig.thinkingConfig.thinkingLevel')
+    }
+    if (thinkingBudget !== null) {
+      const budgetValue = Number(thinkingBudget)
+      const display =
+        budgetValue === -1
+          ? 'dynamic'
+          : budgetValue === 0
+            ? 'none'
+            : formatReasoningBudget(budgetValue)
+      return createReasoningInfo(display, 'generationConfig.thinkingConfig.thinkingBudget')
+    }
+  }
+
+  return createReasoningInfo()
+}
+
+function resolveRequestDetailReasoning(detail = {}) {
+  const storedDisplay = normalizeNonEmptyString(detail.reasoningDisplay)
+  const storedSource = normalizeNonEmptyString(detail.reasoningSource)
+  if (storedDisplay) {
+    return createReasoningInfo(storedDisplay, storedSource)
+  }
+
+  const snapshot = detail.requestBodySnapshot
+  if (snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot)) {
+    if (typeof snapshot.preview === 'string') {
+      const previewResult = extractPreviewReasoningInfo(snapshot.preview)
+      if (previewResult.reasoningDisplay) {
+        return previewResult
+      }
+    }
+
+    return extractRequestReasoningInfo(snapshot)
+  }
+
+  return createReasoningInfo()
+}
+
+function sanitizeValue(value, ctx) {
+  const {
+    keyPath = '',
+    seen,
+    depth = 0,
+    maxDepth = DEFAULT_MAX_DEPTH,
+    maxArrayItems = DEFAULT_MAX_ARRAY_ITEMS,
+    maxStringChars = DEFAULT_MAX_STRING_CHARS
+  } = ctx
+
+  if (value === null || value === undefined) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    if (SENSITIVE_KEY_PATTERN.test(keyPath)) {
+      return maskSensitiveValue(value)
+    }
+    return truncateString(value, maxStringChars)
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString()
+  }
+
+  if (typeof value === 'function') {
+    return '[Function]'
+  }
+
+  if (depth >= maxDepth) {
+    if (Array.isArray(value)) {
+      return `[Array(${value.length})]`
+    }
+    return '[Object]'
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]'
+    }
+    seen.add(value)
+
+    if (Array.isArray(value)) {
+      const result = value.slice(0, maxArrayItems).map((item, index) =>
+        sanitizeValue(item, {
+          ...ctx,
+          keyPath: `${keyPath}[${index}]`,
+          depth: depth + 1
+        })
+      )
+
+      if (value.length > maxArrayItems) {
+        result.push(`...[${value.length - maxArrayItems} more items]`)
+      }
+
+      return result
+    }
+
+    const result = {}
+    for (const [key, childValue] of Object.entries(value)) {
+      const childPath = keyPath ? `${keyPath}.${key}` : key
+      if (key === ENCRYPTED_CONTENT_KEY) {
+        result[key] = createOmittedValue(childValue)
+        continue
+      }
+
+      if (key === TOOLS_KEY) {
+        if (Array.isArray(childValue)) {
+          result[key] = childValue
+            .slice(0, maxArrayItems)
+            .map((item) => summarizeToolEntry(item))
+
+          if (childValue.length > maxArrayItems) {
+            result[key].push(`...[${childValue.length - maxArrayItems} more items]`)
+          }
+        } else if (childValue && typeof childValue === 'object') {
+          result[key] = summarizeToolEntry(childValue)
+        } else {
+          result[key] = sanitizeValue(childValue, {
+            ...ctx,
+            keyPath: childPath,
+            depth: depth + 1
+          })
+        }
+        continue
+      }
+
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
+        result[key] = maskSensitiveValue(childValue)
+        continue
+      }
+
+      result[key] = sanitizeValue(childValue, {
+        ...ctx,
+        keyPath: childPath,
+        depth: depth + 1
+      })
+    }
+
+    return result
+  }
+
+  return String(value)
+}
+
+function enforceTotalSize(snapshot, maxTotalChars = DEFAULT_MAX_TOTAL_CHARS) {
+  let json = ''
+  try {
+    json = JSON.stringify(snapshot)
+  } catch (error) {
+    return {
+      error: 'snapshot_stringify_failed',
+      message: error?.message || String(error)
+    }
+  }
+
+  if (json.length <= maxTotalChars) {
+    return snapshot
+  }
+
+  return {
+    summary: 'request body snapshot truncated',
+    originalChars: json.length,
+    maxChars: maxTotalChars,
+    preview: truncateString(json, maxTotalChars)
+  }
+}
+
+function sanitizeRequestBodySnapshot(body, options = {}) {
+  if (body === undefined) {
+    return null
+  }
+
+  const seen = new WeakSet()
+  const sanitized = sanitizeValue(body, {
+    seen,
+    maxDepth: options.maxDepth || DEFAULT_MAX_DEPTH,
+    maxArrayItems: options.maxArrayItems || DEFAULT_MAX_ARRAY_ITEMS,
+    maxStringChars: options.maxStringChars || DEFAULT_MAX_STRING_CHARS,
+    keyPath: '',
+    depth: 0
+  })
+
+  return enforceTotalSize(sanitized, options.maxTotalChars || DEFAULT_MAX_TOTAL_CHARS)
+}
+
+function getRequestEndpoint(req) {
+  if (!req) {
+    return null
+  }
+
+  const originalUrl = req.originalUrl || req.url || req.path || null
+  if (!originalUrl) {
+    return null
+  }
+
+  const queryIndex = originalUrl.indexOf('?')
+  return queryIndex >= 0 ? originalUrl.slice(0, queryIndex) : originalUrl
+}
+
+function createRequestDetailMeta(req, overrides = {}) {
+  const nowMs = Date.now()
+  const statusCode = toFiniteNumber(overrides.statusCode)
+  const durationMs = toFiniteNumber(overrides.durationMs)
+  const requestStartedAt = toFiniteNumber(overrides.requestStartedAt)
+  const reqStartedAt = toFiniteNumber(req?.requestStartedAt)
+  const effectiveStart = requestStartedAt ?? reqStartedAt
+  const requestBody = overrides.requestBody !== undefined ? overrides.requestBody : req?.body
+
+  return {
+    requestId: overrides.requestId || req?.requestId || null,
+    endpoint: overrides.endpoint || getRequestEndpoint(req),
+    method: overrides.method || req?.method || null,
+    statusCode: statusCode ?? req?.res?.statusCode ?? 200,
+    stream:
+      typeof overrides.stream === 'boolean'
+        ? overrides.stream
+        : Boolean(requestBody && requestBody.stream === true),
+    durationMs: durationMs ?? (effectiveStart ? Math.max(0, nowMs - effectiveStart) : null),
+    requestStartedAt: effectiveStart ? new Date(effectiveStart).toISOString() : null,
+    requestBody
+  }
+}
+
+function extractOpenAICacheReadTokens(usage = {}) {
+  if (!usage || typeof usage !== 'object') {
+    return 0
+  }
+
+  const candidates = [
+    usage.input_tokens_details?.cached_tokens,
+    usage.input_tokens_details?.cached_token,
+    usage.prompt_tokens_details?.cached_tokens,
+    usage.prompt_tokens_details?.cached_token
+  ]
+
+  for (const value of candidates) {
+    if (value === undefined || value === null || value === '') {
+      continue
+    }
+
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) {
+      return Math.max(0, parsed)
+    }
+  }
+
+  return 0
+}
+
+function isOpenAIRelatedEndpoint(endpoint) {
+  return typeof endpoint === 'string' && endpoint.startsWith('/openai/')
+}
+
+function getRequestDetailCacheMetrics(detail = {}) {
+  const read = Math.max(0, Number(detail.cacheReadTokens) || 0)
+  const create = Math.max(0, Number(detail.cacheCreateTokens) || 0)
+  const input = Math.max(0, Number(detail.inputTokens) || 0)
+  const isOpenAIRelated = isOpenAIRelatedEndpoint(detail.endpoint)
+  const denominator = isOpenAIRelated ? input + read : read + create
+
+  if (denominator <= 0) {
+    return {
+      isOpenAIRelated,
+      cacheCreateNotApplicable: isOpenAIRelated,
+      numerator: read,
+      denominator: 0,
+      rate: 0
+    }
+  }
+
+  return {
+    isOpenAIRelated,
+    cacheCreateNotApplicable: isOpenAIRelated,
+    numerator: read,
+    denominator,
+    rate: Number(((read / denominator) * 100).toFixed(2))
+  }
+}
+
+function calculateCacheHitRate(inputOrDetail = 0, cacheReadTokens = 0, cacheCreateTokens = 0) {
+  if (typeof inputOrDetail === 'object' && inputOrDetail !== null) {
+    return getRequestDetailCacheMetrics(inputOrDetail).rate
+  }
+
+  const read = Math.max(0, Number(inputOrDetail) || 0)
+  const create = Math.max(0, Number(cacheReadTokens) || 0)
+  const denominator = read + create
+
+  if (denominator <= 0) {
+    return 0
+  }
+
+  return Number(((read / denominator) * 100).toFixed(2))
+}
+
+module.exports = {
+  sanitizeRequestBodySnapshot,
+  extractRequestReasoningInfo,
+  resolveRequestDetailReasoning,
+  createRequestDetailMeta,
+  extractOpenAICacheReadTokens,
+  isOpenAIRelatedEndpoint,
+  getRequestDetailCacheMetrics,
+  calculateCacheHitRate
+}

--- a/tests/requestDetailHelper.test.js
+++ b/tests/requestDetailHelper.test.js
@@ -3,12 +3,17 @@ const {
   extractRequestReasoningInfo,
   resolveRequestDetailReasoning,
   createRequestDetailMeta,
+  finalizeRequestDetailMeta,
   extractOpenAICacheReadTokens,
   isOpenAIRelatedEndpoint,
   calculateCacheHitRate
 } = require('../src/utils/requestDetailHelper')
 
 describe('requestDetailHelper', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   test('sanitizeRequestBodySnapshot redacts secrets and truncates long text', () => {
     const snapshot = sanitizeRequestBodySnapshot({
       apiKey: 'super-secret-api-key',
@@ -26,7 +31,10 @@ describe('requestDetailHelper', () => {
 
   test('sanitizeRequestBodySnapshot keeps all object keys while truncating long values', () => {
     const payload = Object.fromEntries(
-      Array.from({ length: 50 }, (_, index) => [`key_${index}`, `value-${index}-${'x'.repeat(100)}`])
+      Array.from({ length: 50 }, (_, index) => [
+        `key_${index}`,
+        `value-${index}-${'x'.repeat(100)}`
+      ])
     )
 
     const snapshot = sanitizeRequestBodySnapshot(payload)
@@ -178,11 +186,25 @@ describe('requestDetailHelper', () => {
     expect(meta.requestBody).toEqual(req.body)
   })
 
-  test('identifies /openai/ request detail endpoints', () => {
+  test('finalizeRequestDetailMeta refreshes duration from requestStartedAt', () => {
+    jest.useFakeTimers().setSystemTime(Date.parse('2026-04-09T05:00:00.500Z'))
+
+    const meta = finalizeRequestDetailMeta({
+      requestId: 'req_123',
+      requestStartedAt: '2026-04-09T05:00:00.000Z',
+      durationMs: 25
+    })
+
+    expect(meta.durationMs).toBe(500)
+  })
+
+  test('identifies openai-style request detail endpoints', () => {
     expect(isOpenAIRelatedEndpoint('/openai/v1/responses')).toBe(true)
     expect(isOpenAIRelatedEndpoint('/openai/responses')).toBe(true)
+    expect(isOpenAIRelatedEndpoint('/azure/chat/completions')).toBe(true)
+    expect(isOpenAIRelatedEndpoint('/droid/openai/v1/responses')).toBe(true)
+    expect(isOpenAIRelatedEndpoint('/openai/claude/v1/messages')).toBe(false)
     expect(isOpenAIRelatedEndpoint('/v1/messages')).toBe(false)
-    expect(isOpenAIRelatedEndpoint('/azure/openai/deployments/foo')).toBe(false)
   })
 
   test('extractOpenAICacheReadTokens prefers input_tokens_details.cached_tokens', () => {
@@ -252,5 +274,27 @@ describe('requestDetailHelper', () => {
         cacheReadTokens: 0
       })
     ).toBe(0)
+  })
+
+  test('calculateCacheHitRate uses openai formula for azure records and non-openai formula for claude compatibility routes', () => {
+    expect(
+      calculateCacheHitRate({
+        endpoint: '/azure/chat/completions',
+        accountType: 'azure-openai',
+        inputTokens: 100,
+        cacheReadTokens: 60,
+        cacheCreateTokens: 0
+      })
+    ).toBe(37.5)
+
+    expect(
+      calculateCacheHitRate({
+        endpoint: '/openai/claude/v1/messages',
+        accountType: 'claude',
+        inputTokens: 100,
+        cacheReadTokens: 30,
+        cacheCreateTokens: 20
+      })
+    ).toBe(60)
   })
 })

--- a/tests/requestDetailHelper.test.js
+++ b/tests/requestDetailHelper.test.js
@@ -1,0 +1,256 @@
+const {
+  sanitizeRequestBodySnapshot,
+  extractRequestReasoningInfo,
+  resolveRequestDetailReasoning,
+  createRequestDetailMeta,
+  extractOpenAICacheReadTokens,
+  isOpenAIRelatedEndpoint,
+  calculateCacheHitRate
+} = require('../src/utils/requestDetailHelper')
+
+describe('requestDetailHelper', () => {
+  test('sanitizeRequestBodySnapshot redacts secrets and truncates long text', () => {
+    const snapshot = sanitizeRequestBodySnapshot({
+      apiKey: 'super-secret-api-key',
+      messages: [
+        {
+          role: 'user',
+          content: 'x'.repeat(400)
+        }
+      ]
+    })
+
+    expect(snapshot.apiKey).toContain('***')
+    expect(snapshot.messages[0].content).toBe(`${'x'.repeat(80)}...[320 chars]`)
+  })
+
+  test('sanitizeRequestBodySnapshot keeps all object keys while truncating long values', () => {
+    const payload = Object.fromEntries(
+      Array.from({ length: 50 }, (_, index) => [`key_${index}`, `value-${index}-${'x'.repeat(100)}`])
+    )
+
+    const snapshot = sanitizeRequestBodySnapshot(payload)
+
+    expect(Object.keys(snapshot)).toHaveLength(50)
+    expect(snapshot.__truncatedKeys).toBeUndefined()
+    expect(snapshot.key_0).toBe(`value-0-${'x'.repeat(72)}...[28 chars]`)
+  })
+
+  test('sanitizeRequestBodySnapshot still wraps oversized payloads in preview metadata', () => {
+    const snapshot = sanitizeRequestBodySnapshot(
+      Object.fromEntries(
+        Array.from({ length: 220 }, (_, index) => [`key_${index}`, `${index}-${'x'.repeat(120)}`])
+      )
+    )
+
+    expect(snapshot.summary).toBe('request body snapshot truncated')
+    expect(snapshot.maxChars).toBe(12000)
+    expect(typeof snapshot.preview).toBe('string')
+    expect(snapshot.preview).toContain('...[')
+  })
+
+  test('sanitizeRequestBodySnapshot omits encrypted_content values', () => {
+    const snapshot = sanitizeRequestBodySnapshot({
+      reasoning: {
+        encrypted_content: 'x'.repeat(512)
+      }
+    })
+
+    expect(snapshot.reasoning.encrypted_content).toBe('...[512 chars]')
+  })
+
+  test('sanitizeRequestBodySnapshot keeps only tool type and name', () => {
+    const snapshot = sanitizeRequestBodySnapshot({
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'lookup_weather',
+            description: 'Weather lookup',
+            parameters: {
+              type: 'object',
+              properties: {
+                city: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        },
+        {
+          name: 'claude_tool',
+          description: 'Anthropic style tool',
+          input_schema: {
+            type: 'object'
+          }
+        }
+      ]
+    })
+
+    expect(snapshot.tools).toEqual([
+      { type: 'function', name: 'lookup_weather' },
+      { name: 'claude_tool' }
+    ])
+  })
+
+  test('extractRequestReasoningInfo supports openai, anthropic, and gemini payloads', () => {
+    expect(
+      extractRequestReasoningInfo({
+        reasoning: {
+          effort: 'xhigh'
+        }
+      })
+    ).toEqual({
+      reasoningDisplay: 'xhigh',
+      reasoningSource: 'reasoning.effort'
+    })
+
+    expect(
+      extractRequestReasoningInfo({
+        output_config: {
+          effort: 'medium'
+        }
+      })
+    ).toEqual({
+      reasoningDisplay: 'medium',
+      reasoningSource: 'output_config.effort'
+    })
+
+    expect(
+      extractRequestReasoningInfo({
+        generationConfig: {
+          thinkingConfig: {
+            thinkingBudget: -1
+          }
+        }
+      })
+    ).toEqual({
+      reasoningDisplay: 'dynamic',
+      reasoningSource: 'generationConfig.thinkingConfig.thinkingBudget'
+    })
+  })
+
+  test('resolveRequestDetailReasoning falls back to stored preview text when needed', () => {
+    expect(
+      resolveRequestDetailReasoning({
+        requestBodySnapshot: {
+          preview:
+            '{"model":"gpt-5.4-mini","reasoning":{"effort":"high","summary":"auto"}}...[25 chars]'
+        }
+      })
+    ).toEqual({
+      reasoningDisplay: 'high',
+      reasoningSource: 'reasoning.effort'
+    })
+
+    expect(
+      resolveRequestDetailReasoning({
+        requestBodySnapshot: {
+          preview:
+            '{"model":"claude-opus-4-6","thinking":{"type":"enabled","budget_tokens":4096}...[60 chars]'
+        }
+      })
+    ).toEqual({
+      reasoningDisplay: 'enabled / budget:4096',
+      reasoningSource: 'thinking.type,thinking.budget_tokens'
+    })
+  })
+
+  test('createRequestDetailMeta derives endpoint and duration from request', () => {
+    const now = Date.now()
+    const req = {
+      requestId: 'req_123',
+      originalUrl: '/v1/messages?stream=true',
+      method: 'POST',
+      requestStartedAt: now - 250,
+      body: { model: 'claude-sonnet-4-6', stream: true },
+      res: { statusCode: 201 }
+    }
+
+    const meta = createRequestDetailMeta(req)
+
+    expect(meta.requestId).toBe('req_123')
+    expect(meta.endpoint).toBe('/v1/messages')
+    expect(meta.method).toBe('POST')
+    expect(meta.stream).toBe(true)
+    expect(meta.statusCode).toBe(201)
+    expect(meta.durationMs).toBeGreaterThanOrEqual(200)
+    expect(meta.requestBody).toEqual(req.body)
+  })
+
+  test('identifies /openai/ request detail endpoints', () => {
+    expect(isOpenAIRelatedEndpoint('/openai/v1/responses')).toBe(true)
+    expect(isOpenAIRelatedEndpoint('/openai/responses')).toBe(true)
+    expect(isOpenAIRelatedEndpoint('/v1/messages')).toBe(false)
+    expect(isOpenAIRelatedEndpoint('/azure/openai/deployments/foo')).toBe(false)
+  })
+
+  test('extractOpenAICacheReadTokens prefers input_tokens_details.cached_tokens', () => {
+    expect(
+      extractOpenAICacheReadTokens({
+        input_tokens_details: { cached_tokens: 42 },
+        prompt_tokens_details: { cached_tokens: 99 }
+      })
+    ).toBe(42)
+  })
+
+  test('extractOpenAICacheReadTokens supports singular cached_token fallback fields', () => {
+    expect(
+      extractOpenAICacheReadTokens({
+        input_tokens_details: { cached_token: '17' }
+      })
+    ).toBe(17)
+
+    expect(
+      extractOpenAICacheReadTokens({
+        prompt_tokens_details: { cached_token: 23 }
+      })
+    ).toBe(23)
+  })
+
+  test('extractOpenAICacheReadTokens falls back to prompt_tokens_details.cached_tokens', () => {
+    expect(
+      extractOpenAICacheReadTokens({
+        prompt_tokens_details: { cached_tokens: '31' }
+      })
+    ).toBe(31)
+  })
+
+  test('extractOpenAICacheReadTokens normalizes invalid values to zero', () => {
+    expect(extractOpenAICacheReadTokens()).toBe(0)
+    expect(
+      extractOpenAICacheReadTokens({
+        input_tokens_details: { cached_tokens: -5 }
+      })
+    ).toBe(0)
+    expect(
+      extractOpenAICacheReadTokens({
+        input_tokens_details: { cached_tokens: 'abc' },
+        prompt_tokens_details: { cached_tokens: null }
+      })
+    ).toBe(0)
+  })
+
+  test('calculateCacheHitRate uses cacheRead / (cacheRead + cacheCreate) for non-openai requests', () => {
+    expect(calculateCacheHitRate(120, 80)).toBe(60)
+    expect(calculateCacheHitRate(0, 0)).toBe(0)
+  })
+
+  test('calculateCacheHitRate uses cached_tokens / prompt_tokens for /openai/ requests', () => {
+    expect(
+      calculateCacheHitRate({
+        endpoint: '/openai/v1/responses',
+        inputTokens: 100,
+        cacheReadTokens: 60,
+        cacheCreateTokens: 999
+      })
+    ).toBe(37.5)
+    expect(
+      calculateCacheHitRate({
+        endpoint: '/openai/v1/responses',
+        inputTokens: 0,
+        cacheReadTokens: 0
+      })
+    ).toBe(0)
+  })
+})

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -32,6 +32,7 @@ const redis = require('../src/models/redis')
 const claudeRelayConfigService = require('../src/services/claudeRelayConfigService')
 const claudeAccountService = require('../src/services/account/claudeAccountService')
 const openaiAccountService = require('../src/services/account/openaiAccountService')
+const bedrockAccountService = require('../src/services/account/bedrockAccountService')
 const requestDetailService = require('../src/services/requestDetailService')
 
 describe('requestDetailService', () => {
@@ -437,6 +438,323 @@ describe('requestDetailService', () => {
     expect(result.bodyPreviewEnabled).toBe(false)
     expect(result.snapshotCount).toBe(2)
     expect(result.hasSnapshots).toBe(true)
+  })
+
+  test('getRequestDetail returns null for records outside retention window', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getClient.mockReturnValue({
+      get: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          requestId: 'req_old',
+          timestamp: '2026-04-07T10:00:00.000Z',
+          endpoint: '/v1/messages',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_1',
+          accountType: 'claude',
+          model: 'claude-sonnet-4-6',
+          inputTokens: 100,
+          outputTokens: 50,
+          cost: 0.5,
+          durationMs: 1200
+        })
+      )
+    })
+
+    const result = await requestDetailService.getRequestDetail('req_old')
+
+    expect(result.record).toBeNull()
+    expect(result.retentionHours).toBe(6)
+    expect(result.captureEnabled).toBe(true)
+  })
+
+  test('getRequestDetail returns record within retention window', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    claudeAccountService.getAccount.mockResolvedValue({ name: 'Claude Main' })
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+
+    redis.getClient.mockReturnValue({
+      get: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          requestId: 'req_recent',
+          timestamp: '2026-04-07T14:00:00.000Z',
+          endpoint: '/v1/messages',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_1',
+          accountType: 'claude',
+          model: 'claude-sonnet-4-6',
+          inputTokens: 100,
+          outputTokens: 50,
+          cost: 0.5,
+          durationMs: 1200
+        })
+      )
+    })
+
+    const result = await requestDetailService.getRequestDetail('req_recent')
+
+    expect(result.record).not.toBeNull()
+    expect(result.record.requestId).toBe('req_recent')
+    expect(result.record.apiKeyName).toBe('Primary Key')
+  })
+
+  test('getRequestDetail recovers missing timestamp from retention-window day index', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getClient.mockReturnValue({
+      zscore: jest.fn().mockResolvedValue('1775570400000'),
+      get: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          requestId: 'req_no_ts',
+          endpoint: '/v1/messages',
+          method: 'POST'
+        })
+      )
+    })
+
+    const result = await requestDetailService.getRequestDetail('req_no_ts')
+
+    expect(result.record).not.toBeNull()
+    expect(result.record.requestId).toBe('req_no_ts')
+    expect(result.record.timestamp).toBe('2026-04-07T14:00:00.000Z')
+  })
+
+  test('getRequestDetail recovers unparseable timestamp from retention-window day index', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getClient.mockReturnValue({
+      zscore: jest.fn().mockResolvedValue('1775570400000'),
+      get: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          requestId: 'req_bad_ts',
+          timestamp: 'invalid-date',
+          endpoint: '/v1/messages',
+          method: 'POST'
+        })
+      )
+    })
+
+    const result = await requestDetailService.getRequestDetail('req_bad_ts')
+
+    expect(result.record).not.toBeNull()
+    expect(result.record.requestId).toBe('req_bad_ts')
+    expect(result.record.timestamp).toBe('2026-04-07T14:00:00.000Z')
+  })
+
+  test('getRequestDetail hides legacy records without a recoverable in-window timestamp', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getClient.mockReturnValue({
+      zscore: jest.fn().mockResolvedValue('1775556000000'),
+      get: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          requestId: 'req_legacy_old',
+          endpoint: '/v1/messages',
+          method: 'POST'
+        })
+      )
+    })
+
+    const result = await requestDetailService.getRequestDetail('req_legacy_old')
+
+    expect(result.record).toBeNull()
+  })
+
+  test('resolves bedrock account name from { success, data } wrapper', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Bedrock Key' })
+    bedrockAccountService.getAccount.mockResolvedValue({
+      success: true,
+      data: { name: 'My Bedrock Account' }
+    })
+
+    redis.getClient.mockReturnValue({
+      zrangebyscore: jest.fn().mockResolvedValue(['req_bedrock', '1775563200000']),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_bedrock',
+          timestamp: '2026-04-07T12:00:00.000Z',
+          endpoint: '/v1/messages',
+          method: 'POST',
+          apiKeyId: 'key_bedrock',
+          accountId: 'acct_bedrock',
+          accountType: 'bedrock',
+          model: 'anthropic.claude-sonnet-4-6',
+          inputTokens: 100,
+          outputTokens: 50,
+          cost: 0.5,
+          durationMs: 1200
+        })
+      ])
+    })
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].accountName).toBe('My Bedrock Account')
+    expect(result.records[0].accountTypeName).toBe('AWS Bedrock')
+  })
+
+  test('handles bedrock { success: false } wrapper gracefully', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Some Key' })
+    claudeAccountService.getAccount.mockResolvedValue(null)
+    openaiAccountService.getAccount.mockResolvedValue(null)
+    bedrockAccountService.getAccount.mockResolvedValue({
+      success: false,
+      error: 'Account not found'
+    })
+
+    redis.getClient.mockReturnValue({
+      zrangebyscore: jest.fn().mockResolvedValue(['req_missing', '1775563200000']),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_missing',
+          timestamp: '2026-04-07T12:00:00.000Z',
+          endpoint: '/v1/messages',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_gone',
+          accountType: 'bedrock',
+          model: 'anthropic.claude-sonnet-4-6',
+          inputTokens: 100,
+          outputTokens: 50,
+          cost: 0.5,
+          durationMs: 1200
+        })
+      ])
+    })
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].accountName).toBe('acct_gone')
+    expect(result.records[0].accountTypeName).toBe('AWS Bedrock')
+  })
+
+  test('listRequestDetails without keyword uses deferred enrichment for page records only', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const records = []
+    const pointerEntries = []
+    for (let i = 0; i < 5; i++) {
+      const ts = 1775563200000 + i * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      records.push(
+        JSON.stringify({
+          requestId: `req_${i}`,
+          timestamp: new Date(ts).toISOString(),
+          endpoint: '/openai/v1/responses',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_1',
+          accountType: 'openai',
+          model: 'gpt-5.4',
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          totalTokens: 150,
+          cost: 0.5,
+          durationMs: 1200
+        })
+      )
+    }
+
+    redis.getClient.mockReturnValue({
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn().mockResolvedValue(records)
+    })
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-08T23:59:59.000Z',
+      pageSize: 2,
+      page: 1
+    })
+
+    expect(result.records).toHaveLength(2)
+    expect(result.pagination.totalRecords).toBe(5)
+    expect(result.records[0].apiKeyName).toBe('Primary Key')
+    expect(result.records[0].accountName).toBe('OpenAI Main')
+    expect(result.availableFilters.models).toEqual(['gpt-5.4'])
+    expect(result.summary.totalRequests).toBe(5)
+  })
+
+  test('listRequestDetails backfills invalid timestamps from day-index scores', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getClient.mockReturnValue({
+      zrangebyscore: jest.fn().mockResolvedValue(['req_invalid_ts', '1775563200000']),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_invalid_ts',
+          timestamp: 'invalid-date',
+          endpoint: '/v1/messages',
+          method: 'POST',
+          model: 'claude-sonnet-4-6'
+        })
+      ])
+    })
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].timestamp).toBe('2026-04-07T12:00:00.000Z')
+    expect(result.availableFilters.dateRange.earliest).toBe('2026-04-07T12:00:00.000Z')
   })
 
   test('purgeRequestBodySnapshots removes snapshots while keeping records', async () => {

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -53,7 +53,8 @@ describe('requestDetailService', () => {
 
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
-      requestDetailRetentionHours: 6
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
     })
     redis.getClient.mockReturnValue({ multi: jest.fn(() => multi) })
 
@@ -102,7 +103,8 @@ describe('requestDetailService', () => {
   test('listRequestDetails applies openai cache display flags and openai hit-rate formula', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
-      requestDetailRetentionHours: 6
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
     })
 
     redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
@@ -160,7 +162,8 @@ describe('requestDetailService', () => {
   test('listRequestDetails aggregates mixed openai and non-openai cache metrics correctly', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
-      requestDetailRetentionHours: 6
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
     })
 
     redis.getApiKey.mockImplementation(async (keyId) => ({ name: `Key ${keyId}` }))
@@ -231,7 +234,8 @@ describe('requestDetailService', () => {
   test('listRequestDetails still exposes retained data when capture is disabled', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: false,
-      requestDetailRetentionHours: 6
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: false
     })
 
     redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
@@ -274,7 +278,8 @@ describe('requestDetailService', () => {
   test('listRequestDetails derives reasoning from legacy preview-only records', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
-      requestDetailRetentionHours: 6
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
     })
 
     redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
@@ -318,5 +323,123 @@ describe('requestDetailService', () => {
     expect(result.records).toHaveLength(1)
     expect(result.records[0].reasoningDisplay).toBe('high')
     expect(result.records[0].reasoningSource).toBe('reasoning.effort')
+  })
+
+  test('captureRequestDetail omits requestBodySnapshot when body preview is disabled', async () => {
+    const exec = jest.fn().mockResolvedValue([])
+    const multi = {
+      set: jest.fn().mockReturnThis(),
+      zadd: jest.fn().mockReturnThis(),
+      expire: jest.fn().mockReturnThis(),
+      exec
+    }
+
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: false
+    })
+    redis.getClient.mockReturnValue({ multi: jest.fn(() => multi) })
+
+    await requestDetailService.captureRequestDetail({
+      requestId: 'req_capture_no_preview',
+      timestamp: '2026-04-07T12:00:00.000Z',
+      endpoint: '/openai/v1/responses',
+      method: 'POST',
+      model: 'gpt-5.4',
+      requestBody: {
+        model: 'gpt-5.4',
+        reasoning: {
+          effort: 'high'
+        },
+        input: 'hello world'
+      }
+    })
+
+    const storedPayload = JSON.parse(multi.set.mock.calls[0][1])
+    expect(storedPayload.requestBodySnapshot).toBeUndefined()
+    expect(storedPayload.reasoningDisplay).toBe('high')
+    expect(storedPayload.reasoningSource).toBe('reasoning.effort')
+  })
+
+  test('getRequestBodyPreviewStats counts stored snapshots', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: false
+    })
+
+    redis.getClient.mockReturnValue({
+      scan: jest
+        .fn()
+        .mockResolvedValueOnce([
+          '0',
+          ['request_detail:item:req_1', 'request_detail:item:req_2', 'request_detail:item:req_3']
+        ]),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({ requestId: 'req_1', requestBodySnapshot: { model: 'gpt-5.4' } }),
+        JSON.stringify({ requestId: 'req_2', model: 'gpt-5.4' }),
+        JSON.stringify({
+          requestId: 'req_3',
+          requestBodySnapshot: {
+            preview: '{"model":"gpt-5.4"}'
+          }
+        })
+      ])
+    })
+
+    const result = await requestDetailService.getRequestBodyPreviewStats()
+
+    expect(result.bodyPreviewEnabled).toBe(false)
+    expect(result.snapshotCount).toBe(2)
+    expect(result.hasSnapshots).toBe(true)
+  })
+
+  test('purgeRequestBodySnapshots removes snapshots while keeping records', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: false
+    })
+
+    const exec = jest.fn().mockResolvedValue([])
+    const pipeline = {
+      set: jest.fn().mockReturnThis(),
+      exec
+    }
+    const client = {
+      scan: jest
+        .fn()
+        .mockResolvedValueOnce([
+          '0',
+          ['request_detail:item:req_1', 'request_detail:item:req_2']
+        ]),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_1',
+          model: 'gpt-5.4',
+          requestBodySnapshot: { model: 'gpt-5.4' }
+        }),
+        JSON.stringify({
+          requestId: 'req_2',
+          model: 'claude-sonnet-4-6'
+        })
+      ]),
+      pipeline: jest.fn(() => pipeline)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const result = await requestDetailService.purgeRequestBodySnapshots()
+
+    expect(result.updatedRecords).toBe(1)
+    expect(pipeline.set).toHaveBeenCalledWith(
+      'request_detail:item:req_1',
+      JSON.stringify({
+        requestId: 'req_1',
+        model: 'gpt-5.4'
+      }),
+      'KEEPTTL'
+    )
+    expect(exec).toHaveBeenCalled()
   })
 })

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -21,7 +21,9 @@ jest.mock('../src/services/account/ccrAccountService', () => ({ getAccount: jest
 jest.mock('../src/services/account/geminiAccountService', () => ({ getAccount: jest.fn() }))
 jest.mock('../src/services/account/geminiApiAccountService', () => ({ getAccount: jest.fn() }))
 jest.mock('../src/services/account/openaiAccountService', () => ({ getAccount: jest.fn() }))
-jest.mock('../src/services/account/openaiResponsesAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/openaiResponsesAccountService', () => ({
+  getAccount: jest.fn()
+}))
 jest.mock('../src/services/account/azureOpenaiAccountService', () => ({ getAccount: jest.fn() }))
 jest.mock('../src/services/account/droidAccountService', () => ({ getAccount: jest.fn() }))
 jest.mock('../src/services/account/bedrockAccountService', () => ({ getAccount: jest.fn() }))
@@ -175,12 +177,9 @@ describe('requestDetailService', () => {
     )
 
     redis.getClient.mockReturnValue({
-      zrangebyscore: jest.fn().mockResolvedValue([
-        'req_openai',
-        '1775563200000',
-        'req_claude',
-        '1775566800000'
-      ]),
+      zrangebyscore: jest
+        .fn()
+        .mockResolvedValue(['req_openai', '1775563200000', 'req_claude', '1775566800000']),
       mget: jest.fn().mockResolvedValue([
         JSON.stringify({
           requestId: 'req_openai',
@@ -229,6 +228,51 @@ describe('requestDetailService', () => {
     expect(result.summary.cacheCreateNotApplicable).toBe(false)
     expect(result.summary.cacheCreateTokens).toBe(30)
     expect(result.summary.cacheHitRate).toBe(40.91)
+  })
+
+  test('listRequestDetails treats azure-openai cache hits as openai-style metrics', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Azure Key' })
+
+    redis.getClient.mockReturnValue({
+      zrangebyscore: jest.fn().mockResolvedValue(['req_azure', '1775563200000']),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_azure',
+          timestamp: '2026-04-07T12:00:00.000Z',
+          endpoint: '/azure/chat/completions',
+          method: 'POST',
+          apiKeyId: 'key_azure',
+          accountId: 'acct_azure',
+          accountType: 'azure-openai',
+          model: 'gpt-4o',
+          inputTokens: 100,
+          outputTokens: 20,
+          cacheReadTokens: 60,
+          cacheCreateTokens: 0,
+          totalTokens: 180,
+          cost: 0.3,
+          durationMs: 500
+        })
+      ])
+    })
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].isOpenAIRelated).toBe(true)
+    expect(result.records[0].cacheCreateNotApplicable).toBe(true)
+    expect(result.records[0].cacheHitRate).toBe(37.5)
+    expect(result.summary.cacheCreateTokens).toBe(0)
+    expect(result.summary.cacheHitRate).toBe(37.5)
   })
 
   test('listRequestDetails still exposes retained data when capture is disabled', async () => {
@@ -410,10 +454,7 @@ describe('requestDetailService', () => {
     const client = {
       scan: jest
         .fn()
-        .mockResolvedValueOnce([
-          '0',
-          ['request_detail:item:req_1', 'request_detail:item:req_2']
-        ]),
+        .mockResolvedValueOnce(['0', ['request_detail:item:req_1', 'request_detail:item:req_2']]),
       mget: jest.fn().mockResolvedValue([
         JSON.stringify({
           requestId: 'req_1',

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -1,0 +1,309 @@
+jest.mock('../src/models/redis', () => ({
+  getClient: jest.fn(),
+  getApiKey: jest.fn()
+}))
+
+jest.mock('../src/services/claudeRelayConfigService', () => ({
+  getConfig: jest.fn()
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  warn: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  start: jest.fn()
+}))
+
+jest.mock('../src/services/account/claudeAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/claudeConsoleAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/ccrAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/geminiAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/geminiApiAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/openaiAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/openaiResponsesAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/azureOpenaiAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/droidAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/account/bedrockAccountService', () => ({ getAccount: jest.fn() }))
+
+const redis = require('../src/models/redis')
+const claudeRelayConfigService = require('../src/services/claudeRelayConfigService')
+const claudeAccountService = require('../src/services/account/claudeAccountService')
+const openaiAccountService = require('../src/services/account/openaiAccountService')
+const requestDetailService = require('../src/services/requestDetailService')
+
+describe('requestDetailService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('captureRequestDetail stores normalized request detail records when enabled', async () => {
+    const exec = jest.fn().mockResolvedValue([])
+    const multi = {
+      set: jest.fn().mockReturnThis(),
+      zadd: jest.fn().mockReturnThis(),
+      expire: jest.fn().mockReturnThis(),
+      exec
+    }
+
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionDays: 7
+    })
+    redis.getClient.mockReturnValue({ multi: jest.fn(() => multi) })
+
+    const result = await requestDetailService.captureRequestDetail({
+      requestId: 'req_capture_1',
+      timestamp: '2026-04-07T12:00:00.000Z',
+      endpoint: '/openai/v1/responses',
+      method: 'POST',
+      statusCode: 200,
+      apiKeyId: 'key_1',
+      accountId: 'acct_1',
+      accountType: 'openai',
+      model: 'gpt-5.4',
+      inputTokens: 10,
+      outputTokens: 4,
+      cacheReadTokens: 3,
+      cacheCreateTokens: 2,
+      cost: 0.123456,
+      requestBody: {
+        apiKey: 'super-secret',
+        model: 'gpt-5.4',
+        reasoning: {
+          effort: 'medium'
+        },
+        prompt: 'hello'
+      }
+    })
+
+    expect(result).toEqual({ captured: true, requestId: 'req_capture_1' })
+    expect(multi.set).toHaveBeenCalled()
+    const storedPayload = JSON.parse(multi.set.mock.calls[0][1])
+    expect(storedPayload.requestBodySnapshot.apiKey).toContain('***')
+    expect(storedPayload.endpoint).toBe('/openai/v1/responses')
+    expect(storedPayload.reasoningDisplay).toBe('medium')
+    expect(storedPayload.reasoningSource).toBe('reasoning.effort')
+    expect(multi.zadd).toHaveBeenCalled()
+    expect(exec).toHaveBeenCalled()
+  })
+
+  test('listRequestDetails applies openai cache display flags and openai hit-rate formula', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionDays: 7
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const redisClient = {
+      zrangebyscore: jest.fn().mockResolvedValue(['req_1', '1775563200000']),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_1',
+          timestamp: '2026-04-07T12:00:00.000Z',
+          endpoint: '/openai/v1/responses',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_1',
+          accountType: 'openai',
+          model: 'gpt-5.4',
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 60,
+          cacheCreateTokens: 40,
+          totalTokens: 250,
+          cost: 0.5,
+          durationMs: 1200,
+          requestBodySnapshot: { model: 'gpt-5.4' }
+        })
+      ])
+    }
+
+    redis.getClient.mockReturnValue(redisClient)
+
+    const result = await requestDetailService.listRequestDetails({
+      apiKeyId: 'key_1',
+      model: 'gpt-5.4',
+      keyword: 'primary',
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].apiKeyName).toBe('Primary Key')
+    expect(result.records[0].accountName).toBe('OpenAI Main')
+    expect(result.records[0].requestBodySnapshot).toBeUndefined()
+    expect(result.records[0].isOpenAIRelated).toBe(true)
+    expect(result.records[0].cacheCreateNotApplicable).toBe(true)
+    expect(result.summary.totalRequests).toBe(1)
+    expect(result.summary.cacheCreateTokens).toBe(0)
+    expect(result.summary.cacheCreateNotApplicable).toBe(true)
+    expect(result.summary.cacheHitRate).toBe(37.5)
+    expect(result.availableFilters.models).toEqual(['gpt-5.4'])
+    expect(result.filters.hasCustomDateRange).toBe(true)
+  })
+
+  test('listRequestDetails aggregates mixed openai and non-openai cache metrics correctly', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionDays: 7
+    })
+
+    redis.getApiKey.mockImplementation(async (keyId) => ({ name: `Key ${keyId}` }))
+    openaiAccountService.getAccount.mockImplementation(async (accountId) =>
+      accountId === 'acct_1' ? { name: 'OpenAI Main' } : null
+    )
+    claudeAccountService.getAccount.mockImplementation(async (accountId) =>
+      accountId === 'acct_2' ? { name: 'Claude Main' } : null
+    )
+
+    redis.getClient.mockReturnValue({
+      zrangebyscore: jest.fn().mockResolvedValue([
+        'req_openai',
+        '1775563200000',
+        'req_claude',
+        '1775566800000'
+      ]),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_openai',
+          timestamp: '2026-04-07T12:00:00.000Z',
+          endpoint: '/openai/v1/responses',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_1',
+          accountType: 'openai',
+          model: 'gpt-5.4',
+          inputTokens: 100,
+          outputTokens: 20,
+          cacheReadTokens: 60,
+          cacheCreateTokens: 40,
+          totalTokens: 180,
+          cost: 0.3,
+          durationMs: 500
+        }),
+        JSON.stringify({
+          requestId: 'req_claude',
+          timestamp: '2026-04-07T13:00:00.000Z',
+          endpoint: '/v1/messages',
+          method: 'POST',
+          apiKeyId: 'key_2',
+          accountId: 'acct_2',
+          accountType: 'claude',
+          model: 'claude-sonnet-4-6',
+          inputTokens: 90,
+          outputTokens: 30,
+          cacheReadTokens: 30,
+          cacheCreateTokens: 30,
+          totalTokens: 180,
+          cost: 0.2,
+          durationMs: 700
+        })
+      ])
+    })
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.records).toHaveLength(2)
+    expect(result.summary.totalRequests).toBe(2)
+    expect(result.summary.cacheCreateNotApplicable).toBe(false)
+    expect(result.summary.cacheCreateTokens).toBe(30)
+    expect(result.summary.cacheHitRate).toBe(40.91)
+  })
+
+  test('listRequestDetails still exposes retained data when capture is disabled', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: false,
+      requestDetailRetentionDays: 7
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    redis.getClient.mockReturnValue({
+      zrangebyscore: jest.fn().mockResolvedValue(['req_1', '1775563200000']),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_1',
+          timestamp: '2026-04-07T12:00:00.000Z',
+          endpoint: '/v1/messages',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_1',
+          accountType: 'openai',
+          model: 'gpt-5.4',
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 60,
+          cacheCreateTokens: 40,
+          totalTokens: 250,
+          cost: 0.5,
+          durationMs: 1200
+        })
+      ])
+    })
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.captureEnabled).toBe(false)
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].apiKeyName).toBe('Primary Key')
+  })
+
+  test('listRequestDetails derives reasoning from legacy preview-only records', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionDays: 7
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    redis.getClient.mockReturnValue({
+      zrangebyscore: jest.fn().mockResolvedValue(['req_preview', '1775563200000']),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_preview',
+          timestamp: '2026-04-07T12:00:00.000Z',
+          endpoint: '/openai/v1/responses',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_1',
+          accountType: 'openai',
+          model: 'gpt-5.4',
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 60,
+          cacheCreateTokens: 0,
+          totalTokens: 210,
+          cost: 0.5,
+          durationMs: 1200,
+          requestBodySnapshot: {
+            summary: 'request body snapshot truncated',
+            originalChars: 18000,
+            maxChars: 12000,
+            preview:
+              '{"model":"gpt-5.4","reasoning":{"effort":"high","summary":"auto"},"input":"...[42 chars]'
+          }
+        })
+      ])
+    })
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].reasoningDisplay).toBe('high')
+    expect(result.records[0].reasoningSource).toBe('reasoning.effort')
+  })
+})

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -35,6 +35,11 @@ const requestDetailService = require('../src/services/requestDetailService')
 describe('requestDetailService', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers().setSystemTime(Date.parse('2026-04-07T18:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   test('captureRequestDetail stores normalized request detail records when enabled', async () => {
@@ -48,7 +53,7 @@ describe('requestDetailService', () => {
 
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
-      requestDetailRetentionDays: 7
+      requestDetailRetentionHours: 6
     })
     redis.getClient.mockReturnValue({ multi: jest.fn(() => multi) })
 
@@ -79,6 +84,12 @@ describe('requestDetailService', () => {
 
     expect(result).toEqual({ captured: true, requestId: 'req_capture_1' })
     expect(multi.set).toHaveBeenCalled()
+    expect(multi.set).toHaveBeenCalledWith(
+      'request_detail:item:req_capture_1',
+      expect.any(String),
+      'EX',
+      21600
+    )
     const storedPayload = JSON.parse(multi.set.mock.calls[0][1])
     expect(storedPayload.requestBodySnapshot.apiKey).toContain('***')
     expect(storedPayload.endpoint).toBe('/openai/v1/responses')
@@ -91,7 +102,7 @@ describe('requestDetailService', () => {
   test('listRequestDetails applies openai cache display flags and openai hit-rate formula', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
-      requestDetailRetentionDays: 7
+      requestDetailRetentionHours: 6
     })
 
     redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
@@ -137,6 +148,7 @@ describe('requestDetailService', () => {
     expect(result.records[0].requestBodySnapshot).toBeUndefined()
     expect(result.records[0].isOpenAIRelated).toBe(true)
     expect(result.records[0].cacheCreateNotApplicable).toBe(true)
+    expect(result.retentionHours).toBe(6)
     expect(result.summary.totalRequests).toBe(1)
     expect(result.summary.cacheCreateTokens).toBe(0)
     expect(result.summary.cacheCreateNotApplicable).toBe(true)
@@ -148,7 +160,7 @@ describe('requestDetailService', () => {
   test('listRequestDetails aggregates mixed openai and non-openai cache metrics correctly', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
-      requestDetailRetentionDays: 7
+      requestDetailRetentionHours: 6
     })
 
     redis.getApiKey.mockImplementation(async (keyId) => ({ name: `Key ${keyId}` }))
@@ -219,7 +231,7 @@ describe('requestDetailService', () => {
   test('listRequestDetails still exposes retained data when capture is disabled', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: false,
-      requestDetailRetentionDays: 7
+      requestDetailRetentionHours: 6
     })
 
     redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
@@ -254,6 +266,7 @@ describe('requestDetailService', () => {
     })
 
     expect(result.captureEnabled).toBe(false)
+    expect(result.retentionHours).toBe(6)
     expect(result.records).toHaveLength(1)
     expect(result.records[0].apiKeyName).toBe('Primary Key')
   })
@@ -261,7 +274,7 @@ describe('requestDetailService', () => {
   test('listRequestDetails derives reasoning from legacy preview-only records', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
-      requestDetailRetentionDays: 7
+      requestDetailRetentionHours: 6
     })
 
     redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })

--- a/tests/requestDetailsRoute.test.js
+++ b/tests/requestDetailsRoute.test.js
@@ -12,7 +12,8 @@ jest.mock('../src/middleware/auth', () => ({
 
 jest.mock('../src/services/requestDetailService', () => ({
   listRequestDetails: jest.fn(),
-  getRequestDetail: jest.fn()
+  getRequestDetail: jest.fn(),
+  getRequestBodyPreviewStats: jest.fn()
 }))
 
 jest.mock('../src/utils/logger', () => ({
@@ -42,10 +43,16 @@ function createResponse() {
   return res
 }
 
+function findGetHandler(path) {
+  const route = mockRouter.get.mock.calls.find((call) => call[0] === path)
+  return route?.[2]
+}
+
 describe('requestDetails admin routes', () => {
   beforeEach(() => {
     requestDetailService.listRequestDetails.mockReset()
     requestDetailService.getRequestDetail.mockReset()
+    requestDetailService.getRequestBodyPreviewStats.mockReset()
   })
 
   test('returns 400 for invalid request detail queries', async () => {
@@ -53,7 +60,7 @@ describe('requestDetails admin routes', () => {
     error.statusCode = 400
     requestDetailService.listRequestDetails.mockRejectedValue(error)
 
-    const [, , handler] = mockRouter.get.mock.calls[0]
+    const handler = findGetHandler('/request-details')
     const res = createResponse()
 
     await handler({ query: { startDate: 'bad' } }, res)
@@ -73,7 +80,7 @@ describe('requestDetails admin routes', () => {
       }
     })
 
-    const [, , handler] = mockRouter.get.mock.calls[1]
+    const handler = findGetHandler('/request-details/:requestId')
     const res = createResponse()
 
     await handler({ params: { requestId: 'req_1' } }, res)
@@ -82,5 +89,25 @@ describe('requestDetails admin routes', () => {
     expect(res.body.success).toBe(true)
     expect(res.body.data.captureEnabled).toBe(false)
     expect(res.body.data.record.requestId).toBe('req_1')
+  })
+
+  test('returns request body preview stats', async () => {
+    requestDetailService.getRequestBodyPreviewStats.mockResolvedValue({
+      captureEnabled: true,
+      retentionHours: 6,
+      bodyPreviewEnabled: false,
+      snapshotCount: 3,
+      hasSnapshots: true
+    })
+
+    const handler = findGetHandler('/request-details/body-preview-stats')
+    const res = createResponse()
+
+    await handler({}, res)
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.snapshotCount).toBe(3)
+    expect(res.body.data.hasSnapshots).toBe(true)
   })
 })

--- a/tests/requestDetailsRoute.test.js
+++ b/tests/requestDetailsRoute.test.js
@@ -1,0 +1,86 @@
+const mockRouter = {
+  get: jest.fn()
+}
+
+jest.mock('express', () => ({
+  Router: () => mockRouter
+}), { virtual: true })
+
+jest.mock('../src/middleware/auth', () => ({
+  authenticateAdmin: jest.fn((_req, _res, next) => next())
+}))
+
+jest.mock('../src/services/requestDetailService', () => ({
+  listRequestDetails: jest.fn(),
+  getRequestDetail: jest.fn()
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  start: jest.fn()
+}))
+
+const requestDetailService = require('../src/services/requestDetailService')
+require('../src/routes/admin/requestDetails')
+
+function createResponse() {
+  const res = {
+    statusCode: 200,
+    body: null,
+    json: jest.fn((payload) => {
+      res.body = payload
+      return res
+    }),
+    status: jest.fn((code) => {
+      res.statusCode = code
+      return res
+    })
+  }
+  return res
+}
+
+describe('requestDetails admin routes', () => {
+  beforeEach(() => {
+    requestDetailService.listRequestDetails.mockReset()
+    requestDetailService.getRequestDetail.mockReset()
+  })
+
+  test('returns 400 for invalid request detail queries', async () => {
+    const error = new Error('Invalid date range')
+    error.statusCode = 400
+    requestDetailService.listRequestDetails.mockRejectedValue(error)
+
+    const [, , handler] = mockRouter.get.mock.calls[0]
+    const res = createResponse()
+
+    await handler({ query: { startDate: 'bad' } }, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.body.success).toBe(false)
+    expect(res.body.message).toBe('Invalid date range')
+  })
+
+  test('returns retained detail records even when capture is disabled', async () => {
+    requestDetailService.getRequestDetail.mockResolvedValue({
+      captureEnabled: false,
+      retentionDays: 7,
+      record: {
+        requestId: 'req_1',
+        model: 'gpt-5.4'
+      }
+    })
+
+    const [, , handler] = mockRouter.get.mock.calls[1]
+    const res = createResponse()
+
+    await handler({ params: { requestId: 'req_1' } }, res)
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.captureEnabled).toBe(false)
+    expect(res.body.data.record.requestId).toBe('req_1')
+  })
+})

--- a/tests/requestDetailsRoute.test.js
+++ b/tests/requestDetailsRoute.test.js
@@ -3,9 +3,13 @@ const mockRouter = {
   post: jest.fn()
 }
 
-jest.mock('express', () => ({
-  Router: () => mockRouter
-}), { virtual: true })
+jest.mock(
+  'express',
+  () => ({
+    Router: () => mockRouter
+  }),
+  { virtual: true }
+)
 
 jest.mock('../src/middleware/auth', () => ({
   authenticateAdmin: jest.fn((_req, _res, next) => next())

--- a/tests/requestDetailsRoute.test.js
+++ b/tests/requestDetailsRoute.test.js
@@ -1,5 +1,6 @@
 const mockRouter = {
-  get: jest.fn()
+  get: jest.fn(),
+  post: jest.fn()
 }
 
 jest.mock('express', () => ({
@@ -13,7 +14,8 @@ jest.mock('../src/middleware/auth', () => ({
 jest.mock('../src/services/requestDetailService', () => ({
   listRequestDetails: jest.fn(),
   getRequestDetail: jest.fn(),
-  getRequestBodyPreviewStats: jest.fn()
+  getRequestBodyPreviewStats: jest.fn(),
+  purgeRequestBodySnapshots: jest.fn()
 }))
 
 jest.mock('../src/utils/logger', () => ({
@@ -48,11 +50,17 @@ function findGetHandler(path) {
   return route?.[2]
 }
 
+function findPostHandler(path) {
+  const route = mockRouter.post.mock.calls.find((call) => call[0] === path)
+  return route?.[2]
+}
+
 describe('requestDetails admin routes', () => {
   beforeEach(() => {
     requestDetailService.listRequestDetails.mockReset()
     requestDetailService.getRequestDetail.mockReset()
     requestDetailService.getRequestBodyPreviewStats.mockReset()
+    requestDetailService.purgeRequestBodySnapshots.mockReset()
   })
 
   test('returns 400 for invalid request detail queries', async () => {
@@ -109,5 +117,21 @@ describe('requestDetails admin routes', () => {
     expect(res.body.success).toBe(true)
     expect(res.body.data.snapshotCount).toBe(3)
     expect(res.body.data.hasSnapshots).toBe(true)
+  })
+
+  test('purges stored request body previews via dedicated route', async () => {
+    requestDetailService.purgeRequestBodySnapshots.mockResolvedValue({
+      updatedRecords: 7
+    })
+
+    const handler = findPostHandler('/request-details/body-preview-purge')
+    const res = createResponse()
+
+    await handler({}, res)
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.body.success).toBe(true)
+    expect(res.body.message).toBe('清理完毕')
+    expect(res.body.data.updatedRecords).toBe(7)
   })
 })

--- a/tests/requestDetailsRoute.test.js
+++ b/tests/requestDetailsRoute.test.js
@@ -66,7 +66,7 @@ describe('requestDetails admin routes', () => {
   test('returns retained detail records even when capture is disabled', async () => {
     requestDetailService.getRequestDetail.mockResolvedValue({
       captureEnabled: false,
-      retentionDays: 7,
+      retentionHours: 6,
       record: {
         requestId: 'req_1',
         model: 'gpt-5.4'

--- a/web/admin-spa/src/components/admin/RequestDetailModal.vue
+++ b/web/admin-spa/src/components/admin/RequestDetailModal.vue
@@ -181,15 +181,11 @@
         >
           <div class="mb-3 flex items-center justify-between gap-3">
             <h4 class="section-title mb-0">Request Body 快照</h4>
-            <el-button
-              v-if="bodyPreviewEnabled && detail.requestBodySnapshot"
-              size="small"
-              @click="copySnapshot"
-            >
+            <el-button v-if="hasRequestBodySnapshot" size="small" @click="copySnapshot">
               复制 JSON
             </el-button>
           </div>
-          <div v-if="bodyPreviewEnabled && detail.requestBodySnapshot" class="snapshot-panel">
+          <div v-if="hasRequestBodySnapshot" class="snapshot-panel">
             <pre>{{ formattedSnapshot }}</pre>
           </div>
           <div
@@ -352,6 +348,8 @@ const extractSnapshotDisplaySource = (snapshot) => {
 
   return snapshot
 }
+
+const hasRequestBodySnapshot = computed(() => Boolean(detail.value?.requestBodySnapshot))
 
 const formattedSnapshot = computed(() => {
   if (!detail.value?.requestBodySnapshot) {

--- a/web/admin-spa/src/components/admin/RequestDetailModal.vue
+++ b/web/admin-spa/src/components/admin/RequestDetailModal.vue
@@ -376,10 +376,13 @@ const fetchDetail = async () => {
     return
   }
 
+  const targetRequestId = props.requestId
+
   loading.value = true
   detail.value = null
   try {
-    const response = await getRequestDetailApi(props.requestId)
+    const response = await getRequestDetailApi(targetRequestId)
+    if (targetRequestId !== props.requestId || !props.show) return
     if (response?.success === false) {
       showToast(response.message || '加载请求详情失败', 'error')
       return
@@ -387,11 +390,14 @@ const fetchDetail = async () => {
     bodyPreviewEnabled.value = response.data?.bodyPreviewEnabled === true
     detail.value = response.data?.record || null
   } catch (error) {
+    if (targetRequestId !== props.requestId || !props.show) return
     detail.value = null
     bodyPreviewEnabled.value = false
     showToast(`加载请求详情失败：${error.message || '未知错误'}`, 'error')
   } finally {
-    loading.value = false
+    if (targetRequestId === props.requestId) {
+      loading.value = false
+    }
   }
 }
 

--- a/web/admin-spa/src/components/admin/RequestDetailModal.vue
+++ b/web/admin-spa/src/components/admin/RequestDetailModal.vue
@@ -175,10 +175,22 @@
         >
           <div class="mb-3 flex items-center justify-between gap-3">
             <h4 class="section-title mb-0">Request Body 快照</h4>
-            <el-button size="small" @click="copySnapshot">复制 JSON</el-button>
+            <el-button
+              v-if="bodyPreviewEnabled && detail.requestBodySnapshot"
+              size="small"
+              @click="copySnapshot"
+            >
+              复制 JSON
+            </el-button>
           </div>
-          <div v-if="detail.requestBodySnapshot" class="snapshot-panel">
+          <div v-if="bodyPreviewEnabled && detail.requestBodySnapshot" class="snapshot-panel">
             <pre>{{ formattedSnapshot }}</pre>
+          </div>
+          <div
+            v-else-if="!bodyPreviewEnabled"
+            class="rounded-lg border border-dashed border-amber-300 bg-amber-50/70 px-4 py-6 text-sm text-amber-700 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-300"
+          >
+            请求体预览已关闭，当前仅保留请求摘要字段，不展示请求体快照。
           </div>
           <div
             v-else
@@ -213,6 +225,7 @@ const emit = defineEmits(['close'])
 
 const loading = ref(false)
 const detail = ref(null)
+const bodyPreviewEnabled = ref(false)
 
 const costBreakdown = computed(() => {
   const breakdown = detail.value?.realCostBreakdown || detail.value?.costBreakdown || {}
@@ -366,9 +379,11 @@ const fetchDetail = async () => {
       showToast(response.message || '加载请求详情失败', 'error')
       return
     }
+    bodyPreviewEnabled.value = response.data?.bodyPreviewEnabled === true
     detail.value = response.data?.record || null
   } catch (error) {
     detail.value = null
+    bodyPreviewEnabled.value = false
     showToast(`加载请求详情失败：${error.message || '未知错误'}`, 'error')
   } finally {
     loading.value = false
@@ -416,6 +431,16 @@ watch(
     fetchDetail()
   },
   { immediate: true }
+)
+
+watch(
+  () => props.show,
+  (visible) => {
+    if (!visible) {
+      detail.value = null
+      bodyPreviewEnabled.value = false
+    }
+  }
 )
 </script>
 

--- a/web/admin-spa/src/components/admin/RequestDetailModal.vue
+++ b/web/admin-spa/src/components/admin/RequestDetailModal.vue
@@ -1,0 +1,514 @@
+<template>
+  <el-dialog
+    :append-to-body="true"
+    class="request-detail-modal"
+    :close-on-click-modal="false"
+    :destroy-on-close="true"
+    :model-value="show"
+    top="6vh"
+    width="900px"
+    @close="emitClose"
+  >
+    <template #header>
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-500">请求明细</p>
+          <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100">
+            {{ detail?.model || '加载中...' }}
+          </h3>
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            Request ID: {{ requestId || '未知' }}
+          </p>
+        </div>
+        <el-tag v-if="detail" effect="dark" :type="statusTagType(detail.statusCode)">
+          {{ detail.statusCode || 200 }}
+        </el-tag>
+      </div>
+    </template>
+
+    <div v-loading="loading" class="space-y-4">
+      <div
+        v-if="!loading && !detail"
+        class="rounded-xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+      >
+        未找到该请求详情
+      </div>
+
+      <template v-else-if="detail">
+        <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <div class="info-card">
+            <p class="info-label">接口</p>
+            <p class="info-value">{{ detail.endpoint || '-' }}</p>
+            <p class="info-sub">{{ detail.method || 'POST' }}</p>
+          </div>
+          <div class="info-card">
+            <p class="info-label">耗时</p>
+            <p class="info-value">{{ formatDuration(detail.durationMs) }}</p>
+            <p class="info-sub">{{ detail.stream ? '流式请求' : '非流式请求' }}</p>
+          </div>
+          <div class="info-card">
+            <p class="info-label">费用</p>
+            <p class="info-value text-amber-600 dark:text-amber-400">
+              {{ formatCost(detail.cost) }}
+            </p>
+            <p class="info-sub">真实成本 {{ formatCost(detail.realCost) }}</p>
+          </div>
+          <div class="info-card">
+            <p class="info-label">缓存命中率</p>
+            <p class="info-value text-cyan-600 dark:text-cyan-400">
+              {{ formatPercent(detail.cacheHitRate) }}
+            </p>
+            <p class="info-sub">{{ cacheHitRateLabel }}</p>
+          </div>
+        </div>
+
+        <div class="grid gap-4 xl:grid-cols-[1.2fr,0.8fr]">
+          <div
+            class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+          >
+            <h4 class="section-title">基础信息</h4>
+            <div class="grid gap-3 md:grid-cols-2">
+              <div>
+                <p class="field-label">时间</p>
+                <p class="field-value">{{ formatDate(detail.timestamp) }}</p>
+              </div>
+              <div>
+                <p class="field-label">API Key</p>
+                <p class="field-value">{{ detail.apiKeyName || detail.apiKeyId || '-' }}</p>
+                <p class="field-sub">{{ detail.apiKeyId || '-' }}</p>
+              </div>
+              <div>
+                <p class="field-label">使用账户</p>
+                <p class="field-value">{{ detail.accountName || detail.accountId || '-' }}</p>
+                <p class="field-sub">{{ detail.accountTypeName || detail.accountType || '-' }}</p>
+              </div>
+              <div>
+                <p class="field-label">模型</p>
+                <p class="field-value">{{ detail.model || '-' }}</p>
+                <p class="field-sub">
+                  {{ detail.isLongContextRequest ? '长上下文请求' : '标准上下文' }}
+                </p>
+              </div>
+              <div>
+                <p class="field-label">推理</p>
+                <p class="field-value">{{ formatReasoning(detail.reasoningDisplay) }}</p>
+                <p class="field-sub">
+                  {{ detail.reasoningSource ? `来源：${detail.reasoningSource}` : '未指定' }}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div
+            class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+          >
+            <h4 class="section-title">Token 明细</h4>
+            <div class="space-y-2 text-sm">
+              <div class="metric-row">
+                <span>输入</span>
+                <span class="font-semibold text-blue-600 dark:text-blue-400">{{
+                  formatNumber(detail.inputTokens)
+                }}</span>
+              </div>
+              <div class="metric-row">
+                <span>输出</span>
+                <span class="font-semibold text-green-600 dark:text-green-400">{{
+                  formatNumber(detail.outputTokens)
+                }}</span>
+              </div>
+              <div class="metric-row">
+                <span>缓存读取</span>
+                <span class="font-semibold text-cyan-600 dark:text-cyan-400">{{
+                  formatNumber(detail.cacheReadTokens)
+                }}</span>
+              </div>
+              <div class="metric-row">
+                <span>缓存创建</span>
+                <span class="font-semibold text-purple-600 dark:text-purple-400">{{
+                  formatCacheCreate(detail.cacheCreateTokens, detail.cacheCreateNotApplicable)
+                }}</span>
+              </div>
+              <div
+                class="metric-row border-t border-dashed border-gray-200 pt-2 dark:border-gray-700"
+              >
+                <span>总 Token</span>
+                <span class="font-semibold text-gray-900 dark:text-gray-100">{{
+                  formatNumber(detail.totalTokens)
+                }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+        >
+          <h4 class="section-title">费用拆分</h4>
+          <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+            <div class="cost-chip">
+              <span>输入</span>
+              <strong>{{ formatCost(costBreakdown.input) }}</strong>
+            </div>
+            <div class="cost-chip">
+              <span>输出</span>
+              <strong>{{ formatCost(costBreakdown.output) }}</strong>
+            </div>
+            <div class="cost-chip">
+              <span>缓存创建</span>
+              <strong>{{
+                formatCacheCreateCost(costBreakdown.cacheCreate, detail.cacheCreateNotApplicable)
+              }}</strong>
+            </div>
+            <div class="cost-chip">
+              <span>缓存读取</span>
+              <strong>{{ formatCost(costBreakdown.cacheRead) }}</strong>
+            </div>
+            <div class="cost-chip">
+              <span>总计</span>
+              <strong>{{ formatCost(costBreakdown.total || detail.cost) }}</strong>
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+        >
+          <div class="mb-3 flex items-center justify-between gap-3">
+            <h4 class="section-title mb-0">Request Body 快照</h4>
+            <el-button size="small" @click="copySnapshot">复制 JSON</el-button>
+          </div>
+          <div v-if="detail.requestBodySnapshot" class="snapshot-panel">
+            <pre>{{ formattedSnapshot }}</pre>
+          </div>
+          <div
+            v-else
+            class="rounded-lg border border-dashed border-gray-300 px-4 py-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+          >
+            未保存请求体快照
+          </div>
+        </div>
+      </template>
+    </div>
+  </el-dialog>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import dayjs from 'dayjs'
+import { getRequestDetailApi } from '@/utils/http_apis'
+import { showToast, formatNumber } from '@/utils/tools'
+
+const props = defineProps({
+  show: {
+    type: Boolean,
+    default: false
+  },
+  requestId: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['close'])
+
+const loading = ref(false)
+const detail = ref(null)
+
+const costBreakdown = computed(() => {
+  const breakdown = detail.value?.realCostBreakdown || detail.value?.costBreakdown || {}
+  return {
+    input: breakdown.input || 0,
+    output: breakdown.output || 0,
+    cacheCreate: breakdown.cacheCreate || breakdown.cacheWrite || 0,
+    cacheRead: breakdown.cacheRead || 0,
+    total: breakdown.total || detail.value?.realCost || detail.value?.cost || 0
+  }
+})
+
+const previewSuffixPattern = /\.\.\.\[\d+ chars\]$/
+
+const tryFormatJsonString = (value) => {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2)
+  } catch (error) {
+    return null
+  }
+}
+
+const formatJsonLikeText = (value) => {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  const suffix = value.match(previewSuffixPattern)?.[0] || ''
+  const source = suffix ? value.slice(0, -suffix.length) : value
+  let formatted = ''
+  let indent = 0
+  let inString = false
+  let escaping = false
+
+  const appendIndent = () => {
+    formatted += '  '.repeat(Math.max(0, indent))
+  }
+
+  for (const char of source) {
+    if (escaping) {
+      formatted += char
+      escaping = false
+      continue
+    }
+
+    if (char === '\\') {
+      formatted += char
+      escaping = inString
+      continue
+    }
+
+    if (char === '"') {
+      inString = !inString
+      formatted += char
+      continue
+    }
+
+    if (inString) {
+      formatted += char
+      continue
+    }
+
+    if (char === '{' || char === '[') {
+      formatted += `${char}\n`
+      indent += 1
+      appendIndent()
+      continue
+    }
+
+    if (char === '}' || char === ']') {
+      formatted = formatted.replace(/[ \t]+$/g, '')
+      formatted = formatted.replace(/\n?$/, '\n')
+      indent = Math.max(0, indent - 1)
+      appendIndent()
+      formatted += char
+      continue
+    }
+
+    if (char === ',') {
+      formatted += ',\n'
+      appendIndent()
+      continue
+    }
+
+    if (char === ':') {
+      formatted += ': '
+      continue
+    }
+
+    formatted += char
+  }
+
+  const trimmed = formatted.trim()
+  if (!trimmed) {
+    return suffix
+  }
+
+  return suffix ? `${trimmed}\n${suffix}` : trimmed
+}
+
+const extractSnapshotDisplaySource = (snapshot) => {
+  if (!snapshot) {
+    return ''
+  }
+
+  if (
+    typeof snapshot === 'object' &&
+    !Array.isArray(snapshot) &&
+    typeof snapshot.preview === 'string'
+  ) {
+    return snapshot.preview
+  }
+
+  return snapshot
+}
+
+const formattedSnapshot = computed(() => {
+  if (!detail.value?.requestBodySnapshot) {
+    return ''
+  }
+
+  const snapshotSource = extractSnapshotDisplaySource(detail.value.requestBodySnapshot)
+
+  if (typeof snapshotSource === 'string') {
+    return tryFormatJsonString(snapshotSource) || formatJsonLikeText(snapshotSource)
+  }
+
+  return JSON.stringify(snapshotSource, null, 2)
+})
+
+const cacheHitRateLabel = computed(() =>
+  detail.value?.isOpenAIRelated ? 'cached_tokens / prompt_tokens' : '读 / (读 + 建)'
+)
+
+const emitClose = () => emit('close')
+
+const fetchDetail = async () => {
+  if (!props.show || !props.requestId) {
+    return
+  }
+
+  loading.value = true
+  detail.value = null
+  try {
+    const response = await getRequestDetailApi(props.requestId)
+    if (response?.success === false) {
+      showToast(response.message || '加载请求详情失败', 'error')
+      return
+    }
+    detail.value = response.data?.record || null
+  } catch (error) {
+    detail.value = null
+    showToast(`加载请求详情失败：${error.message || '未知错误'}`, 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+const copySnapshot = async () => {
+  if (!formattedSnapshot.value) {
+    showToast('没有可复制的快照', 'info')
+    return
+  }
+
+  try {
+    await navigator.clipboard.writeText(formattedSnapshot.value)
+    showToast('已复制请求快照', 'success')
+  } catch (error) {
+    showToast('复制失败，请手动复制', 'error')
+  }
+}
+
+const formatDate = (value) => (value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-')
+const formatDuration = (value) => `${Number(value || 0)}ms`
+const formatPercent = (value) => `${Number(value || 0).toFixed(2)}%`
+const formatCacheCreate = (value, notApplicable = false) =>
+  notApplicable ? '-' : formatNumber(value)
+const formatReasoning = (value) => value || '-'
+const formatCost = (value) => {
+  const num = Number(value || 0)
+  if (num >= 1) return `$${num.toFixed(2)}`
+  if (num >= 0.001) return `$${num.toFixed(4)}`
+  return `$${num.toFixed(6)}`
+}
+const formatCacheCreateCost = (value, notApplicable = false) =>
+  notApplicable ? '-' : formatCost(value)
+
+const statusTagType = (statusCode) => {
+  if (statusCode >= 500) return 'danger'
+  if (statusCode >= 400) return 'warning'
+  return 'success'
+}
+
+watch(
+  () => [props.show, props.requestId],
+  () => {
+    fetchDetail()
+  },
+  { immediate: true }
+)
+</script>
+
+<style scoped>
+.request-detail-modal :deep(.el-dialog__body) {
+  padding-top: 8px;
+}
+
+.info-card {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 16px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(240, 249, 255, 0.94));
+}
+
+.dark .info-card {
+  background: linear-gradient(135deg, rgba(17, 24, 39, 0.94), rgba(15, 23, 42, 0.92));
+  border-color: rgba(71, 85, 105, 0.35);
+}
+
+.info-label,
+.field-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(100 116 139);
+}
+
+.info-value,
+.field-value {
+  margin-top: 6px;
+  font-size: 18px;
+  font-weight: 700;
+  color: rgb(15 23 42);
+}
+
+.dark .info-value,
+.dark .field-value {
+  color: rgb(241 245 249);
+}
+
+.info-sub,
+.field-sub {
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgb(100 116 139);
+}
+
+.section-title {
+  margin-bottom: 12px;
+  font-size: 14px;
+  font-weight: 700;
+  color: rgb(30 41 59);
+}
+
+.dark .section-title {
+  color: rgb(226 232 240);
+}
+
+.metric-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cost-chip {
+  border-radius: 14px;
+  background: rgb(248 250 252);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.dark .cost-chip {
+  background: rgba(30, 41, 59, 0.75);
+}
+
+.snapshot-panel {
+  max-height: 380px;
+  overflow: auto;
+  border-radius: 14px;
+  background: rgb(15 23 42);
+  padding: 16px;
+}
+
+.snapshot-panel pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+  line-height: 1.55;
+  color: rgb(226 232 240);
+}
+</style>

--- a/web/admin-spa/src/components/admin/RequestDetailModal.vue
+++ b/web/admin-spa/src/components/admin/RequestDetailModal.vue
@@ -4,25 +4,31 @@
     class="request-detail-modal"
     :close-on-click-modal="false"
     :destroy-on-close="true"
+    :fullscreen="isMobileViewport"
     :model-value="show"
+    :show-close="false"
     top="6vh"
-    width="900px"
+    width="960px"
     @close="emitClose"
   >
     <template #header>
-      <div class="flex items-center justify-between gap-4">
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-500">请求明细</p>
+      <div class="flex flex-wrap items-start justify-between gap-3 sm:flex-nowrap sm:items-center">
+        <div class="min-w-0 flex-1">
           <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100">
             {{ detail?.model || '加载中...' }}
           </h3>
-          <p class="text-xs text-gray-500 dark:text-gray-400">
+          <p class="mt-1 break-all text-xs text-gray-500 dark:text-gray-400 sm:text-sm">
             Request ID: {{ requestId || '未知' }}
           </p>
         </div>
-        <el-tag v-if="detail" effect="dark" :type="statusTagType(detail.statusCode)">
-          {{ detail.statusCode || 200 }}
-        </el-tag>
+        <div class="flex items-center gap-2 self-start sm:self-center">
+          <el-tag v-if="detail" effect="dark" :type="statusTagType(detail.statusCode)">
+            {{ detail.statusCode || 200 }}
+          </el-tag>
+          <button aria-label="关闭" class="modal-close-button" type="button" @click="emitClose">
+            <i class="fas fa-times" />
+          </button>
+        </div>
       </div>
     </template>
 
@@ -205,7 +211,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import dayjs from 'dayjs'
 import { getRequestDetailApi } from '@/utils/http_apis'
 import { showToast, formatNumber } from '@/utils/tools'
@@ -226,6 +232,7 @@ const emit = defineEmits(['close'])
 const loading = ref(false)
 const detail = ref(null)
 const bodyPreviewEnabled = ref(false)
+const isMobileViewport = ref(false)
 
 const costBreakdown = computed(() => {
   const breakdown = detail.value?.realCostBreakdown || detail.value?.costBreakdown || {}
@@ -425,6 +432,13 @@ const statusTagType = (statusCode) => {
   return 'success'
 }
 
+const syncViewportState = () => {
+  if (typeof window === 'undefined') {
+    return
+  }
+  isMobileViewport.value = window.innerWidth < 768
+}
+
 watch(
   () => [props.show, props.requestId],
   () => {
@@ -442,11 +456,87 @@ watch(
     }
   }
 )
+
+onMounted(() => {
+  syncViewportState()
+  window.addEventListener('resize', syncViewportState)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', syncViewportState)
+})
 </script>
 
 <style scoped>
+.request-detail-modal :deep(.el-dialog) {
+  width: min(960px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+  margin: 0 auto;
+  overflow: hidden;
+  border-radius: 24px;
+}
+
+.request-detail-modal :deep(.el-dialog__header) {
+  margin: 0;
+  padding: 18px 20px 0;
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(10px);
+}
+
+.dark .request-detail-modal :deep(.el-dialog__header) {
+  background: rgba(17, 24, 39, 0.98);
+}
+
 .request-detail-modal :deep(.el-dialog__body) {
-  padding-top: 8px;
+  padding: 12px 20px 20px;
+  max-height: min(78vh, 920px);
+  overflow-y: auto;
+}
+
+.request-detail-modal :deep(.el-dialog.is-fullscreen) {
+  width: 100vw !important;
+  max-width: none;
+  height: 100vh;
+  margin: 0;
+  border-radius: 0;
+}
+
+.request-detail-modal :deep(.el-dialog.is-fullscreen .el-dialog__header) {
+  padding: 14px 16px 0;
+}
+
+.request-detail-modal :deep(.el-dialog.is-fullscreen .el-dialog__body) {
+  padding: 12px 16px 24px;
+  max-height: none;
+  height: calc(100vh - 76px);
+}
+
+.modal-close-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 9999px;
+  color: rgb(100 116 139);
+  transition: all 0.2s ease;
+}
+
+.modal-close-button:hover {
+  background: rgba(148, 163, 184, 0.14);
+  color: rgb(51 65 85);
+}
+
+.dark .modal-close-button {
+  color: rgb(203 213 225);
+}
+
+.dark .modal-close-button:hover {
+  background: rgba(71, 85, 105, 0.35);
+  color: rgb(248 250 252);
 }
 
 .info-card {
@@ -535,5 +625,39 @@ watch(
   font-size: 12px;
   line-height: 1.55;
   color: rgb(226 232 240);
+}
+
+@media (max-width: 767px) {
+  .request-detail-modal :deep(.el-dialog__header) {
+    padding: 14px 16px 0;
+  }
+
+  .request-detail-modal :deep(.el-dialog__body) {
+    padding: 12px 16px 20px;
+    max-height: calc(100vh - 88px);
+  }
+
+  .info-card {
+    padding: 14px;
+  }
+
+  .info-value,
+  .field-value {
+    font-size: 16px;
+  }
+
+  .cost-chip {
+    padding: 10px 12px;
+  }
+
+  .snapshot-panel {
+    max-height: min(42vh, 420px);
+    padding: 14px;
+  }
+
+  .snapshot-panel pre {
+    font-size: 11px;
+    line-height: 1.5;
+  }
 }
 </style>

--- a/web/admin-spa/src/components/layout/MainLayout.vue
+++ b/web/admin-spa/src/components/layout/MainLayout.vue
@@ -39,6 +39,7 @@ const tabRouteMap = computed(() => {
     dashboard: '/dashboard',
     apiKeys: '/api-keys',
     accounts: '/accounts',
+    requestDetails: '/request-details',
     quotaCards: '/quota-cards',
     settings: '/settings'
   }
@@ -67,6 +68,7 @@ const initActiveTab = () => {
       Dashboard: 'dashboard',
       ApiKeys: 'apiKeys',
       Accounts: 'accounts',
+      RequestDetails: 'requestDetails',
       QuotaCards: 'quotaCards',
       Settings: 'settings'
     }
@@ -96,6 +98,7 @@ watch(
         Dashboard: 'dashboard',
         ApiKeys: 'apiKeys',
         Accounts: 'accounts',
+        RequestDetails: 'requestDetails',
         QuotaCards: 'quotaCards',
         Tutorial: 'tutorial',
         Settings: 'settings'

--- a/web/admin-spa/src/components/layout/TabBar.vue
+++ b/web/admin-spa/src/components/layout/TabBar.vue
@@ -57,6 +57,7 @@ const tabs = computed(() => {
     { key: 'dashboard', name: '仪表板', shortName: '仪表板', icon: 'fas fa-tachometer-alt' },
     { key: 'apiKeys', name: 'API Keys', shortName: 'API', icon: 'fas fa-key' },
     { key: 'accounts', name: '账户管理', shortName: '账户', icon: 'fas fa-user-circle' },
+    { key: 'requestDetails', name: '请求明细', shortName: '明细', icon: 'fas fa-table' },
     { key: 'quotaCards', name: '额度卡', shortName: '额度卡', icon: 'fas fa-ticket-alt' }
   ]
 

--- a/web/admin-spa/src/router/index.js
+++ b/web/admin-spa/src/router/index.js
@@ -17,6 +17,7 @@ const AccountUsageRecordsView = () => import('@/views/AccountUsageRecordsView.vu
 const SettingsView = () => import('@/views/SettingsView.vue')
 const ApiStatsView = () => import('@/views/ApiStatsView.vue')
 const QuotaCardsView = () => import('@/views/QuotaCardsView.vue')
+const RequestDetailsView = () => import('@/views/RequestDetailsView.vue')
 
 const routes = [
   {
@@ -156,6 +157,18 @@ const routes = [
         path: '',
         name: 'QuotaCards',
         component: QuotaCardsView
+      }
+    ]
+  },
+  {
+    path: '/request-details',
+    component: MainLayout,
+    meta: { requiresAuth: true },
+    children: [
+      {
+        path: '',
+        name: 'RequestDetails',
+        component: RequestDetailsView
       }
     ]
   },

--- a/web/admin-spa/src/utils/http_apis.js
+++ b/web/admin-spa/src/utils/http_apis.js
@@ -53,6 +53,8 @@ export const getRequestDetailsApi = (params) =>
   request({ url: '/admin/request-details', method: 'GET', params })
 export const getRequestDetailBodyPreviewStatsApi = (config) =>
   request({ url: '/admin/request-details/body-preview-stats', method: 'GET', ...config })
+export const purgeRequestDetailBodyPreviewApi = (config) =>
+  request({ url: '/admin/request-details/body-preview-purge', method: 'POST', ...config })
 export const getRequestDetailApi = (requestId) =>
   request({ url: `/admin/request-details/${requestId}`, method: 'GET' })
 

--- a/web/admin-spa/src/utils/http_apis.js
+++ b/web/admin-spa/src/utils/http_apis.js
@@ -49,6 +49,10 @@ export const getTempUnavailableApi = () =>
 export const getUsageCostsApi = (period) =>
   request({ url: `/admin/usage-costs?period=${period}`, method: 'GET' })
 export const getUsageStatsApi = (url) => request({ url, method: 'GET' })
+export const getRequestDetailsApi = (params) =>
+  request({ url: '/admin/request-details', method: 'GET', params })
+export const getRequestDetailApi = (requestId) =>
+  request({ url: `/admin/request-details/${requestId}`, method: 'GET' })
 
 // 客户端
 export const getSupportedClientsApi = () =>

--- a/web/admin-spa/src/utils/http_apis.js
+++ b/web/admin-spa/src/utils/http_apis.js
@@ -51,6 +51,8 @@ export const getUsageCostsApi = (period) =>
 export const getUsageStatsApi = (url) => request({ url, method: 'GET' })
 export const getRequestDetailsApi = (params) =>
   request({ url: '/admin/request-details', method: 'GET', params })
+export const getRequestDetailBodyPreviewStatsApi = (config) =>
+  request({ url: '/admin/request-details/body-preview-stats', method: 'GET', ...config })
 export const getRequestDetailApi = (requestId) =>
   request({ url: `/admin/request-details/${requestId}`, method: 'GET' })
 

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -38,7 +38,7 @@
         </div>
 
         <div
-          v-if="!captureEnabled && !loading && records.length === 0"
+          v-if="!captureEnabled && !loading && records.length === 0 && !hasActiveFilters"
           class="rounded-2xl border border-dashed border-gray-300 bg-gray-50/80 p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800/50"
         >
           <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -50,16 +50,41 @@
                 到系统设置开启“请求明细采集”后，后台会开始记录新的请求摘要。历史请求不会回填。
               </p>
             </div>
-            <button
-              class="group relative inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
-              @click="goToSettings"
-            >
-              <span
-                class="absolute -inset-0.5 rounded-lg bg-gradient-to-r from-blue-500 to-indigo-500 opacity-0 blur transition duration-300 group-hover:opacity-20"
-              ></span>
-              <i class="fas fa-cog relative text-blue-500" />
-              <span class="relative">前往系统设置</span>
-            </button>
+            <div class="flex flex-col gap-2 sm:flex-row">
+              <button
+                class="group relative inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+                @click="goToSettings"
+              >
+                <span
+                  class="absolute -inset-0.5 rounded-lg bg-gradient-to-r from-blue-500 to-indigo-500 opacity-0 blur transition duration-300 group-hover:opacity-20"
+                ></span>
+                <i class="fas fa-cog relative text-blue-500" />
+                <span class="relative">前往系统设置</span>
+              </button>
+              <el-tooltip placement="top">
+                <template #content>
+                  <div class="max-w-xs text-xs leading-relaxed">
+                    清理所有已保存的历史请求体预览数据；仅影响历史预览，不影响当前请求体预览开关设置
+                  </div>
+                </template>
+                <button
+                  class="group relative inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+                  :disabled="requestDetailBodyPreviewPurging"
+                  @click="handleRequestDetailBodyPreviewPurge"
+                >
+                  <span
+                    class="absolute -inset-0.5 rounded-lg bg-gradient-to-r from-red-500 to-orange-500 opacity-0 blur transition duration-300 group-hover:opacity-20"
+                  ></span>
+                  <i
+                    :class="[
+                      'fas relative text-red-500',
+                      requestDetailBodyPreviewPurging ? 'fa-spinner fa-spin' : 'fa-trash-alt'
+                    ]"
+                  />
+                  <span class="relative">清理历史预览</span>
+                </button>
+              </el-tooltip>
+            </div>
           </div>
         </div>
 
@@ -284,6 +309,30 @@
                   />
                   <span class="relative">导出 CSV</span>
                 </button>
+
+                <el-tooltip placement="top">
+                  <template #content>
+                    <div class="max-w-xs text-xs leading-relaxed">
+                      清理所有已保存的历史请求体预览数据；仅影响历史预览，不影响当前请求体预览开关设置
+                    </div>
+                  </template>
+                  <button
+                    class="toolbar-action-button group relative flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+                    :disabled="requestDetailBodyPreviewPurging"
+                    @click="handleRequestDetailBodyPreviewPurge"
+                  >
+                    <span
+                      class="absolute -inset-0.5 rounded-lg bg-gradient-to-r from-red-500 to-orange-500 opacity-0 blur transition duration-300 group-hover:opacity-20"
+                    ></span>
+                    <i
+                      :class="[
+                        'fas relative text-red-500',
+                        requestDetailBodyPreviewPurging ? 'fa-spinner fa-spin' : 'fa-trash-alt'
+                      ]"
+                    />
+                    <span class="relative">清理历史预览</span>
+                  </button>
+                </el-tooltip>
               </div>
             </div>
           </div>
@@ -535,17 +584,24 @@
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import dayjs from 'dayjs'
+import { debounce } from 'lodash-es'
 import { useRouter } from 'vue-router'
-import { getRequestDetailsApi } from '@/utils/http_apis'
+import {
+  getRequestDetailsApi,
+  getRequestDetailBodyPreviewStatsApi,
+  purgeRequestDetailBodyPreviewApi
+} from '@/utils/http_apis'
 import { showToast, formatDate, formatNumber } from '@/utils/tools'
 import RequestDetailModal from '@/components/admin/RequestDetailModal.vue'
 
 const router = useRouter()
 
+let fetchVersion = 0
 const loading = ref(false)
 const exporting = ref(false)
+const requestDetailBodyPreviewPurging = ref(false)
 const detailVisible = ref(false)
 const activeRequestId = ref('')
 const captureEnabled = ref(false)
@@ -571,6 +627,17 @@ const filters = reactive({
   model: '',
   endpoint: '',
   sortOrder: 'desc'
+})
+
+const hasActiveFilters = computed(() => {
+  return !!(
+    filters.keyword ||
+    filters.apiKeyId ||
+    filters.accountId ||
+    filters.model ||
+    filters.endpoint ||
+    (filters.dateRange && filters.dateRange.length === 2)
+  )
 })
 
 const summary = reactive({
@@ -666,7 +733,7 @@ const syncResponseState = (data) => {
   pagination.totalRecords = pageInfo.totalRecords || 0
 
   const filterEcho = data.filters || {}
-  filters.keyword = filterEcho.keyword || ''
+  // keyword 不回写：用户可能正在输入，回写会覆盖用户当前的输入
   filters.apiKeyId = filterEcho.apiKeyId || ''
   filters.accountId = filterEcho.accountId || ''
   filters.model = filterEcho.model || ''
@@ -701,18 +768,24 @@ const syncResponseState = (data) => {
 }
 
 const fetchRecords = async (page = pagination.currentPage) => {
+  debouncedKeywordFetch.cancel()
+  const version = ++fetchVersion
   loading.value = true
   try {
     const response = await getRequestDetailsApi(buildParams(page))
+    if (version !== fetchVersion) return
     if (response?.success === false) {
       showToast(response.message || '加载请求明细失败', 'error')
       return
     }
     syncResponseState(response.data || {})
   } catch (error) {
+    if (version !== fetchVersion) return
     showToast(`加载请求明细失败：${error.message || '未知错误'}`, 'error')
   } finally {
-    loading.value = false
+    if (version === fetchVersion) {
+      loading.value = false
+    }
   }
 }
 
@@ -741,6 +814,48 @@ const resetFilters = () => {
   filters.sortOrder = 'desc'
   pagination.currentPage = 1
   fetchRecords(1)
+  // resetFilters 同步写 filters.keyword = '' 会触发 keyword watcher 排一个新 debounce，
+  // 需要在 watcher 执行后（nextTick）取消它，避免多余请求和 loading 闪烁
+  nextTick(() => debouncedKeywordFetch.cancel())
+}
+
+const handleRequestDetailBodyPreviewPurge = async () => {
+  if (requestDetailBodyPreviewPurging.value) return
+
+  try {
+    const statsResponse = await getRequestDetailBodyPreviewStatsApi()
+
+    if (statsResponse?.success === false) {
+      showToast(statsResponse.message || '检查历史请求体预览失败', 'error')
+      return
+    }
+
+    const snapshotCount = Number(statsResponse?.data?.snapshotCount || 0)
+    if (snapshotCount <= 0) {
+      showToast('暂无历史请求体预览需要清理', 'success')
+      return
+    }
+
+    const confirmed = window.confirm(
+      `检测到当前仍有 ${snapshotCount} 条请求明细保存了请求体预览。\n清理后将仅移除历史请求体预览，保留请求明细摘要字段。\n\n是否继续？`
+    )
+    if (!confirmed) return
+
+    requestDetailBodyPreviewPurging.value = true
+    const purgeResponse = await purgeRequestDetailBodyPreviewApi()
+
+    if (purgeResponse?.success === false) {
+      showToast(purgeResponse.message || '清理历史请求体预览失败', 'error')
+      return
+    }
+
+    showToast(purgeResponse?.message || '清理完毕', 'success')
+  } catch (error) {
+    showToast('清理历史请求体预览失败', 'error')
+    console.error(error)
+  } finally {
+    requestDetailBodyPreviewPurging.value = false
+  }
 }
 
 const goToSettings = () => router.push('/settings')
@@ -760,6 +875,7 @@ const exportCsv = async () => {
     const aggregated = []
     let page = 1
     let totalPages = 1
+    let totalRecords = 0
     const maxPages = 100
 
     while (page <= totalPages && page <= maxPages) {
@@ -770,7 +886,17 @@ const exportCsv = async () => {
       const payload = response.data || {}
       aggregated.push(...(payload.records || []))
       totalPages = payload.pagination?.totalPages || 1
+      if (page === 1) {
+        totalRecords = payload.pagination?.totalRecords || 0
+      }
       page += 1
+    }
+
+    if (totalPages > maxPages) {
+      showToast(
+        `数据量超过导出上限（已导出 ${aggregated.length} 条，共 ${totalRecords} 条），建议缩小筛选范围后重试`,
+        'warning'
+      )
     }
 
     if (aggregated.length === 0) {
@@ -862,16 +988,22 @@ const formatDuration = (value) => `${Number(value || 0)}ms`
 const formatPercent = (value) => `${Number(value || 0).toFixed(2)}%`
 const formatReasoning = (value) => value || '-'
 
+const debouncedKeywordFetch = debounce(() => {
+  pagination.currentPage = 1
+  fetchRecords(1)
+}, 300)
+
 watch(
-  () => [
-    filters.keyword,
-    filters.apiKeyId,
-    filters.accountId,
-    filters.model,
-    filters.endpoint,
-    filters.sortOrder
-  ],
+  () => filters.keyword,
   () => {
+    debouncedKeywordFetch()
+  }
+)
+
+watch(
+  () => [filters.apiKeyId, filters.accountId, filters.model, filters.endpoint, filters.sortOrder],
+  () => {
+    debouncedKeywordFetch.cancel()
     pagination.currentPage = 1
     fetchRecords(1)
   }

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -28,7 +28,7 @@
                 class="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
               >
                 <span class="mr-2 h-2 w-2 rounded-full bg-blue-500" />
-                保留 {{ retentionDays }} 天
+                {{ formatRetentionHours(retentionHours) }}
               </span>
             </div>
             <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 sm:text-base">
@@ -550,7 +550,7 @@ const exporting = ref(false)
 const detailVisible = ref(false)
 const activeRequestId = ref('')
 const captureEnabled = ref(false)
-const retentionDays = ref(7)
+const retentionHours = ref(6)
 const records = ref([])
 const availableApiKeys = ref([])
 const availableAccounts = ref([])
@@ -620,7 +620,7 @@ const buildParams = (page) => {
 
 const syncResponseState = (data) => {
   captureEnabled.value = data.captureEnabled === true
-  retentionDays.value = data.retentionDays || 7
+  retentionHours.value = data.retentionHours || 6
   records.value = data.records || []
 
   const pageInfo = data.pagination || {}
@@ -804,6 +804,23 @@ const formatCost = (value) => {
 }
 const formatCacheCreate = (value, notApplicable = false) =>
   notApplicable ? '-' : formatNumber(value)
+const formatRetentionHours = (value) => {
+  const totalHours = Number(value || 0)
+  if (totalHours <= 0) return '保留 6 小时'
+
+  const days = Math.floor(totalHours / 24)
+  const hours = totalHours % 24
+
+  if (days > 0 && hours > 0) {
+    return `保留 ${days} 天 ${hours} 小时`
+  }
+
+  if (days > 0) {
+    return `保留 ${days} 天`
+  }
+
+  return `保留 ${hours} 小时`
+}
 const formatDuration = (value) => `${Number(value || 0)}ms`
 const formatPercent = (value) => `${Number(value || 0).toFixed(2)}%`
 const formatReasoning = (value) => value || '-'

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -1,0 +1,1074 @@
+<template>
+  <div class="request-details-container">
+    <div class="card p-4 sm:p-6">
+      <div class="mb-4 flex flex-col gap-4 sm:mb-6">
+        <div class="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+          <div>
+            <div class="flex flex-wrap items-center gap-2 sm:gap-3">
+              <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100 sm:text-xl">
+                请求明细
+              </h3>
+              <span
+                :class="[
+                  'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold',
+                  captureEnabled
+                    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+                    : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
+                ]"
+              >
+                <span
+                  :class="[
+                    'mr-2 h-2 w-2 rounded-full',
+                    captureEnabled ? 'bg-green-500' : 'bg-gray-400'
+                  ]"
+                />
+                {{ captureEnabled ? '采集已开启' : '采集已关闭' }}
+              </span>
+              <span
+                class="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+              >
+                <span class="mr-2 h-2 w-2 rounded-full bg-blue-500" />
+                保留 {{ retentionDays }} 天
+              </span>
+            </div>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 sm:text-base">
+              搜索每次请求的 API Key、使用账户、模型、接口、Token、费用、耗时与脱敏后的请求快照
+            </p>
+          </div>
+        </div>
+
+        <div
+          v-if="!captureEnabled && !loading && records.length === 0"
+          class="rounded-2xl border border-dashed border-gray-300 bg-gray-50/80 p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800/50"
+        >
+          <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100">
+                请求明细采集尚未开启
+              </h3>
+              <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                到系统设置开启“请求明细采集”后，后台会开始记录新的请求摘要。历史请求不会回填。
+              </p>
+            </div>
+            <button
+              class="group relative inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+              @click="goToSettings"
+            >
+              <span
+                class="absolute -inset-0.5 rounded-lg bg-gradient-to-r from-blue-500 to-indigo-500 opacity-0 blur transition duration-300 group-hover:opacity-20"
+              ></span>
+              <i class="fas fa-cog relative text-blue-500" />
+              <span class="relative">前往系统设置</span>
+            </button>
+          </div>
+        </div>
+
+        <template v-else>
+          <div
+            v-if="!captureEnabled"
+            class="rounded-xl border border-amber-200 bg-amber-50/90 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200"
+          >
+            请求明细采集已关闭，当前展示的是仍在保留期内的历史记录；不会继续写入新的请求明细。
+          </div>
+
+          <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+            <div class="summary-card">
+              <p class="summary-label">总请求</p>
+              <p class="summary-value">{{ formatNumber(summary.totalRequests) }}</p>
+            </div>
+            <div class="summary-card">
+              <p class="summary-label">输入 / 输出</p>
+              <p class="summary-value">{{ formatNumber(summary.inputTokens) }}</p>
+              <p class="summary-sub">输出 {{ formatNumber(summary.outputTokens) }}</p>
+            </div>
+            <div class="summary-card">
+              <p class="summary-label">缓存命中率</p>
+              <p class="summary-value text-cyan-600 dark:text-cyan-400">
+                {{ formatPercent(summary.cacheHitRate) }}
+              </p>
+              <p class="summary-sub">
+                读 {{ formatNumber(summary.cacheReadTokens) }} / 建
+                {{ formatCacheCreate(summary.cacheCreateTokens, summary.cacheCreateNotApplicable) }}
+              </p>
+            </div>
+            <div class="summary-card">
+              <p class="summary-label">总费用</p>
+              <p class="summary-value text-amber-600 dark:text-amber-400">
+                {{ formatCost(summary.totalCost) }}
+              </p>
+            </div>
+            <div class="summary-card">
+              <p class="summary-label">平均耗时</p>
+              <p class="summary-value">{{ formatDuration(summary.avgDurationMs) }}</p>
+            </div>
+          </div>
+
+          <div
+            class="rounded-2xl border border-gray-200 bg-gray-50/70 p-4 dark:border-gray-700 dark:bg-gray-800/40"
+          >
+            <div class="request-toolbar">
+              <div class="request-filters">
+                <div class="request-filter-row request-filter-row-primary">
+                  <div class="toolbar-control group">
+                    <div
+                      class="toolbar-control-glow bg-gradient-to-r from-blue-500 to-purple-500"
+                    ></div>
+                    <el-date-picker
+                      v-model="filters.dateRange"
+                      class="toolbar-element w-full"
+                      clearable
+                      end-placeholder="结束时间"
+                      format="YYYY-MM-DD HH:mm:ss"
+                      start-placeholder="开始时间"
+                      type="datetimerange"
+                      unlink-panels
+                      value-format="YYYY-MM-DDTHH:mm:ss[Z]"
+                    />
+                  </div>
+
+                  <div class="toolbar-control group">
+                    <div
+                      class="toolbar-control-glow bg-gradient-to-r from-cyan-500 to-teal-500"
+                    ></div>
+                    <el-input
+                      v-model="filters.keyword"
+                      class="toolbar-element w-full"
+                      clearable
+                      placeholder="搜索 Request ID / API Key / 账户 / 模型 / 接口"
+                    >
+                      <template #prefix>
+                        <i class="fas fa-search text-cyan-500" />
+                      </template>
+                    </el-input>
+                  </div>
+                </div>
+
+                <div class="request-filter-row request-filter-row-secondary">
+                  <div class="toolbar-control group">
+                    <div
+                      class="toolbar-control-glow bg-gradient-to-r from-indigo-500 to-blue-500"
+                    ></div>
+                    <el-select
+                      v-model="filters.apiKeyId"
+                      class="toolbar-element w-full"
+                      clearable
+                      filterable
+                      placeholder="所有 API Key"
+                    >
+                      <el-option
+                        v-for="item in availableApiKeys"
+                        :key="item.id"
+                        :label="item.name"
+                        :value="item.id"
+                      />
+                    </el-select>
+                  </div>
+
+                  <div class="toolbar-control group">
+                    <div
+                      class="toolbar-control-glow bg-gradient-to-r from-purple-500 to-pink-500"
+                    ></div>
+                    <el-select
+                      v-model="filters.accountId"
+                      class="toolbar-element w-full"
+                      clearable
+                      filterable
+                      placeholder="所有账户"
+                    >
+                      <el-option
+                        v-for="item in availableAccounts"
+                        :key="item.id"
+                        :label="`${item.name}（${item.accountTypeName}）`"
+                        :value="item.id"
+                      />
+                    </el-select>
+                  </div>
+
+                  <div class="toolbar-control group">
+                    <div
+                      class="toolbar-control-glow bg-gradient-to-r from-emerald-500 to-green-500"
+                    ></div>
+                    <el-select
+                      v-model="filters.model"
+                      class="toolbar-element w-full"
+                      clearable
+                      filterable
+                      placeholder="所有模型"
+                    >
+                      <el-option
+                        v-for="item in availableModels"
+                        :key="item"
+                        :label="item"
+                        :value="item"
+                      />
+                    </el-select>
+                  </div>
+
+                  <div class="toolbar-control group">
+                    <div
+                      class="toolbar-control-glow bg-gradient-to-r from-orange-500 to-amber-500"
+                    ></div>
+                    <el-select
+                      v-model="filters.endpoint"
+                      class="toolbar-element w-full"
+                      clearable
+                      filterable
+                      placeholder="所有接口"
+                    >
+                      <el-option
+                        v-for="item in availableEndpoints"
+                        :key="item"
+                        :label="item"
+                        :value="item"
+                      />
+                    </el-select>
+                  </div>
+
+                  <div class="toolbar-control group">
+                    <div
+                      class="toolbar-control-glow bg-gradient-to-r from-slate-500 to-gray-500"
+                    ></div>
+                    <el-select
+                      v-model="filters.sortOrder"
+                      class="toolbar-element w-full"
+                      placeholder="时间排序"
+                    >
+                      <el-option label="时间降序" value="desc" />
+                      <el-option label="时间升序" value="asc" />
+                    </el-select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="request-toolbar-actions">
+                <button
+                  class="toolbar-action-button group relative flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+                  :disabled="loading"
+                  @click="refreshRecords"
+                >
+                  <span
+                    class="absolute -inset-0.5 rounded-lg bg-gradient-to-r from-green-500 to-teal-500 opacity-0 blur transition duration-300 group-hover:opacity-20"
+                  ></span>
+                  <i
+                    :class="[
+                      'fas relative text-green-500',
+                      loading ? 'fa-spinner fa-spin' : 'fa-sync-alt'
+                    ]"
+                  />
+                  <span class="relative">刷新</span>
+                </button>
+
+                <button
+                  class="toolbar-action-button group relative flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+                  @click="resetFilters"
+                >
+                  <span
+                    class="absolute -inset-0.5 rounded-lg bg-gradient-to-r from-gray-400 to-gray-500 opacity-0 blur transition duration-300 group-hover:opacity-20"
+                  ></span>
+                  <i class="fas fa-undo relative text-gray-500" />
+                  <span class="relative">重置筛选</span>
+                </button>
+
+                <button
+                  class="toolbar-action-button group relative flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500"
+                  :disabled="exporting"
+                  @click="exportCsv"
+                >
+                  <span
+                    class="absolute -inset-0.5 rounded-lg bg-gradient-to-r from-blue-500 to-indigo-500 opacity-0 blur transition duration-300 group-hover:opacity-20"
+                  ></span>
+                  <i
+                    :class="[
+                      'fas relative text-blue-500',
+                      exporting ? 'fa-spinner fa-spin' : 'fa-file-export'
+                    ]"
+                  />
+                  <span class="relative">导出 CSV</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <div class="table-wrapper">
+        <div
+          v-if="loading"
+          class="flex items-center justify-center p-12 text-gray-500 dark:text-gray-400"
+        >
+          <i class="fas fa-spinner fa-spin mr-2" />加载中...
+        </div>
+
+        <div
+          v-else-if="records.length === 0"
+          class="flex flex-col items-center gap-3 p-12 text-center text-gray-500 dark:text-gray-400"
+        >
+          <i class="fas fa-inbox text-3xl text-cyan-500" />
+          <p class="text-base font-semibold text-gray-700 dark:text-gray-200">暂无请求明细</p>
+          <p class="max-w-xl text-sm">
+            {{ emptyHint }}
+          </p>
+        </div>
+
+        <div v-else class="space-y-4">
+          <div class="table-container hidden xl:block">
+            <table class="request-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead
+                class="sticky top-0 z-10 bg-gradient-to-b from-gray-50 to-gray-100/90 backdrop-blur-sm dark:from-gray-700 dark:to-gray-800/90"
+              >
+                <tr>
+                  <th
+                    class="min-w-[170px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    统计时间
+                  </th>
+                  <th
+                    class="min-w-[170px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    API Key
+                  </th>
+                  <th
+                    class="min-w-[170px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    使用账户
+                  </th>
+                  <th
+                    class="min-w-[140px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    模型
+                  </th>
+                  <th
+                    class="min-w-[110px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    推理
+                  </th>
+                  <th
+                    class="min-w-[180px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    接口
+                  </th>
+                  <th
+                    class="min-w-[96px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    输入
+                  </th>
+                  <th
+                    class="min-w-[96px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    输出
+                  </th>
+                  <th
+                    class="min-w-[110px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    缓存读取
+                  </th>
+                  <th
+                    class="min-w-[110px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    缓存创建
+                  </th>
+                  <th
+                    class="min-w-[110px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    缓存命中率
+                  </th>
+                  <th
+                    class="min-w-[100px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    费用
+                  </th>
+                  <th
+                    class="min-w-[100px] px-3 py-4 text-left text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    耗时
+                  </th>
+                  <th
+                    class="min-w-[96px] px-3 py-4 text-right text-xs font-bold uppercase tracking-wider text-gray-700 dark:text-gray-300"
+                  >
+                    操作
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900"
+              >
+                <tr
+                  v-for="record in records"
+                  :key="record.requestId"
+                  class="request-row hover:bg-gray-50/90 dark:hover:bg-gray-800/70"
+                >
+                  <td class="table-cell">
+                    <div class="font-medium">{{ formatDate(record.timestamp) }}</div>
+                    <div class="text-xs text-gray-500 dark:text-gray-400">
+                      {{ record.requestId }}
+                    </div>
+                  </td>
+                  <td class="table-cell">
+                    <div class="font-semibold">
+                      {{ record.apiKeyName || record.apiKeyId || '-' }}
+                    </div>
+                    <div class="text-xs text-gray-500 dark:text-gray-400">
+                      {{ record.apiKeyId || '-' }}
+                    </div>
+                  </td>
+                  <td class="table-cell">
+                    <div class="font-semibold">
+                      {{ record.accountName || record.accountId || '-' }}
+                    </div>
+                    <div class="text-xs text-gray-500 dark:text-gray-400">
+                      {{ record.accountTypeName || record.accountType || '-' }}
+                    </div>
+                  </td>
+                  <td class="table-cell">{{ record.model }}</td>
+                  <td class="table-cell">{{ formatReasoning(record.reasoningDisplay) }}</td>
+                  <td class="table-cell">
+                    <div>{{ record.endpoint || '-' }}</div>
+                    <div class="text-xs text-gray-500 dark:text-gray-400">
+                      {{ record.method || 'POST' }}
+                    </div>
+                  </td>
+                  <td class="table-cell text-blue-600 dark:text-blue-400">
+                    {{ formatNumber(record.inputTokens) }}
+                  </td>
+                  <td class="table-cell text-green-600 dark:text-green-400">
+                    {{ formatNumber(record.outputTokens) }}
+                  </td>
+                  <td class="table-cell text-cyan-600 dark:text-cyan-400">
+                    {{ formatNumber(record.cacheReadTokens) }}
+                  </td>
+                  <td class="table-cell text-purple-600 dark:text-purple-400">
+                    {{
+                      formatCacheCreate(record.cacheCreateTokens, record.cacheCreateNotApplicable)
+                    }}
+                  </td>
+                  <td class="table-cell">{{ formatPercent(record.cacheHitRate) }}</td>
+                  <td class="table-cell text-amber-600 dark:text-amber-400">
+                    {{ formatCost(record.cost) }}
+                  </td>
+                  <td class="table-cell">{{ formatDuration(record.durationMs) }}</td>
+                  <td class="table-cell text-right">
+                    <button
+                      class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500 dark:hover:bg-gray-700"
+                      @click="openDetail(record.requestId)"
+                    >
+                      详情
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="space-y-3 xl:hidden">
+            <div
+              v-for="record in records"
+              :key="record.requestId"
+              class="card p-4 transition-shadow hover:shadow-lg"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <p class="text-sm font-bold text-gray-900 dark:text-gray-100">
+                    {{ record.model }}
+                  </p>
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
+                    {{ formatDate(record.timestamp) }}
+                  </p>
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
+                    {{ record.endpoint || '-' }}
+                  </p>
+                </div>
+                <button
+                  class="inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-500 dark:hover:bg-gray-700"
+                  @click="openDetail(record.requestId)"
+                >
+                  详情
+                </button>
+              </div>
+              <div class="mt-3 grid grid-cols-2 gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <div>API Key：{{ record.apiKeyName || '-' }}</div>
+                <div>账户：{{ record.accountName || '-' }}</div>
+                <div>推理：{{ formatReasoning(record.reasoningDisplay) }}</div>
+                <div>输入：{{ formatNumber(record.inputTokens) }}</div>
+                <div>输出：{{ formatNumber(record.outputTokens) }}</div>
+                <div>缓存读：{{ formatNumber(record.cacheReadTokens) }}</div>
+                <div>
+                  缓存建：{{
+                    formatCacheCreate(record.cacheCreateTokens, record.cacheCreateNotApplicable)
+                  }}
+                </div>
+                <div>命中率：{{ formatPercent(record.cacheHitRate) }}</div>
+                <div>耗时：{{ formatDuration(record.durationMs) }}</div>
+                <div class="text-amber-600 dark:text-amber-400">
+                  费用：{{ formatCost(record.cost) }}
+                </div>
+                <div class="text-xs text-gray-500 dark:text-gray-400">{{ record.requestId }}</div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            class="flex flex-col gap-3 border-t border-gray-200 px-4 pb-4 pt-4 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div class="text-sm text-gray-500 dark:text-gray-400">
+              共 {{ pagination.totalRecords }} 条记录
+            </div>
+            <el-pagination
+              background
+              :current-page="pagination.currentPage"
+              layout="prev, pager, next, sizes"
+              :page-size="pagination.pageSize"
+              :page-sizes="[20, 50, 100, 200]"
+              :total="pagination.totalRecords"
+              @current-change="handlePageChange"
+              @size-change="handleSizeChange"
+            />
+          </div>
+        </div>
+      </div>
+
+      <RequestDetailModal
+        :request-id="activeRequestId"
+        :show="detailVisible"
+        @close="closeDetail"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import dayjs from 'dayjs'
+import { useRouter } from 'vue-router'
+import { getRequestDetailsApi } from '@/utils/http_apis'
+import { showToast, formatDate, formatNumber } from '@/utils/tools'
+import RequestDetailModal from '@/components/admin/RequestDetailModal.vue'
+
+const router = useRouter()
+
+const loading = ref(false)
+const exporting = ref(false)
+const detailVisible = ref(false)
+const activeRequestId = ref('')
+const captureEnabled = ref(false)
+const retentionDays = ref(7)
+const records = ref([])
+const availableApiKeys = ref([])
+const availableAccounts = ref([])
+const availableModels = ref([])
+const availableEndpoints = ref([])
+
+const pagination = reactive({
+  currentPage: 1,
+  pageSize: 50,
+  totalRecords: 0
+})
+
+const filters = reactive({
+  dateRange: null,
+  keyword: '',
+  apiKeyId: '',
+  accountId: '',
+  model: '',
+  endpoint: '',
+  sortOrder: 'desc'
+})
+
+const summary = reactive({
+  totalRequests: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreateTokens: 0,
+  totalCost: 0,
+  avgDurationMs: 0,
+  cacheHitRate: 0,
+  cacheCreateNotApplicable: false
+})
+
+const emptyHint = computed(() => {
+  if (
+    filters.keyword ||
+    filters.apiKeyId ||
+    filters.accountId ||
+    filters.model ||
+    filters.endpoint
+  ) {
+    return '当前筛选条件下没有结果，请尝试放宽搜索条件。'
+  }
+  return '这里只展示开启请求明细采集之后的新请求记录。'
+})
+
+const buildParams = (page) => {
+  const params = {
+    page,
+    pageSize: pagination.pageSize,
+    sortOrder: filters.sortOrder
+  }
+
+  if (filters.keyword) params.keyword = filters.keyword
+  if (filters.apiKeyId) params.apiKeyId = filters.apiKeyId
+  if (filters.accountId) params.accountId = filters.accountId
+  if (filters.model) params.model = filters.model
+  if (filters.endpoint) params.endpoint = filters.endpoint
+  if (filters.dateRange && filters.dateRange.length === 2) {
+    params.startDate = dayjs(filters.dateRange[0]).toISOString()
+    params.endDate = dayjs(filters.dateRange[1]).toISOString()
+  }
+
+  return params
+}
+
+const syncResponseState = (data) => {
+  captureEnabled.value = data.captureEnabled === true
+  retentionDays.value = data.retentionDays || 7
+  records.value = data.records || []
+
+  const pageInfo = data.pagination || {}
+  pagination.currentPage = pageInfo.currentPage || 1
+  pagination.pageSize = pageInfo.pageSize || pagination.pageSize
+  pagination.totalRecords = pageInfo.totalRecords || 0
+
+  const filterEcho = data.filters || {}
+  filters.keyword = filterEcho.keyword || ''
+  filters.apiKeyId = filterEcho.apiKeyId || ''
+  filters.accountId = filterEcho.accountId || ''
+  filters.model = filterEcho.model || ''
+  filters.endpoint = filterEcho.endpoint || ''
+  filters.sortOrder = filterEcho.sortOrder || 'desc'
+  if (filterEcho.startDate && filterEcho.endDate) {
+    const nextRange = [filterEcho.startDate, filterEcho.endDate]
+    const currentRange = filters.dateRange || []
+    if (
+      filterEcho.hasCustomDateRange &&
+      (currentRange[0] !== nextRange[0] || currentRange[1] !== nextRange[1])
+    ) {
+      filters.dateRange = nextRange
+    }
+  }
+
+  availableApiKeys.value = data.availableFilters?.apiKeys || []
+  availableAccounts.value = data.availableFilters?.accounts || []
+  availableModels.value = data.availableFilters?.models || []
+  availableEndpoints.value = data.availableFilters?.endpoints || []
+
+  const summaryData = data.summary || {}
+  summary.totalRequests = summaryData.totalRequests || 0
+  summary.inputTokens = summaryData.inputTokens || 0
+  summary.outputTokens = summaryData.outputTokens || 0
+  summary.cacheReadTokens = summaryData.cacheReadTokens || 0
+  summary.cacheCreateTokens = summaryData.cacheCreateTokens || 0
+  summary.totalCost = summaryData.totalCost || 0
+  summary.avgDurationMs = summaryData.avgDurationMs || 0
+  summary.cacheHitRate = summaryData.cacheHitRate || 0
+  summary.cacheCreateNotApplicable = summaryData.cacheCreateNotApplicable === true
+}
+
+const fetchRecords = async (page = pagination.currentPage) => {
+  loading.value = true
+  try {
+    const response = await getRequestDetailsApi(buildParams(page))
+    if (response?.success === false) {
+      showToast(response.message || '加载请求明细失败', 'error')
+      return
+    }
+    syncResponseState(response.data || {})
+  } catch (error) {
+    showToast(`加载请求明细失败：${error.message || '未知错误'}`, 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+const handlePageChange = (page) => {
+  pagination.currentPage = page
+  fetchRecords(page)
+}
+
+const handleSizeChange = (size) => {
+  pagination.pageSize = size
+  pagination.currentPage = 1
+  fetchRecords(1)
+}
+
+const refreshRecords = () => {
+  fetchRecords(pagination.currentPage)
+}
+
+const resetFilters = () => {
+  filters.dateRange = null
+  filters.keyword = ''
+  filters.apiKeyId = ''
+  filters.accountId = ''
+  filters.model = ''
+  filters.endpoint = ''
+  filters.sortOrder = 'desc'
+  pagination.currentPage = 1
+  fetchRecords(1)
+}
+
+const goToSettings = () => router.push('/settings')
+const openDetail = (requestId) => {
+  activeRequestId.value = requestId
+  detailVisible.value = true
+}
+const closeDetail = () => {
+  detailVisible.value = false
+  activeRequestId.value = ''
+}
+
+const exportCsv = async () => {
+  if (exporting.value) return
+  exporting.value = true
+  try {
+    const aggregated = []
+    let page = 1
+    let totalPages = 1
+    const maxPages = 100
+
+    while (page <= totalPages && page <= maxPages) {
+      const response = await getRequestDetailsApi({
+        ...buildParams(page),
+        pageSize: 200
+      })
+      const payload = response.data || {}
+      aggregated.push(...(payload.records || []))
+      totalPages = payload.pagination?.totalPages || 1
+      page += 1
+    }
+
+    if (aggregated.length === 0) {
+      showToast('没有可导出的记录', 'info')
+      return
+    }
+
+    const headers = [
+      '统计时间',
+      'Request ID',
+      'API Key',
+      '使用账户',
+      '消费类型',
+      '模型',
+      '推理',
+      '接口',
+      '输入',
+      '输出',
+      '缓存读取',
+      '缓存创建',
+      '缓存命中率',
+      '费用',
+      '耗时(ms)'
+    ]
+
+    const rows = [headers.join(',')]
+    aggregated.forEach((record) => {
+      const row = [
+        formatDate(record.timestamp),
+        record.requestId || '',
+        record.apiKeyName || record.apiKeyId || '',
+        record.accountName || record.accountId || '',
+        record.accountTypeName || record.accountType || '',
+        record.model || '',
+        formatReasoning(record.reasoningDisplay),
+        record.endpoint || '',
+        record.inputTokens || 0,
+        record.outputTokens || 0,
+        record.cacheReadTokens || 0,
+        formatCacheCreate(record.cacheCreateTokens, record.cacheCreateNotApplicable),
+        formatPercent(record.cacheHitRate),
+        formatCost(record.cost),
+        record.durationMs || 0
+      ]
+      rows.push(row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+    })
+
+    const blob = new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'request-details.csv'
+    link.click()
+    URL.revokeObjectURL(url)
+    showToast('导出 CSV 成功', 'success')
+  } catch (error) {
+    showToast(`导出失败：${error.message || '未知错误'}`, 'error')
+  } finally {
+    exporting.value = false
+  }
+}
+
+const formatCost = (value) => {
+  const num = Number(value || 0)
+  if (num >= 1) return `$${num.toFixed(2)}`
+  if (num >= 0.001) return `$${num.toFixed(4)}`
+  return `$${num.toFixed(6)}`
+}
+const formatCacheCreate = (value, notApplicable = false) =>
+  notApplicable ? '-' : formatNumber(value)
+const formatDuration = (value) => `${Number(value || 0)}ms`
+const formatPercent = (value) => `${Number(value || 0).toFixed(2)}%`
+const formatReasoning = (value) => value || '-'
+
+watch(
+  () => [
+    filters.keyword,
+    filters.apiKeyId,
+    filters.accountId,
+    filters.model,
+    filters.endpoint,
+    filters.sortOrder
+  ],
+  () => {
+    pagination.currentPage = 1
+    fetchRecords(1)
+  }
+)
+
+watch(
+  () => filters.dateRange,
+  () => {
+    pagination.currentPage = 1
+    fetchRecords(1)
+  },
+  { deep: true }
+)
+
+onMounted(() => {
+  fetchRecords()
+})
+</script>
+
+<style scoped>
+.request-details-container {
+  min-height: calc(100vh - 300px);
+}
+
+.summary-card {
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  border-radius: 16px;
+  padding: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.96));
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.04);
+}
+
+.dark .summary-card {
+  background: linear-gradient(135deg, rgba(31, 41, 55, 0.96), rgba(17, 24, 39, 0.94));
+  border-color: rgba(75, 85, 99, 0.55);
+}
+
+.summary-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgb(107 114 128);
+}
+
+.summary-value {
+  margin-top: 8px;
+  font-size: 24px;
+  font-weight: 800;
+  color: rgb(15 23 42);
+}
+
+.dark .summary-value {
+  color: rgb(241 245 249);
+}
+
+.summary-sub {
+  margin-top: 6px;
+  font-size: 12px;
+  color: rgb(100 116 139);
+}
+
+.request-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.request-filters {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.request-filter-row {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.request-filter-row-primary,
+.request-filter-row-secondary {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.toolbar-control {
+  position: relative;
+  min-width: 0;
+}
+
+.toolbar-control-glow {
+  position: absolute;
+  inset: -2px;
+  border-radius: 12px;
+  opacity: 0;
+  filter: blur(10px);
+  transition: opacity 0.3s ease;
+}
+
+.toolbar-control:hover .toolbar-control-glow {
+  opacity: 0.16;
+}
+
+.toolbar-control :deep(.el-input__wrapper),
+.toolbar-control :deep(.el-select__wrapper) {
+  min-height: 40px;
+  border-radius: 10px;
+  border: 1px solid rgb(229 231 235);
+  background: rgb(255 255 255);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.toolbar-control :deep(.el-input__wrapper:hover),
+.toolbar-control :deep(.el-select__wrapper:hover) {
+  border-color: rgb(209 213 219);
+}
+
+.toolbar-control :deep(.el-input__wrapper.is-focus),
+.toolbar-control :deep(.el-select__wrapper.is-focused) {
+  border-color: rgb(6 182 212);
+  box-shadow: 0 0 0 1px rgba(6, 182, 212, 0.15);
+}
+
+.dark .toolbar-control :deep(.el-input__wrapper),
+.dark .toolbar-control :deep(.el-select__wrapper) {
+  border-color: rgb(75 85 99);
+  background: rgb(31 41 55);
+}
+
+.toolbar-control :deep(.el-date-editor) {
+  width: 100%;
+}
+
+.request-toolbar-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.toolbar-action-button {
+  min-width: 112px;
+  white-space: nowrap;
+}
+
+.table-cell {
+  padding: 14px 16px;
+  font-size: 13px;
+  color: rgb(31 41 55);
+  vertical-align: top;
+}
+
+.dark .table-cell {
+  color: rgb(226 232 240);
+}
+
+.table-wrapper {
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  width: 100%;
+  position: relative;
+}
+
+.dark .table-wrapper {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.table-container {
+  overflow-x: auto;
+  overflow-y: hidden;
+  margin: 0;
+  padding: 0;
+  max-width: 100%;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table-container table {
+  min-width: 1500px;
+  border-collapse: collapse;
+  table-layout: auto;
+}
+
+.table-container::-webkit-scrollbar {
+  height: 8px;
+}
+
+.table-container::-webkit-scrollbar-track {
+  background: #f3f4f6;
+  border-radius: 4px;
+}
+
+.table-container::-webkit-scrollbar-thumb {
+  background: #d1d5db;
+  border-radius: 4px;
+}
+
+.table-container::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af;
+}
+
+.dark .table-container::-webkit-scrollbar-track {
+  background: rgba(31, 41, 55, 0.9);
+}
+
+.dark .table-container::-webkit-scrollbar-thumb {
+  background: rgba(107, 114, 128, 0.9);
+}
+
+.request-table tbody tr:nth-child(even) {
+  background: rgba(249, 250, 251, 0.65);
+}
+
+.dark .request-table tbody tr:nth-child(even) {
+  background: rgba(31, 41, 55, 0.55);
+}
+
+@media (min-width: 768px) {
+  .request-filter-row-primary {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  }
+
+  .request-filter-row-secondary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .request-toolbar-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
+@media (min-width: 1280px) {
+  .request-toolbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 16px;
+  }
+
+  .request-filter-row-primary {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  }
+
+  .request-filter-row-secondary {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .request-toolbar-actions {
+    align-self: stretch;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+  }
+}
+</style>

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -122,7 +122,6 @@
                       start-placeholder="开始时间"
                       type="datetimerange"
                       unlink-panels
-                      value-format="YYYY-MM-DDTHH:mm:ss[Z]"
                     />
                   </div>
 
@@ -605,6 +604,30 @@ const emptyHint = computed(() => {
   return '这里只展示开启请求明细采集之后的新请求记录。'
 })
 
+const toPickerDate = (value) => {
+  const parsed = dayjs(value)
+  return parsed.isValid() ? parsed.toDate() : null
+}
+
+const getDateRangeTimestamp = (value) => {
+  const parsed = dayjs(value)
+  return parsed.isValid() ? parsed.valueOf() : null
+}
+
+const areDateRangesEqual = (currentRange = [], nextRange = []) => {
+  if (!Array.isArray(currentRange) || !Array.isArray(nextRange)) {
+    return false
+  }
+
+  if (currentRange.length !== nextRange.length) {
+    return false
+  }
+
+  return currentRange.every(
+    (value, index) => getDateRangeTimestamp(value) === getDateRangeTimestamp(nextRange[index])
+  )
+}
+
 const buildParams = (page) => {
   const params = {
     page,
@@ -618,8 +641,14 @@ const buildParams = (page) => {
   if (filters.model) params.model = filters.model
   if (filters.endpoint) params.endpoint = filters.endpoint
   if (filters.dateRange && filters.dateRange.length === 2) {
-    params.startDate = dayjs(filters.dateRange[0]).toISOString()
-    params.endDate = dayjs(filters.dateRange[1]).toISOString()
+    const [startDate, endDate] = filters.dateRange
+    const parsedStart = dayjs(startDate)
+    const parsedEnd = dayjs(endDate)
+
+    if (parsedStart.isValid() && parsedEnd.isValid()) {
+      params.startDate = parsedStart.toISOString()
+      params.endDate = parsedEnd.toISOString()
+    }
   }
 
   return params
@@ -644,11 +673,11 @@ const syncResponseState = (data) => {
   filters.endpoint = filterEcho.endpoint || ''
   filters.sortOrder = filterEcho.sortOrder || 'desc'
   if (filterEcho.startDate && filterEcho.endDate) {
-    const nextRange = [filterEcho.startDate, filterEcho.endDate]
-    const currentRange = filters.dateRange || []
+    const nextRange = [toPickerDate(filterEcho.startDate), toPickerDate(filterEcho.endDate)]
     if (
       filterEcho.hasCustomDateRange &&
-      (currentRange[0] !== nextRange[0] || currentRange[1] !== nextRange[1])
+      nextRange.every(Boolean) &&
+      !areDateRangesEqual(filters.dateRange || [], nextRange)
     ) {
       filters.dateRange = nextRange
     }

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -32,7 +32,7 @@
               </span>
             </div>
             <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 sm:text-base">
-              搜索每次请求的 API Key、使用账户、模型、接口、Token、费用、耗时与脱敏后的请求快照
+              {{ pageDescription }}
             </p>
           </div>
         </div>
@@ -551,6 +551,7 @@ const detailVisible = ref(false)
 const activeRequestId = ref('')
 const captureEnabled = ref(false)
 const retentionHours = ref(6)
+const bodyPreviewEnabled = ref(false)
 const records = ref([])
 const availableApiKeys = ref([])
 const availableAccounts = ref([])
@@ -584,6 +585,12 @@ const summary = reactive({
   cacheHitRate: 0,
   cacheCreateNotApplicable: false
 })
+
+const pageDescription = computed(() =>
+  bodyPreviewEnabled.value
+    ? '搜索每次请求的 API Key、使用账户、模型、接口、Token、费用、耗时与脱敏后的请求快照'
+    : '搜索每次请求的 API Key、使用账户、模型、接口、Token、费用、耗时与请求摘要'
+)
 
 const emptyHint = computed(() => {
   if (
@@ -621,6 +628,7 @@ const buildParams = (page) => {
 const syncResponseState = (data) => {
   captureEnabled.value = data.captureEnabled === true
   retentionHours.value = data.retentionHours || 6
+  bodyPreviewEnabled.value = data.bodyPreviewEnabled === true
   records.value = data.records || []
 
   const pageInfo = data.pagination || {}

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -312,7 +312,7 @@
 
         <div v-else class="space-y-4">
           <div class="table-container hidden xl:block">
-            <table class="request-table min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <table class="request-table w-full divide-y divide-gray-200 dark:divide-gray-700">
               <thead
                 class="sticky top-0 z-10 bg-gradient-to-b from-gray-50 to-gray-100/90 backdrop-blur-sm dark:from-gray-700 dark:to-gray-800/90"
               >
@@ -1023,6 +1023,10 @@ onMounted(() => {
   min-width: 1500px;
   border-collapse: collapse;
   table-layout: auto;
+}
+
+.request-table {
+  width: max(100%, 1500px);
 }
 
 .table-container::-webkit-scrollbar {

--- a/web/admin-spa/src/views/SettingsView.vue
+++ b/web/admin-spa/src/views/SettingsView.vue
@@ -1135,19 +1135,58 @@
                 <div>
                   <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                     <i class="fas fa-calendar-day mr-2 text-gray-400"></i>
-                    请求明细保留天数
+                    请求明细保留时间
                   </label>
-                  <input
-                    v-model.number="claudeConfig.requestDetailRetentionDays"
-                    class="mt-1 block w-full max-w-xs rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 dark:border-gray-500 dark:bg-gray-700 dark:text-white sm:text-sm"
-                    max="30"
-                    min="1"
-                    placeholder="7"
-                    type="number"
-                    @change="saveClaudeConfig"
-                  />
+                  <div class="mt-1 flex max-w-md flex-col gap-3 sm:flex-row sm:items-end">
+                    <div class="flex-1">
+                      <label
+                        class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                      >
+                        天
+                      </label>
+                      <input
+                        v-model.number="requestDetailRetentionInput.days"
+                        class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 dark:border-gray-500 dark:bg-gray-700 dark:text-white sm:text-sm"
+                        max="30"
+                        min="0"
+                        placeholder="0"
+                        type="number"
+                        @change="handleRequestDetailRetentionChange"
+                      />
+                    </div>
+                    <div class="flex-1">
+                      <label
+                        class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                      >
+                        小时
+                      </label>
+                      <input
+                        v-model.number="requestDetailRetentionInput.hours"
+                        class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 dark:border-gray-500 dark:bg-gray-700 dark:text-white sm:text-sm"
+                        max="23"
+                        min="0"
+                        placeholder="6"
+                        type="number"
+                        @change="handleRequestDetailRetentionChange"
+                      />
+                    </div>
+                  </div>
+                  <p
+                    v-if="requestDetailRetentionError"
+                    class="mt-2 text-xs text-red-500 dark:text-red-400"
+                  >
+                    {{ requestDetailRetentionError }}
+                  </p>
+                  <p
+                    v-else-if="requestDetailRetentionWarning"
+                    class="mt-2 text-xs text-amber-600 dark:text-amber-400"
+                  >
+                    <i class="fas fa-exclamation-triangle mr-1"></i>
+                    {{ requestDetailRetentionWarning }}
+                  </p>
                   <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    新请求明细会按天保留，支持 1-30 天；关闭采集不会删除已保留的数据，直到自然过期
+                    新请求明细按小时保留，支持 0-30 天与 0-23 小时组合，总保留时间为 1-720
+                    小时；关闭采集不会删除已保留的数据，直到自然过期
                   </p>
                 </div>
               </div>
@@ -1884,7 +1923,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount, watch, computed } from 'vue'
+import { ref, reactive, onMounted, onBeforeUnmount, watch, computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { showToast } from '@/utils/tools'
 import { useSettingsStore } from '@/stores/settings'
@@ -1998,10 +2037,90 @@ const claudeConfig = ref({
   concurrentRequestQueueMaxSizeMultiplier: 0,
   concurrentRequestQueueTimeoutMs: 10000,
   requestDetailCaptureEnabled: false,
-  requestDetailRetentionDays: 7,
+  requestDetailRetentionHours: 6,
   updatedAt: null,
   updatedBy: null
 })
+
+const REQUEST_DETAIL_RETENTION_DEFAULT_HOURS = 6
+const REQUEST_DETAIL_RETENTION_WARNING_HOURS = 72
+const REQUEST_DETAIL_RETENTION_MAX_HOURS = 720
+
+const requestDetailRetentionInput = reactive({
+  days: 0,
+  hours: REQUEST_DETAIL_RETENTION_DEFAULT_HOURS
+})
+
+const normalizeRetentionPart = (value) => {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const splitRequestDetailRetentionHours = (totalHours = REQUEST_DETAIL_RETENTION_DEFAULT_HOURS) => {
+  const normalized = Math.max(
+    1,
+    Math.min(REQUEST_DETAIL_RETENTION_MAX_HOURS, normalizeRetentionPart(totalHours))
+  )
+  return {
+    days: Math.floor(normalized / 24),
+    hours: normalized % 24
+  }
+}
+
+const syncRequestDetailRetentionInput = (totalHours = REQUEST_DETAIL_RETENTION_DEFAULT_HOURS) => {
+  const { days, hours } = splitRequestDetailRetentionHours(totalHours)
+  requestDetailRetentionInput.days = days
+  requestDetailRetentionInput.hours = hours
+}
+
+const requestDetailRetentionTotalHours = computed(() => {
+  const days = normalizeRetentionPart(requestDetailRetentionInput.days)
+  const hours = normalizeRetentionPart(requestDetailRetentionInput.hours)
+  return days * 24 + hours
+})
+
+const requestDetailRetentionError = computed(() => {
+  const days = normalizeRetentionPart(requestDetailRetentionInput.days)
+  const hours = normalizeRetentionPart(requestDetailRetentionInput.hours)
+
+  if (days < 0 || days > 30) {
+    return '天数必须在 0 到 30 之间'
+  }
+
+  if (hours < 0 || hours > 23) {
+    return '小时数必须在 0 到 23 之间'
+  }
+
+  if (requestDetailRetentionTotalHours.value < 1) {
+    return '请求明细保留时间至少需要 1 小时'
+  }
+
+  if (requestDetailRetentionTotalHours.value > REQUEST_DETAIL_RETENTION_MAX_HOURS) {
+    return '请求明细保留时间不能超过 30 天'
+  }
+
+  return ''
+})
+
+const requestDetailRetentionWarning = computed(() => {
+  if (
+    !requestDetailRetentionError.value &&
+    requestDetailRetentionTotalHours.value > REQUEST_DETAIL_RETENTION_WARNING_HOURS
+  ) {
+    return '保留时间超过 72 小时会增加 Redis 存储压力'
+  }
+  return ''
+})
+
+const handleRequestDetailRetentionChange = () => {
+  if (requestDetailRetentionError.value) {
+    showToast(requestDetailRetentionError.value, 'error')
+    return
+  }
+
+  claudeConfig.value.requestDetailRetentionHours = requestDetailRetentionTotalHours.value
+  saveClaudeConfig()
+}
 
 // 服务倍率配置
 const serviceRatesLoading = ref(false)
@@ -2300,10 +2419,12 @@ const loadClaudeConfig = async () => {
           response.config?.concurrentRequestQueueMaxSizeMultiplier ?? 0,
         concurrentRequestQueueTimeoutMs: response.config?.concurrentRequestQueueTimeoutMs ?? 10000,
         requestDetailCaptureEnabled: response.config?.requestDetailCaptureEnabled ?? false,
-        requestDetailRetentionDays: response.config?.requestDetailRetentionDays ?? 7,
+        requestDetailRetentionHours:
+          response.config?.requestDetailRetentionHours ?? REQUEST_DETAIL_RETENTION_DEFAULT_HOURS,
         updatedAt: response.config?.updatedAt || null,
         updatedBy: response.config?.updatedBy || null
       }
+      syncRequestDetailRetentionInput(claudeConfig.value.requestDetailRetentionHours)
     }
   } catch (error) {
     if (error.name === 'AbortError') return
@@ -2335,7 +2456,7 @@ const saveClaudeConfig = async () => {
         claudeConfig.value.concurrentRequestQueueMaxSizeMultiplier,
       concurrentRequestQueueTimeoutMs: claudeConfig.value.concurrentRequestQueueTimeoutMs,
       requestDetailCaptureEnabled: claudeConfig.value.requestDetailCaptureEnabled,
-      requestDetailRetentionDays: claudeConfig.value.requestDetailRetentionDays
+      requestDetailRetentionHours: claudeConfig.value.requestDetailRetentionHours
     }
 
     const response = await httpApis.updateClaudeRelayConfigApi(payload, {
@@ -2344,9 +2465,13 @@ const saveClaudeConfig = async () => {
     if (response.success && isMounted.value) {
       claudeConfig.value = {
         ...claudeConfig.value,
+        requestDetailRetentionHours:
+          response.config?.requestDetailRetentionHours ??
+          claudeConfig.value.requestDetailRetentionHours,
         updatedAt: response.config?.updatedAt || new Date().toISOString(),
         updatedBy: response.config?.updatedBy || null
       }
+      syncRequestDetailRetentionInput(claudeConfig.value.requestDetailRetentionHours)
       showToast('Claude 转发配置已保存', 'success')
     }
   } catch (error) {

--- a/web/admin-spa/src/views/SettingsView.vue
+++ b/web/admin-spa/src/views/SettingsView.vue
@@ -1189,6 +1189,41 @@
                     小时；关闭采集不会删除已保留的数据，直到自然过期
                   </p>
                 </div>
+
+                <div
+                  class="rounded-lg border border-gray-200 bg-gray-50/80 p-4 dark:border-gray-700 dark:bg-gray-900/30"
+                >
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="flex-1">
+                      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        <i class="fas fa-eye mr-2 text-gray-400"></i>
+                        请求体预览
+                      </label>
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        关闭后，请求明细详情页不再展示请求体预览，Redis 也不会继续保存请求体快照。
+                      </p>
+                      <p
+                        v-if="claudeConfig.requestDetailBodyPreviewEnabled"
+                        class="mt-2 text-xs text-amber-600 dark:text-amber-400"
+                      >
+                        <i class="fas fa-exclamation-triangle mr-1"></i>
+                        开启请求体预览会增加 Redis 存储压力
+                      </p>
+                    </div>
+
+                    <label class="relative inline-flex cursor-pointer items-center">
+                      <input
+                        v-model="claudeConfig.requestDetailBodyPreviewEnabled"
+                        class="peer sr-only"
+                        type="checkbox"
+                        @change="handleRequestDetailBodyPreviewToggle"
+                      />
+                      <div
+                        class="peer h-6 w-11 rounded-full bg-gray-200 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-cyan-500 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-cyan-300 dark:border-gray-600 dark:bg-gray-700 dark:peer-focus:ring-cyan-800"
+                      ></div>
+                    </label>
+                  </div>
+                </div>
               </div>
 
               <div class="mt-4 rounded-lg bg-cyan-50 p-4 dark:bg-cyan-900/20">
@@ -1196,8 +1231,12 @@
                   <i class="fas fa-shield-alt mt-0.5 text-cyan-500"></i>
                   <div class="ml-3">
                     <p class="text-sm text-cyan-700 dark:text-cyan-300">
-                      <strong>采集内容：</strong
-                      >仅保存脱敏且截断后的请求快照、Token、费用、耗时和缓存指标，不保存完整原始提示词正文。
+                      <strong>采集内容：</strong>
+                      {{
+                        claudeConfig.requestDetailBodyPreviewEnabled
+                          ? '保存脱敏且截断后的请求体预览，以及 Token、费用、耗时和缓存指标，不保存完整原始提示词正文。'
+                          : '仅保存请求摘要字段、Token、费用、耗时和缓存指标，不保存请求体预览与完整原始提示词正文。'
+                      }}
                     </p>
                   </div>
                 </div>
@@ -2038,6 +2077,7 @@ const claudeConfig = ref({
   concurrentRequestQueueTimeoutMs: 10000,
   requestDetailCaptureEnabled: false,
   requestDetailRetentionHours: 6,
+  requestDetailBodyPreviewEnabled: false,
   updatedAt: null,
   updatedBy: null
 })
@@ -2120,6 +2160,59 @@ const handleRequestDetailRetentionChange = () => {
 
   claudeConfig.value.requestDetailRetentionHours = requestDetailRetentionTotalHours.value
   saveClaudeConfig()
+}
+
+const handleRequestDetailBodyPreviewToggle = async () => {
+  const nextValue = claudeConfig.value.requestDetailBodyPreviewEnabled === true
+
+  if (nextValue) {
+    await saveClaudeConfig()
+    return
+  }
+
+  let shouldPurgeSnapshots = false
+
+  try {
+    const statsResponse = await httpApis.getRequestDetailBodyPreviewStatsApi({
+      signal: abortController.value.signal
+    })
+
+    if (statsResponse?.success === false) {
+      claudeConfig.value.requestDetailBodyPreviewEnabled = true
+      showToast(statsResponse.message || '检查历史请求体预览失败', 'error')
+      return
+    }
+
+    const snapshotCount = Number(statsResponse?.data?.snapshotCount || 0)
+    if (snapshotCount > 0) {
+      const confirmed = await showConfirm(
+        '关闭请求体预览',
+        `检测到当前仍有 ${snapshotCount} 条请求明细保存了请求体预览。\n关闭后会移除这些历史请求体预览，且后续新请求也不再保存预览。\n\n是否继续？`,
+        '确认关闭',
+        '取消',
+        'danger'
+      )
+
+      if (!confirmed) {
+        claudeConfig.value.requestDetailBodyPreviewEnabled = true
+        return
+      }
+
+      shouldPurgeSnapshots = true
+    }
+
+    const response = await saveClaudeConfig({
+      purgeRequestDetailBodySnapshots: shouldPurgeSnapshots
+    })
+    if (response?.success === false) {
+      claudeConfig.value.requestDetailBodyPreviewEnabled = true
+    }
+  } catch (error) {
+    claudeConfig.value.requestDetailBodyPreviewEnabled = true
+    if (error.name === 'AbortError') return
+    showToast('更新请求体预览配置失败', 'error')
+    console.error(error)
+  }
 }
 
 // 服务倍率配置
@@ -2421,6 +2514,7 @@ const loadClaudeConfig = async () => {
         requestDetailCaptureEnabled: response.config?.requestDetailCaptureEnabled ?? false,
         requestDetailRetentionHours:
           response.config?.requestDetailRetentionHours ?? REQUEST_DETAIL_RETENTION_DEFAULT_HOURS,
+        requestDetailBodyPreviewEnabled: response.config?.requestDetailBodyPreviewEnabled ?? false,
         updatedAt: response.config?.updatedAt || null,
         updatedBy: response.config?.updatedBy || null
       }
@@ -2439,7 +2533,7 @@ const loadClaudeConfig = async () => {
 }
 
 // 保存 Claude 转发配置
-const saveClaudeConfig = async () => {
+const saveClaudeConfig = async (options = {}) => {
   if (!isMounted.value) return
   try {
     const payload = {
@@ -2456,7 +2550,12 @@ const saveClaudeConfig = async () => {
         claudeConfig.value.concurrentRequestQueueMaxSizeMultiplier,
       concurrentRequestQueueTimeoutMs: claudeConfig.value.concurrentRequestQueueTimeoutMs,
       requestDetailCaptureEnabled: claudeConfig.value.requestDetailCaptureEnabled,
-      requestDetailRetentionHours: claudeConfig.value.requestDetailRetentionHours
+      requestDetailRetentionHours: claudeConfig.value.requestDetailRetentionHours,
+      requestDetailBodyPreviewEnabled: claudeConfig.value.requestDetailBodyPreviewEnabled
+    }
+
+    if (options.purgeRequestDetailBodySnapshots === true) {
+      payload.purgeRequestDetailBodySnapshots = true
     }
 
     const response = await httpApis.updateClaudeRelayConfigApi(payload, {
@@ -2468,17 +2567,30 @@ const saveClaudeConfig = async () => {
         requestDetailRetentionHours:
           response.config?.requestDetailRetentionHours ??
           claudeConfig.value.requestDetailRetentionHours,
+        requestDetailBodyPreviewEnabled:
+          response.config?.requestDetailBodyPreviewEnabled ??
+          claudeConfig.value.requestDetailBodyPreviewEnabled,
         updatedAt: response.config?.updatedAt || new Date().toISOString(),
         updatedBy: response.config?.updatedBy || null
       }
       syncRequestDetailRetentionInput(claudeConfig.value.requestDetailRetentionHours)
-      showToast('Claude 转发配置已保存', 'success')
+      showToast(
+        response.warning || response.message || 'Claude 转发配置已保存',
+        response.warning ? 'warning' : 'success'
+      )
+      return response
     }
+
+    if (isMounted.value) {
+      showToast(response.message || '保存 Claude 转发配置失败', 'error')
+    }
+    return response
   } catch (error) {
     if (error.name === 'AbortError') return
     if (!isMounted.value) return
     showToast('保存 Claude 转发配置失败', 'error')
     console.error(error)
+    return { success: false, message: error.message || '保存 Claude 转发配置失败' }
   }
 }
 

--- a/web/admin-spa/src/views/SettingsView.vue
+++ b/web/admin-spa/src/views/SettingsView.vue
@@ -1200,7 +1200,7 @@
                         请求体预览
                       </label>
                       <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                        关闭后，仅影响后续新请求不再保存请求体预览；历史预览可通过下方按钮手动清理。
+                        关闭后，仅影响后续新请求不再保存请求体预览；历史预览可在「请求明细」页面手动清理。
                       </p>
                       <p
                         v-if="claudeConfig.requestDetailBodyPreviewEnabled"
@@ -1209,31 +1209,6 @@
                         <i class="fas fa-exclamation-triangle mr-1"></i>
                         开启请求体预览会增加 Redis 存储压力
                       </p>
-                      <div
-                        class="mt-3 flex flex-col gap-2 rounded-lg border border-gray-200 bg-white/70 p-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between"
-                      >
-                        <span>
-                          历史请求体预览可随时手动清理；清理仅影响已保存的历史预览，不影响当前开关对后续请求的行为。
-                        </span>
-                        <button
-                          class="inline-flex items-center justify-center rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 shadow-sm transition-colors hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300 dark:hover:bg-red-900/30"
-                          :disabled="
-                            requestDetailBodyPreviewSaving || requestDetailBodyPreviewPurging
-                          "
-                          type="button"
-                          @click="handleRequestDetailBodyPreviewPurge"
-                        >
-                          <i
-                            class="mr-1.5"
-                            :class="
-                              requestDetailBodyPreviewPurging
-                                ? 'fas fa-spinner fa-spin'
-                                : 'fas fa-trash-alt'
-                            "
-                          ></i>
-                          {{ requestDetailBodyPreviewPurging ? '清理中...' : '清理历史预览' }}
-                        </button>
-                      </div>
                     </div>
 
                     <button
@@ -1244,7 +1219,7 @@
                           ? 'bg-cyan-500'
                           : 'bg-gray-200 dark:bg-gray-700'
                       "
-                      :disabled="requestDetailBodyPreviewSaving || requestDetailBodyPreviewPurging"
+                      :disabled="requestDetailBodyPreviewSaving"
                       role="switch"
                       type="button"
                       @click="handleRequestDetailBodyPreviewToggle"
@@ -2134,7 +2109,6 @@ const requestDetailRetentionInput = reactive({
   hours: REQUEST_DETAIL_RETENTION_DEFAULT_HOURS
 })
 const requestDetailBodyPreviewSaving = ref(false)
-const requestDetailBodyPreviewPurging = ref(false)
 
 const normalizeRetentionPart = (value) => {
   const parsed = Number.parseInt(value, 10)
@@ -2208,7 +2182,7 @@ const handleRequestDetailRetentionChange = () => {
 }
 
 const handleRequestDetailBodyPreviewToggle = async () => {
-  if (requestDetailBodyPreviewSaving.value || requestDetailBodyPreviewPurging.value) return
+  if (requestDetailBodyPreviewSaving.value) return
 
   const nextValue = !claudeConfig.value.requestDetailBodyPreviewEnabled
 
@@ -2221,50 +2195,6 @@ const handleRequestDetailBodyPreviewToggle = async () => {
     console.error(error)
   } finally {
     requestDetailBodyPreviewSaving.value = false
-  }
-}
-
-const handleRequestDetailBodyPreviewPurge = async () => {
-  if (requestDetailBodyPreviewSaving.value || requestDetailBodyPreviewPurging.value) return
-
-  try {
-    const statsResponse = await httpApis.getRequestDetailBodyPreviewStatsApi({
-      signal: abortController.value.signal
-    })
-
-    if (statsResponse?.success === false) {
-      showToast(statsResponse.message || '检查历史请求体预览失败', 'error')
-      return
-    }
-
-    const snapshotCount = Number(statsResponse?.data?.snapshotCount || 0)
-    if (snapshotCount <= 0) {
-      showToast('暂无历史请求体预览需要清理', 'success')
-      return
-    }
-
-    const confirmed = window.confirm(
-      `检测到当前仍有 ${snapshotCount} 条请求明细保存了请求体预览。\n清理后将仅移除历史请求体预览，保留请求明细摘要字段。\n\n是否继续？`
-    )
-    if (!confirmed) return
-
-    requestDetailBodyPreviewPurging.value = true
-    const purgeResponse = await httpApis.purgeRequestDetailBodyPreviewApi({
-      signal: abortController.value.signal
-    })
-
-    if (purgeResponse?.success === false) {
-      showToast(purgeResponse.message || '清理历史请求体预览失败', 'error')
-      return
-    }
-
-    showToast(purgeResponse?.message || '清理完毕', 'success')
-  } catch (error) {
-    if (error?.name === 'AbortError') return
-    showToast('清理历史请求体预览失败', 'error')
-    console.error(error)
-  } finally {
-    requestDetailBodyPreviewPurging.value = false
   }
 }
 

--- a/web/admin-spa/src/views/SettingsView.vue
+++ b/web/admin-spa/src/views/SettingsView.vue
@@ -1210,10 +1210,11 @@
                         开启请求体预览会增加 Redis 存储压力
                       </p>
                       <div
-                        v-else
                         class="mt-3 flex flex-col gap-2 rounded-lg border border-gray-200 bg-white/70 p-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between"
                       >
-                        <span>历史请求体预览不会自动删除；如需释放 Redis 存储，请手动清理。</span>
+                        <span>
+                          历史请求体预览可随时手动清理；清理仅影响已保存的历史预览，不影响当前开关对后续请求的行为。
+                        </span>
                         <button
                           class="inline-flex items-center justify-center rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 shadow-sm transition-colors hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300 dark:hover:bg-red-900/30"
                           :disabled="
@@ -2248,10 +2249,16 @@ const handleRequestDetailBodyPreviewPurge = async () => {
     if (!confirmed) return
 
     requestDetailBodyPreviewPurging.value = true
-    await saveClaudeConfig({
-      requestDetailBodyPreviewEnabled: false,
-      purgeRequestDetailBodySnapshots: true
+    const purgeResponse = await httpApis.purgeRequestDetailBodyPreviewApi({
+      signal: abortController.value.signal
     })
+
+    if (purgeResponse?.success === false) {
+      showToast(purgeResponse.message || '清理历史请求体预览失败', 'error')
+      return
+    }
+
+    showToast(purgeResponse?.message || '清理完毕', 'success')
   } catch (error) {
     if (error?.name === 'AbortError') return
     showToast('清理历史请求体预览失败', 'error')

--- a/web/admin-spa/src/views/SettingsView.vue
+++ b/web/admin-spa/src/views/SettingsView.vue
@@ -1098,6 +1098,73 @@
               </div>
             </div>
 
+            <!-- 请求明细采集 -->
+            <div
+              class="mb-6 rounded-lg bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:bg-gray-800/80"
+            >
+              <div class="flex items-center justify-between">
+                <div class="flex items-center">
+                  <div
+                    class="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 text-white shadow-lg"
+                  >
+                    <i class="fas fa-table text-xl"></i>
+                  </div>
+                  <div class="ml-4">
+                    <h4 class="text-lg font-semibold text-gray-900 dark:text-white">
+                      请求明细采集
+                    </h4>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                      采集后台请求摘要，供“请求明细”标签页按时间、API Key、账户、模型和接口检索
+                    </p>
+                  </div>
+                </div>
+                <label class="relative inline-flex cursor-pointer items-center">
+                  <input
+                    v-model="claudeConfig.requestDetailCaptureEnabled"
+                    class="peer sr-only"
+                    type="checkbox"
+                    @change="saveClaudeConfig"
+                  />
+                  <div
+                    class="peer h-6 w-11 rounded-full bg-gray-200 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-cyan-500 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-cyan-300 dark:border-gray-600 dark:bg-gray-700 dark:peer-focus:ring-cyan-800"
+                  ></div>
+                </label>
+              </div>
+
+              <div v-if="claudeConfig.requestDetailCaptureEnabled" class="mt-6 space-y-4">
+                <div>
+                  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <i class="fas fa-calendar-day mr-2 text-gray-400"></i>
+                    请求明细保留天数
+                  </label>
+                  <input
+                    v-model.number="claudeConfig.requestDetailRetentionDays"
+                    class="mt-1 block w-full max-w-xs rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 dark:border-gray-500 dark:bg-gray-700 dark:text-white sm:text-sm"
+                    max="30"
+                    min="1"
+                    placeholder="7"
+                    type="number"
+                    @change="saveClaudeConfig"
+                  />
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    新请求明细会按天保留，支持 1-30 天；关闭采集不会删除已保留的数据，直到自然过期
+                  </p>
+                </div>
+              </div>
+
+              <div class="mt-4 rounded-lg bg-cyan-50 p-4 dark:bg-cyan-900/20">
+                <div class="flex">
+                  <i class="fas fa-shield-alt mt-0.5 text-cyan-500"></i>
+                  <div class="ml-3">
+                    <p class="text-sm text-cyan-700 dark:text-cyan-300">
+                      <strong>采集内容：</strong
+                      >仅保存脱敏且截断后的请求快照、Token、费用、耗时和缓存指标，不保存完整原始提示词正文。
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
             <!-- 配置更新信息 -->
             <div
               v-if="claudeConfig.updatedAt"
@@ -1930,6 +1997,8 @@ const claudeConfig = ref({
   concurrentRequestQueueMaxSize: 3,
   concurrentRequestQueueMaxSizeMultiplier: 0,
   concurrentRequestQueueTimeoutMs: 10000,
+  requestDetailCaptureEnabled: false,
+  requestDetailRetentionDays: 7,
   updatedAt: null,
   updatedBy: null
 })
@@ -2230,6 +2299,8 @@ const loadClaudeConfig = async () => {
         concurrentRequestQueueMaxSizeMultiplier:
           response.config?.concurrentRequestQueueMaxSizeMultiplier ?? 0,
         concurrentRequestQueueTimeoutMs: response.config?.concurrentRequestQueueTimeoutMs ?? 10000,
+        requestDetailCaptureEnabled: response.config?.requestDetailCaptureEnabled ?? false,
+        requestDetailRetentionDays: response.config?.requestDetailRetentionDays ?? 7,
         updatedAt: response.config?.updatedAt || null,
         updatedBy: response.config?.updatedBy || null
       }
@@ -2262,7 +2333,9 @@ const saveClaudeConfig = async () => {
       concurrentRequestQueueMaxSize: claudeConfig.value.concurrentRequestQueueMaxSize,
       concurrentRequestQueueMaxSizeMultiplier:
         claudeConfig.value.concurrentRequestQueueMaxSizeMultiplier,
-      concurrentRequestQueueTimeoutMs: claudeConfig.value.concurrentRequestQueueTimeoutMs
+      concurrentRequestQueueTimeoutMs: claudeConfig.value.concurrentRequestQueueTimeoutMs,
+      requestDetailCaptureEnabled: claudeConfig.value.requestDetailCaptureEnabled,
+      requestDetailRetentionDays: claudeConfig.value.requestDetailRetentionDays
     }
 
     const response = await httpApis.updateClaudeRelayConfigApi(payload, {

--- a/web/admin-spa/src/views/SettingsView.vue
+++ b/web/admin-spa/src/views/SettingsView.vue
@@ -1200,7 +1200,7 @@
                         请求体预览
                       </label>
                       <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                        关闭后，请求明细详情页不再展示请求体预览，Redis 也不会继续保存请求体快照。
+                        关闭后，仅影响后续新请求不再保存请求体预览；历史预览可通过下方按钮手动清理。
                       </p>
                       <p
                         v-if="claudeConfig.requestDetailBodyPreviewEnabled"
@@ -1209,19 +1209,55 @@
                         <i class="fas fa-exclamation-triangle mr-1"></i>
                         开启请求体预览会增加 Redis 存储压力
                       </p>
+                      <div
+                        v-else
+                        class="mt-3 flex flex-col gap-2 rounded-lg border border-gray-200 bg-white/70 p-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <span>历史请求体预览不会自动删除；如需释放 Redis 存储，请手动清理。</span>
+                        <button
+                          class="inline-flex items-center justify-center rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 shadow-sm transition-colors hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300 dark:hover:bg-red-900/30"
+                          :disabled="
+                            requestDetailBodyPreviewSaving || requestDetailBodyPreviewPurging
+                          "
+                          type="button"
+                          @click="handleRequestDetailBodyPreviewPurge"
+                        >
+                          <i
+                            class="mr-1.5"
+                            :class="
+                              requestDetailBodyPreviewPurging
+                                ? 'fas fa-spinner fa-spin'
+                                : 'fas fa-trash-alt'
+                            "
+                          ></i>
+                          {{ requestDetailBodyPreviewPurging ? '清理中...' : '清理历史预览' }}
+                        </button>
+                      </div>
                     </div>
 
-                    <label class="relative inline-flex cursor-pointer items-center">
-                      <input
-                        v-model="claudeConfig.requestDetailBodyPreviewEnabled"
-                        class="peer sr-only"
-                        type="checkbox"
-                        @change="handleRequestDetailBodyPreviewToggle"
-                      />
-                      <div
-                        class="peer h-6 w-11 rounded-full bg-gray-200 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-cyan-500 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-cyan-300 dark:border-gray-600 dark:bg-gray-700 dark:peer-focus:ring-cyan-800"
-                      ></div>
-                    </label>
+                    <button
+                      :aria-checked="claudeConfig.requestDetailBodyPreviewEnabled"
+                      class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-4 focus:ring-cyan-300 disabled:cursor-not-allowed disabled:opacity-60 dark:focus:ring-cyan-800"
+                      :class="
+                        claudeConfig.requestDetailBodyPreviewEnabled
+                          ? 'bg-cyan-500'
+                          : 'bg-gray-200 dark:bg-gray-700'
+                      "
+                      :disabled="requestDetailBodyPreviewSaving || requestDetailBodyPreviewPurging"
+                      role="switch"
+                      type="button"
+                      @click="handleRequestDetailBodyPreviewToggle"
+                    >
+                      <span class="sr-only">切换请求体预览</span>
+                      <span
+                        class="absolute left-[2px] top-[2px] h-5 w-5 rounded-full border bg-white transition-transform"
+                        :class="
+                          claudeConfig.requestDetailBodyPreviewEnabled
+                            ? 'translate-x-full border-white'
+                            : 'border-gray-300'
+                        "
+                      ></span>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -2016,13 +2052,19 @@ const showConfirm = (
     showConfirmModal.value = true
   })
 }
+
 const handleConfirmModal = () => {
   showConfirmModal.value = false
-  confirmResolve.value?.(true)
+  const resolve = confirmResolve.value
+  confirmResolve.value = null
+  resolve?.(true)
 }
+
 const handleCancelModal = () => {
   showConfirmModal.value = false
-  confirmResolve.value?.(false)
+  const resolve = confirmResolve.value
+  confirmResolve.value = null
+  resolve?.(false)
 }
 
 // 计算属性：隐藏管理后台按钮（反转 showAdminButton 的值）
@@ -2090,6 +2132,8 @@ const requestDetailRetentionInput = reactive({
   days: 0,
   hours: REQUEST_DETAIL_RETENTION_DEFAULT_HOURS
 })
+const requestDetailBodyPreviewSaving = ref(false)
+const requestDetailBodyPreviewPurging = ref(false)
 
 const normalizeRetentionPart = (value) => {
   const parsed = Number.parseInt(value, 10)
@@ -2163,14 +2207,24 @@ const handleRequestDetailRetentionChange = () => {
 }
 
 const handleRequestDetailBodyPreviewToggle = async () => {
-  const nextValue = claudeConfig.value.requestDetailBodyPreviewEnabled === true
+  if (requestDetailBodyPreviewSaving.value || requestDetailBodyPreviewPurging.value) return
 
-  if (nextValue) {
-    await saveClaudeConfig()
-    return
+  const nextValue = !claudeConfig.value.requestDetailBodyPreviewEnabled
+
+  requestDetailBodyPreviewSaving.value = true
+  try {
+    await saveClaudeConfig({ requestDetailBodyPreviewEnabled: nextValue })
+  } catch (error) {
+    if (error?.name === 'AbortError') return
+    showToast('更新请求体预览配置失败', 'error')
+    console.error(error)
+  } finally {
+    requestDetailBodyPreviewSaving.value = false
   }
+}
 
-  let shouldPurgeSnapshots = false
+const handleRequestDetailBodyPreviewPurge = async () => {
+  if (requestDetailBodyPreviewSaving.value || requestDetailBodyPreviewPurging.value) return
 
   try {
     const statsResponse = await httpApis.getRequestDetailBodyPreviewStatsApi({
@@ -2178,40 +2232,32 @@ const handleRequestDetailBodyPreviewToggle = async () => {
     })
 
     if (statsResponse?.success === false) {
-      claudeConfig.value.requestDetailBodyPreviewEnabled = true
       showToast(statsResponse.message || '检查历史请求体预览失败', 'error')
       return
     }
 
     const snapshotCount = Number(statsResponse?.data?.snapshotCount || 0)
-    if (snapshotCount > 0) {
-      const confirmed = await showConfirm(
-        '关闭请求体预览',
-        `检测到当前仍有 ${snapshotCount} 条请求明细保存了请求体预览。\n关闭后会移除这些历史请求体预览，且后续新请求也不再保存预览。\n\n是否继续？`,
-        '确认关闭',
-        '取消',
-        'danger'
-      )
-
-      if (!confirmed) {
-        claudeConfig.value.requestDetailBodyPreviewEnabled = true
-        return
-      }
-
-      shouldPurgeSnapshots = true
+    if (snapshotCount <= 0) {
+      showToast('暂无历史请求体预览需要清理', 'success')
+      return
     }
 
-    const response = await saveClaudeConfig({
-      purgeRequestDetailBodySnapshots: shouldPurgeSnapshots
+    const confirmed = window.confirm(
+      `检测到当前仍有 ${snapshotCount} 条请求明细保存了请求体预览。\n清理后将仅移除历史请求体预览，保留请求明细摘要字段。\n\n是否继续？`
+    )
+    if (!confirmed) return
+
+    requestDetailBodyPreviewPurging.value = true
+    await saveClaudeConfig({
+      requestDetailBodyPreviewEnabled: false,
+      purgeRequestDetailBodySnapshots: true
     })
-    if (response?.success === false) {
-      claudeConfig.value.requestDetailBodyPreviewEnabled = true
-    }
   } catch (error) {
-    claudeConfig.value.requestDetailBodyPreviewEnabled = true
-    if (error.name === 'AbortError') return
-    showToast('更新请求体预览配置失败', 'error')
+    if (error?.name === 'AbortError') return
+    showToast('清理历史请求体预览失败', 'error')
     console.error(error)
+  } finally {
+    requestDetailBodyPreviewPurging.value = false
   }
 }
 
@@ -2536,6 +2582,13 @@ const loadClaudeConfig = async () => {
 const saveClaudeConfig = async (options = {}) => {
   if (!isMounted.value) return
   try {
+    const requestDetailBodyPreviewEnabled = Object.prototype.hasOwnProperty.call(
+      options,
+      'requestDetailBodyPreviewEnabled'
+    )
+      ? options.requestDetailBodyPreviewEnabled === true
+      : claudeConfig.value.requestDetailBodyPreviewEnabled
+
     const payload = {
       claudeCodeOnlyEnabled: claudeConfig.value.claudeCodeOnlyEnabled,
       globalSessionBindingEnabled: claudeConfig.value.globalSessionBindingEnabled,
@@ -2551,7 +2604,7 @@ const saveClaudeConfig = async (options = {}) => {
       concurrentRequestQueueTimeoutMs: claudeConfig.value.concurrentRequestQueueTimeoutMs,
       requestDetailCaptureEnabled: claudeConfig.value.requestDetailCaptureEnabled,
       requestDetailRetentionHours: claudeConfig.value.requestDetailRetentionHours,
-      requestDetailBodyPreviewEnabled: claudeConfig.value.requestDetailBodyPreviewEnabled
+      requestDetailBodyPreviewEnabled
     }
 
     if (options.purgeRequestDetailBodySnapshots === true) {


### PR DESCRIPTION
## Summary
- add a new top-level admin `请求明细` tab with searchable request-level tracing
- capture structured request details behind admin settings with hour-based retention and optional request body previews
- expose request detail list/detail APIs, preview maintenance actions, and regression coverage for capture, sanitization, routing, and settings behavior

## What changed
### Backend
- add request-detail capture/storage via `requestDetailService`
- add `GET /admin/request-details` and `GET /admin/request-details/:requestId`
- add `GET /admin/request-details/body-preview-stats` and `POST /admin/request-details/body-preview-purge` for preview cleanup workflows
- extend existing usage-recording paths to attach request metadata from OpenAI, Claude, Gemini, Azure OpenAI, and related relay entrypoints
- add request body snapshot sanitization with masking/truncation rules for large/sensitive payloads, including targeted handling for `encrypted_content` and `tools`
- add normalized reasoning extraction across OpenAI, Anthropic, and Gemini payload shapes
- add config support for:
  - `requestDetailCaptureEnabled`
  - `requestDetailRetentionHours`
  - `requestDetailBodyPreviewEnabled`

### Admin UI
- add a new top-level `请求明细` page and route
- add request detail filters, summary cards, desktop table, mobile cards, CSV export, and detail modal
- align the page styling with the existing admin pages (`API Keys` / `账户管理`)
- show provider-aware cache metrics:
  - `/openai/` requests display cache create as `-`
  - `/openai/` cache hit rate uses `cached_tokens / prompt_tokens`
- show normalized `推理` values and source metadata in the detail view
- improve request body snapshot readability by rendering formatted preview content instead of the outer truncation wrapper
- make request body preview a separate settings toggle, and decouple historical preview cleanup into its own action with dedicated success messaging (`清理完毕`)
- improve the request detail modal on mobile and simplify the header by removing the extra `请求明细` eyebrow label

## Notes
- request detail capture is disabled by default and only starts collecting new records after being enabled in settings
- request detail retention now uses hours instead of whole days; the default is `6` hours
- request body preview is disabled by default; when disabled, new request details keep summary fields but do not store `requestBodySnapshot`
- historical request body previews can be purged independently without changing the current preview toggle state
- this does not backfill historical logs or rewrite old Redis records beyond explicit preview purge actions
- `/responses/compact` is not forced into token/cost tracing when reliable usage data is unavailable

## Tests
Passed locally:

```bash
npx jest --runInBand tests/requestDetailHelper.test.js tests/requestDetailService.test.js tests/requestDetailsRoute.test.js
cd web/admin-spa && npm run build
```