### PR TITLE
fix(oauth): migrate Claude Code OAuth to platform.claude.com + add missing scopes

### DIFF
--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -41,7 +41,7 @@ function isProAccount(info) {
 
 class ClaudeAccountService {
   constructor() {
-    this.claudeApiUrl = 'https://console.anthropic.com/v1/oauth/token'
+    this.claudeApiUrl = 'https://platform.claude.com/v1/oauth/token'
     this.claudeOauthClientId = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
     let maxWarnings = parseInt(process.env.CLAUDE_5H_WARNING_MAX_NOTIFICATIONS || '', 10)
 

--- a/src/utils/oauthHelper.js
+++ b/src/utils/oauthHelper.js
@@ -11,7 +11,7 @@ const logger = require('./logger')
 // OAuth 配置常量 - 从claude-code-login.js提取
 const OAUTH_CONFIG = {
   AUTHORIZE_URL: 'https://claude.ai/oauth/authorize',
-  TOKEN_URL: 'https://console.anthropic.com/v1/oauth/token',
+  TOKEN_URL: 'https://platform.claude.com/v1/oauth/token',
   CLIENT_ID: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   REDIRECT_URI: 'https://platform.claude.com/oauth/code/callback',
   SCOPES: 'org:create_api_key user:profile user:inference user:sessions:claude_code',

--- a/src/utils/oauthHelper.js
+++ b/src/utils/oauthHelper.js
@@ -14,7 +14,7 @@ const OAUTH_CONFIG = {
   TOKEN_URL: 'https://platform.claude.com/v1/oauth/token',
   CLIENT_ID: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   REDIRECT_URI: 'https://platform.claude.com/oauth/code/callback',
-  SCOPES: 'org:create_api_key user:profile user:inference user:sessions:claude_code',
+  SCOPES: 'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload',
   SCOPES_SETUP: 'user:inference' // Setup Token 只需要推理权限
 }
 

--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -4925,6 +4925,9 @@ const onAuthMethodChange = () => {
 
 // 构建 Claude 账户数据（辅助函数）
 const buildClaudeAccountData = (tokenInfo, accountName, clientId) => {
+  if (!tokenInfo) {
+    throw new Error('OAuth 凭证缺失，请先完成 OAuth 授权流程')
+  }
   const proxyPayload = buildProxyPayload(form.value.proxy)
   const claudeOauthPayload = tokenInfo.claudeAiOauth || tokenInfo
 
@@ -5047,6 +5050,9 @@ const handleOAuthSuccess = async (tokenInfoOrList) => {
 
     if (currentPlatform === 'claude') {
       // Claude使用claudeAiOauth字段
+      if (!tokenInfo) {
+        throw new Error('OAuth 凭证缺失，请先完成 OAuth 授权流程')
+      }
       const claudeOauthPayload = tokenInfo.claudeAiOauth || tokenInfo
       data.claudeAiOauth = claudeOauthPayload
       if (claudeOauthPayload) {


### PR DESCRIPTION
## Summary

Fix three related issues that together break Claude Code OAuth account creation and refresh after Anthropic's recent platform migration.

- **Token endpoint**: Anthropic moved `/v1/oauth/token` from `console.anthropic.com` to `platform.claude.com`. The old endpoint now returns `403` for `grant_type=refresh_token`, so every Claude OAuth account's token refresh fails ~8 hours after creation and the relay cannot recover automatically.
- **Missing scopes**: Current Claude Code clients request 6 OAuth scopes. This service only requested 4, missing `user:mcp_servers` and `user:file_upload`. The authorization server then returns a degraded/incomplete response, leaving the admin UI with `null` tokenInfo and breaking account creation.
- **Frontend crash**: When `tokenInfo` is null for any reason, `AccountForm.vue` directly reads `tokenInfo.claudeAiOauth` and the form crashes with `Cannot read properties of null (reading 'claudeAiOauth')` and an unhelpful stack instead of telling the user what to do.

## Changes

| Commit | File | Change |
|---|---|---|
| c7483588 | `src/utils/oauthHelper.js`, `src/services/account/claudeAccountService.js` | Point `TOKEN_URL` and `claudeApiUrl` at `https://platform.claude.com/v1/oauth/token` |
| 753ec501 | `src/utils/oauthHelper.js` | Add `user:mcp_servers` and `user:file_upload` to `SCOPES` |
| ab33f9e3 | `web/admin-spa/src/components/accounts/AccountForm.vue` | Null guard in `buildClaudeAccountData()` and inline single-tokenInfo branch, surfacing an actionable error |

## Verification

Deployed all three fixes to a production relay instance and confirmed:
- `grep TOKEN_URL` inside the rebuilt container shows `platform.claude.com` ✓
- Token refresh against an existing account succeeds (previously 403) ✓
- New accounts created via the admin UI OAuth flow land with all 5 scopes: `user:file_upload user:inference user:mcp_servers user:profile user:sessions:claude_code` ✓
- Manually triggering the null branch in `AccountForm.vue` now shows the localized error message instead of crashing ✓

## Test plan

- [ ] `npm install` (no new dependencies)
- [ ] Admin UI: add a new Claude OAuth account end-to-end, confirm success toast
- [ ] Admin UI: trigger `Admin refresh` on an existing account and verify `lastRefreshAt` updates
- [ ] Verify via logs that requests against `https://platform.claude.com/v1/oauth/token` return `200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)