### PR TITLE
 feat(openai): add configurable responses payload toggles and admin controls

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1316,7 +1316,10 @@ const authenticateApiKey = async (req, res, next) => {
       dailyCostLimit: validation.keyData.dailyCostLimit,
       dailyCost: validation.keyData.dailyCost,
       totalCostLimit: validation.keyData.totalCostLimit,
-      totalCost: validation.keyData.totalCost
+      totalCost: validation.keyData.totalCost,
+      enableOpenAIResponsesCodexAdaptation: validation.keyData.enableOpenAIResponsesCodexAdaptation,
+      enableOpenAIResponsesPayloadRules: validation.keyData.enableOpenAIResponsesPayloadRules,
+      openaiResponsesPayloadRules: validation.keyData.openaiResponsesPayloadRules
     }
 
     const authDuration = Date.now() - startTime

--- a/src/models/redis.js
+++ b/src/models/redis.js
@@ -773,11 +773,25 @@ class RedisClient {
     const parsed = { ...data }
 
     // 布尔字段
-    const boolFields = ['isActive', 'enableModelRestriction', 'isDeleted']
+    const boolFields = [
+      'isActive',
+      'enableModelRestriction',
+      'enableClientRestriction',
+      'enableOpenAIResponsesCodexAdaptation',
+      'enableOpenAIResponsesPayloadRules',
+      'isDeleted'
+    ]
     for (const field of boolFields) {
       if (parsed[field] !== undefined) {
         parsed[field] = parsed[field] === 'true'
       }
+    }
+
+    if (parsed.enableOpenAIResponsesCodexAdaptation === undefined) {
+      parsed.enableOpenAIResponsesCodexAdaptation = true
+    }
+    if (parsed.enableOpenAIResponsesPayloadRules === undefined) {
+      parsed.enableOpenAIResponsesPayloadRules = false
     }
 
     // 数字字段
@@ -799,7 +813,12 @@ class RedisClient {
     }
 
     // 数组字段（JSON 解析）
-    const arrayFields = ['tags', 'restrictedModels', 'allowedClients']
+    const arrayFields = [
+      'tags',
+      'restrictedModels',
+      'allowedClients',
+      'openaiResponsesPayloadRules'
+    ]
     for (const field of arrayFields) {
       if (parsed[field]) {
         try {
@@ -808,6 +827,10 @@ class RedisClient {
           parsed[field] = []
         }
       }
+    }
+
+    if (!Array.isArray(parsed.openaiResponsesPayloadRules)) {
+      parsed.openaiResponsesPayloadRules = []
     }
 
     // 对象字段（JSON 解析）

--- a/src/routes/admin/apiKeys.js
+++ b/src/routes/admin/apiKeys.js
@@ -5,6 +5,7 @@ const { authenticateAdmin } = require('../../middleware/auth')
 const logger = require('../../utils/logger')
 const CostCalculator = require('../../utils/costCalculator')
 const config = require('../../../config/config')
+const requestBodyRuleService = require('../../services/requestBodyRuleService')
 
 const router = express.Router()
 
@@ -1493,7 +1494,10 @@ router.post('/api-keys', authenticateAdmin, async (req, res) => {
       icon, // 新增：图标
       serviceRates, // API Key 级别服务倍率
       weeklyResetDay, // 周费用重置日 (1-7)
-      weeklyResetHour // 周费用重置时 (0-23)
+      weeklyResetHour, // 周费用重置时 (0-23)
+      enableOpenAIResponsesCodexAdaptation,
+      enableOpenAIResponsesPayloadRules,
+      openaiResponsesPayloadRules
     } = req.body
 
     // 输入验证
@@ -1626,6 +1630,30 @@ router.post('/api-keys', authenticateAdmin, async (req, res) => {
       return res.status(400).json({ error: serviceRatesError })
     }
 
+    if (
+      enableOpenAIResponsesCodexAdaptation !== undefined &&
+      typeof enableOpenAIResponsesCodexAdaptation !== 'boolean'
+    ) {
+      return res
+        .status(400)
+        .json({ error: 'enableOpenAIResponsesCodexAdaptation must be a boolean' })
+    }
+
+    if (
+      enableOpenAIResponsesPayloadRules !== undefined &&
+      typeof enableOpenAIResponsesPayloadRules !== 'boolean'
+    ) {
+      return res
+        .status(400)
+        .json({ error: 'enableOpenAIResponsesPayloadRules must be a boolean' })
+    }
+
+    const payloadRulesValidation =
+      requestBodyRuleService.validateAndNormalizeRules(openaiResponsesPayloadRules)
+    if (!payloadRulesValidation.valid) {
+      return res.status(400).json({ error: payloadRulesValidation.error })
+    }
+
     // 验证周费用重置配置
     if (weeklyResetDay !== undefined && weeklyResetDay !== null && weeklyResetDay !== '') {
       const day = Number(weeklyResetDay)
@@ -1678,7 +1706,16 @@ router.post('/api-keys', authenticateAdmin, async (req, res) => {
       weeklyResetHour:
         weeklyResetHour !== undefined && weeklyResetHour !== null && weeklyResetHour !== ''
           ? Number(weeklyResetHour)
-          : 0
+          : 0,
+      enableOpenAIResponsesCodexAdaptation:
+        enableOpenAIResponsesCodexAdaptation !== undefined
+          ? enableOpenAIResponsesCodexAdaptation
+          : true,
+      enableOpenAIResponsesPayloadRules:
+        enableOpenAIResponsesPayloadRules !== undefined
+          ? enableOpenAIResponsesPayloadRules
+          : false,
+      openaiResponsesPayloadRules: payloadRulesValidation.rules
     })
 
     logger.success(`🔑 Admin created new API key: ${name}`)
@@ -2087,7 +2124,10 @@ router.put('/api-keys/:keyId', authenticateAdmin, async (req, res) => {
       ownerId, // 新增：所有者ID字段
       serviceRates, // API Key 级别服务倍率
       weeklyResetDay, // 周费用重置日 (1-7)
-      weeklyResetHour // 周费用重置时 (0-23)
+      weeklyResetHour, // 周费用重置时 (0-23)
+      enableOpenAIResponsesCodexAdaptation,
+      enableOpenAIResponsesPayloadRules,
+      openaiResponsesPayloadRules
     } = req.body
 
     // 只允许更新指定字段
@@ -2280,6 +2320,33 @@ router.put('/api-keys/:keyId', authenticateAdmin, async (req, res) => {
         return res.status(400).json({ error: singleServiceRatesError })
       }
       updates.serviceRates = serviceRates
+    }
+
+    if (enableOpenAIResponsesCodexAdaptation !== undefined) {
+      if (typeof enableOpenAIResponsesCodexAdaptation !== 'boolean') {
+        return res
+          .status(400)
+          .json({ error: 'enableOpenAIResponsesCodexAdaptation must be a boolean' })
+      }
+      updates.enableOpenAIResponsesCodexAdaptation = enableOpenAIResponsesCodexAdaptation
+    }
+
+    if (enableOpenAIResponsesPayloadRules !== undefined) {
+      if (typeof enableOpenAIResponsesPayloadRules !== 'boolean') {
+        return res
+          .status(400)
+          .json({ error: 'enableOpenAIResponsesPayloadRules must be a boolean' })
+      }
+      updates.enableOpenAIResponsesPayloadRules = enableOpenAIResponsesPayloadRules
+    }
+
+    if (openaiResponsesPayloadRules !== undefined) {
+      const payloadRulesValidation =
+        requestBodyRuleService.validateAndNormalizeRules(openaiResponsesPayloadRules)
+      if (!payloadRulesValidation.valid) {
+        return res.status(400).json({ error: payloadRulesValidation.error })
+      }
+      updates.openaiResponsesPayloadRules = payloadRulesValidation.rules
     }
 
     // 处理周费用重置配置

--- a/src/routes/admin/apiKeys.js
+++ b/src/routes/admin/apiKeys.js
@@ -1643,13 +1643,12 @@ router.post('/api-keys', authenticateAdmin, async (req, res) => {
       enableOpenAIResponsesPayloadRules !== undefined &&
       typeof enableOpenAIResponsesPayloadRules !== 'boolean'
     ) {
-      return res
-        .status(400)
-        .json({ error: 'enableOpenAIResponsesPayloadRules must be a boolean' })
+      return res.status(400).json({ error: 'enableOpenAIResponsesPayloadRules must be a boolean' })
     }
 
-    const payloadRulesValidation =
-      requestBodyRuleService.validateAndNormalizeRules(openaiResponsesPayloadRules)
+    const payloadRulesValidation = requestBodyRuleService.validateAndNormalizeRules(
+      openaiResponsesPayloadRules
+    )
     if (!payloadRulesValidation.valid) {
       return res.status(400).json({ error: payloadRulesValidation.error })
     }
@@ -1712,9 +1711,7 @@ router.post('/api-keys', authenticateAdmin, async (req, res) => {
           ? enableOpenAIResponsesCodexAdaptation
           : true,
       enableOpenAIResponsesPayloadRules:
-        enableOpenAIResponsesPayloadRules !== undefined
-          ? enableOpenAIResponsesPayloadRules
-          : false,
+        enableOpenAIResponsesPayloadRules !== undefined ? enableOpenAIResponsesPayloadRules : false,
       openaiResponsesPayloadRules: payloadRulesValidation.rules
     })
 
@@ -2341,8 +2338,9 @@ router.put('/api-keys/:keyId', authenticateAdmin, async (req, res) => {
     }
 
     if (openaiResponsesPayloadRules !== undefined) {
-      const payloadRulesValidation =
-        requestBodyRuleService.validateAndNormalizeRules(openaiResponsesPayloadRules)
+      const payloadRulesValidation = requestBodyRuleService.validateAndNormalizeRules(
+        openaiResponsesPayloadRules
+      )
       if (!payloadRulesValidation.valid) {
         return res.status(400).json({ error: payloadRulesValidation.error })
       }

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -313,9 +313,6 @@ const handleResponses = async (req, res) => {
     const codexCliPattern = /^(codex_vscode|codex_cli_rs|codex_exec)\/[\d.]+/i
     const isCodexCLI = codexCliPattern.test(userAgent)
 
-    // 提取 service_tier 用于后续费用计算（在字段被移除前保存）
-    req._serviceTier = req.body?.service_tier || null
-
     const standardResponsesRoute = isStandardResponsesRoute(req)
     const compactRoute = isCompactResponsesRoute(req)
     const shouldUseToggleControlledFlow = standardResponsesRoute && !compactRoute
@@ -352,6 +349,9 @@ const handleResponses = async (req, res) => {
         logger.info('✅ Codex CLI request detected, forwarding as-is')
       }
     }
+
+    // 从最终请求体中提取 service_tier，用于后续费用计算
+    req._serviceTier = req.body?.service_tier || null
 
     // 从最终请求体中提取模型、会话 ID 和流式标志
     // NOTE: For some clients, prompt_cache_key is the only stable per-session key.

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -95,18 +95,27 @@ function isStandardResponsesRoute(req) {
   return req.path === '/responses' || req.path === '/v1/responses'
 }
 
-function normalizeGpt5ModelForCodex(body = {}) {
-  const requestedModel = body?.model || null
+function getCodexCompatibleModel(requestedModel = null) {
   const isCodexModel =
     typeof requestedModel === 'string' && requestedModel.toLowerCase().includes('codex')
 
   if (requestedModel && requestedModel.startsWith('gpt-5-') && !isCodexModel) {
-    logger.info(`📝 Model ${requestedModel} detected, normalizing to gpt-5 for Codex API`)
-    body.model = 'gpt-5'
     return 'gpt-5'
   }
 
   return requestedModel
+}
+
+function normalizeGpt5ModelForCodex(body = {}) {
+  const requestedModel = body?.model || null
+  const compatibleModel = getCodexCompatibleModel(requestedModel)
+
+  if (compatibleModel !== requestedModel) {
+    logger.info(`📝 Model ${requestedModel} detected, normalizing to gpt-5 for Codex API`)
+    body.model = compatibleModel
+  }
+
+  return compatibleModel
 }
 
 function applyCodexCliAdaptation(body = {}) {
@@ -366,13 +375,20 @@ const handleResponses = async (req, res) => {
     sessionHash = sessionId ? crypto.createHash('sha256').update(sessionId).digest('hex') : null
 
     const requestedModel = req.body?.model || null
+    const schedulerModel = getCodexCompatibleModel(requestedModel)
     const isStream = req.body?.stream !== false // 默认为流式（兼容现有行为）
+
+    if (schedulerModel !== requestedModel) {
+      logger.info(
+        `🧭 Using Codex-compatible model ${schedulerModel} for account selection (requested: ${requestedModel})`
+      )
+    }
 
     // 使用调度器选择账户
     ;({ accessToken, accountId, accountType, proxy, account } = await getOpenAIAuthToken(
       apiKeyData,
       sessionId,
-      requestedModel
+      schedulerModel
     ))
 
     // 如果是 OpenAI-Responses 账户，使用专门的中继服务处理
@@ -380,6 +396,16 @@ const handleResponses = async (req, res) => {
       logger.info(`🔀 Using OpenAI-Responses relay service for account: ${account.name}`)
       return await openaiResponsesRelayService.handleRequest(req, res, account, apiKeyData)
     }
+
+    if (schedulerModel !== requestedModel) {
+      logger.info(
+        `📝 Standard Responses request normalized model ${requestedModel} -> ${schedulerModel} for OpenAI Codex backend`
+      )
+      req.body.model = schedulerModel
+    }
+
+    const upstreamRequestedModel = req.body?.model || requestedModel
+
     // 基于白名单构造上游所需的请求头，确保键为小写且值受控
     const incoming = req.headers || {}
 
@@ -657,13 +683,13 @@ const handleResponses = async (req, res) => {
     if (!isStream) {
       // 非流式响应处理
       try {
-        logger.info(`📄 Processing OpenAI non-stream response for model: ${requestedModel}`)
+        logger.info(`📄 Processing OpenAI non-stream response for model: ${upstreamRequestedModel}`)
 
         // 直接获取完整响应
         const responseData = upstream.data
 
         // 从响应中获取实际的 model 和 usage
-        actualModel = responseData.model || requestedModel || 'gpt-4'
+        actualModel = responseData.model || upstreamRequestedModel || 'gpt-4'
         usageData = responseData.usage
 
         logger.debug(`📊 Non-stream response - Model: ${actualModel}, Usage:`, usageData)
@@ -797,7 +823,7 @@ const handleResponses = async (req, res) => {
           const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
 
           // 使用响应中的真实 model，如果没有则使用请求中的 model，最后回退到默认值
-          const modelToRecord = actualModel || requestedModel || 'gpt-4'
+          const modelToRecord = actualModel || upstreamRequestedModel || 'gpt-4'
 
           const streamCosts = await apiKeyService.recordUsage(
             apiKeyData.id,
@@ -817,7 +843,7 @@ const handleResponses = async (req, res) => {
           )
 
           logger.info(
-            `📊 Recorded OpenAI usage - Input: ${totalInputTokens}(actual:${actualInputTokens}+cached:${cacheReadTokens}), Output: ${outputTokens}, Total: ${usageData.total_tokens || totalInputTokens + outputTokens}, Model: ${modelToRecord} (actual: ${actualModel}, requested: ${requestedModel})`
+            `📊 Recorded OpenAI usage - Input: ${totalInputTokens}(actual:${actualInputTokens}+cached:${cacheReadTokens}), Output: ${outputTokens}, Total: ${usageData.total_tokens || totalInputTokens + outputTokens}, Model: ${modelToRecord} (actual: ${actualModel}, requested: ${upstreamRequestedModel})`
           )
           usageReported = true
 

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -19,6 +19,7 @@ const {
   createRequestDetailMeta,
   extractOpenAICacheReadTokens
 } = require('../utils/requestDetailHelper')
+const requestBodyRuleService = require('../services/requestBodyRuleService')
 
 // Codex CLI 系统提示词（非 Codex CLI 客户端请求时注入，统一端点也使用）
 const CODEX_CLI_INSTRUCTIONS =
@@ -76,6 +77,57 @@ function extractCodexUsageHeaders(headers) {
 
   const hasData = Object.values(snapshot).some((value) => value !== null)
   return hasData ? snapshot : null
+}
+
+function isCompactResponsesRoute(req) {
+  return (
+    req.path === '/responses/compact' ||
+    req.path === '/v1/responses/compact' ||
+    (req.originalUrl && req.originalUrl.includes('/responses/compact'))
+  )
+}
+
+function isStandardResponsesRoute(req) {
+  if (req._fromUnifiedEndpoint) {
+    return false
+  }
+
+  return req.path === '/responses' || req.path === '/v1/responses'
+}
+
+function normalizeGpt5ModelForCodex(body = {}) {
+  const requestedModel = body?.model || null
+  const isCodexModel =
+    typeof requestedModel === 'string' && requestedModel.toLowerCase().includes('codex')
+
+  if (requestedModel && requestedModel.startsWith('gpt-5-') && !isCodexModel) {
+    logger.info(`📝 Model ${requestedModel} detected, normalizing to gpt-5 for Codex API`)
+    body.model = 'gpt-5'
+    return 'gpt-5'
+  }
+
+  return requestedModel
+}
+
+function applyCodexCliAdaptation(body = {}) {
+  const fieldsToRemove = [
+    'temperature',
+    'top_p',
+    'max_output_tokens',
+    'user',
+    'text_formatting',
+    'truncation',
+    'text',
+    'service_tier',
+    'prompt_cache_retention',
+    'safety_identifier'
+  ]
+
+  fieldsToRemove.forEach((field) => {
+    delete body[field]
+  })
+
+  body.instructions = CODEX_CLI_INSTRUCTIONS
 }
 
 async function applyRateLimitTracking(
@@ -255,7 +307,53 @@ const handleResponses = async (req, res) => {
       })
     }
 
-    // 从请求头或请求体中提取会话 ID
+    // 判断是否为 Codex CLI 的请求（基于 User-Agent）
+    // 支持: codex_vscode, codex_cli_rs, codex_exec (非交互式/脚本模式)
+    const userAgent = req.headers['user-agent'] || ''
+    const codexCliPattern = /^(codex_vscode|codex_cli_rs|codex_exec)\/[\d.]+/i
+    const isCodexCLI = codexCliPattern.test(userAgent)
+
+    // 提取 service_tier 用于后续费用计算（在字段被移除前保存）
+    req._serviceTier = req.body?.service_tier || null
+
+    const standardResponsesRoute = isStandardResponsesRoute(req)
+    const compactRoute = isCompactResponsesRoute(req)
+    const shouldUseToggleControlledFlow = standardResponsesRoute && !compactRoute
+
+    if (shouldUseToggleControlledFlow) {
+      const shouldApplyCodexAdaptation =
+        apiKeyData.enableOpenAIResponsesCodexAdaptation === true && !isCodexCLI
+      const shouldApplyPayloadRules = apiKeyData.enableOpenAIResponsesPayloadRules === true
+
+      if (shouldApplyCodexAdaptation) {
+        normalizeGpt5ModelForCodex(req.body)
+        applyCodexCliAdaptation(req.body)
+        logger.info('📝 Standard Responses request applied Codex CLI adaptation')
+      } else if (isCodexCLI) {
+        logger.info('✅ Codex CLI request detected, forwarding current payload')
+      } else {
+        logger.info('📦 Standard Responses request is passing through without Codex adaptation')
+      }
+
+      if (shouldApplyPayloadRules) {
+        req.body = requestBodyRuleService.applyRules(
+          req.body,
+          apiKeyData.openaiResponsesPayloadRules
+        )
+        logger.info('🧩 Standard Responses request applied API key payload rules')
+      }
+    } else {
+      normalizeGpt5ModelForCodex(req.body)
+
+      if (!isCodexCLI && !req._fromUnifiedEndpoint) {
+        applyCodexCliAdaptation(req.body)
+        logger.info('📝 Non-Codex CLI request detected, applying Codex CLI adaptation')
+      } else {
+        logger.info('✅ Codex CLI request detected, forwarding as-is')
+      }
+    }
+
+    // 从最终请求体中提取模型、会话 ID 和流式标志
     // NOTE: For some clients, prompt_cache_key is the only stable per-session key.
     const sessionId =
       req.headers['session_id'] ||
@@ -267,55 +365,8 @@ const handleResponses = async (req, res) => {
 
     sessionHash = sessionId ? crypto.createHash('sha256').update(sessionId).digest('hex') : null
 
-    // 从请求体中提取模型和流式标志
-    let requestedModel = req.body?.model || null
-    const isCodexModel =
-      typeof requestedModel === 'string' && requestedModel.toLowerCase().includes('codex')
-
-    // 如果模型是 gpt-5 开头且后面还有内容（如 gpt-5-2025-08-07），并且不是 Codex 系列，则覆盖为 gpt-5
-    if (requestedModel && requestedModel.startsWith('gpt-5-') && !isCodexModel) {
-      logger.info(`📝 Model ${requestedModel} detected, normalizing to gpt-5 for Codex API`)
-      requestedModel = 'gpt-5'
-      req.body.model = 'gpt-5' // 同时更新请求体中的模型
-    }
-
+    const requestedModel = req.body?.model || null
     const isStream = req.body?.stream !== false // 默认为流式（兼容现有行为）
-
-    // 判断是否为 Codex CLI 的请求（基于 User-Agent）
-    // 支持: codex_vscode, codex_cli_rs, codex_exec (非交互式/脚本模式)
-    const userAgent = req.headers['user-agent'] || ''
-    const codexCliPattern = /^(codex_vscode|codex_cli_rs|codex_exec)\/[\d.]+/i
-    const isCodexCLI = codexCliPattern.test(userAgent)
-
-    // 提取 service_tier 用于后续费用计算（在字段被移除前保存）
-    req._serviceTier = req.body?.service_tier || null
-
-    // 如果不是 Codex CLI 请求且不是来自 unified 端点（已完成格式转换），则进行适配
-    if (!isCodexCLI && !req._fromUnifiedEndpoint) {
-      // 移除不需要的请求体字段
-      const fieldsToRemove = [
-        'temperature',
-        'top_p',
-        'max_output_tokens',
-        'user',
-        'text_formatting',
-        'truncation',
-        'text',
-        'service_tier',
-        'prompt_cache_retention',
-        'safety_identifier'
-      ]
-      fieldsToRemove.forEach((field) => {
-        delete req.body[field]
-      })
-
-      // 设置固定的 Codex CLI instructions
-      req.body.instructions = CODEX_CLI_INSTRUCTIONS
-
-      logger.info('📝 Non-Codex CLI request detected, applying Codex CLI adaptation')
-    } else {
-      logger.info('✅ Codex CLI request detected, forwarding as-is')
-    }
 
     // 使用调度器选择账户
     ;({ accessToken, accountId, accountType, proxy, account } = await getOpenAIAuthToken(
@@ -341,19 +392,13 @@ const handleResponses = async (req, res) => {
       }
     }
 
-    // 判断是否访问 compact 端点
-    const isCompactRoute =
-      req.path === '/responses/compact' ||
-      req.path === '/v1/responses/compact' ||
-      (req.originalUrl && req.originalUrl.includes('/responses/compact'))
-
     // 覆盖或新增必要头部
     headers['authorization'] = `Bearer ${accessToken}`
     headers['chatgpt-account-id'] = account.accountId || account.chatgptUserId || accountId
     headers['host'] = 'chatgpt.com'
     headers['accept'] = isStream ? 'text/event-stream' : 'application/json'
     headers['content-type'] = 'application/json'
-    if (!isCompactRoute) {
+    if (!compactRoute) {
       req.body['store'] = false
     } else if (req.body && Object.prototype.hasOwnProperty.call(req.body, 'store')) {
       delete req.body['store']
@@ -379,7 +424,7 @@ const handleResponses = async (req, res) => {
       logger.debug('🌐 No proxy configured for OpenAI request')
     }
 
-    const codexEndpoint = isCompactRoute
+    const codexEndpoint = compactRoute
       ? 'https://chatgpt.com/backend-api/codex/responses/compact'
       : 'https://chatgpt.com/backend-api/codex/responses'
 

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -7,6 +7,7 @@ const serviceRatesService = require('./serviceRatesService')
 const requestDetailService = require('./requestDetailService')
 const { isClaudeFamilyModel } = require('../utils/modelHelper')
 const { finalizeRequestDetailMeta } = require('../utils/requestDetailHelper')
+const requestBodyRuleService = require('./requestBodyRuleService')
 
 const ACCOUNT_TYPE_CONFIG = {
   claude: { prefix: 'claude:account:' },
@@ -126,6 +127,43 @@ function sanitizeAccountIdForType(accountId, accountType) {
   return accountId
 }
 
+function parseBooleanWithDefault(value, defaultValue = false) {
+  if (value === undefined || value === null || value === '') {
+    return defaultValue
+  }
+
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    return value === 'true'
+  }
+
+  return Boolean(value)
+}
+
+function parseOpenAIResponsesPayloadRules(rawRules) {
+  if (rawRules === undefined || rawRules === null || rawRules === '') {
+    return []
+  }
+
+  let parsedRules = rawRules
+  if (typeof rawRules === 'string') {
+    try {
+      parsedRules = JSON.parse(rawRules)
+    } catch (error) {
+      return []
+    }
+  }
+
+  if (!Array.isArray(parsedRules)) {
+    return []
+  }
+
+  return parsedRules.map((rule) => requestBodyRuleService.normalizeRule(rule)).filter(Boolean)
+}
+
 class ApiKeyService {
   constructor() {
     this.prefix = config.security.apiKeyPrefix
@@ -165,8 +203,18 @@ class ApiKeyService {
       icon = '', // 新增：图标（base64编码）
       serviceRates = {}, // API Key 级别服务倍率覆盖
       weeklyResetDay = 1, // 周费用重置日 (1=周一 ... 7=周日)
-      weeklyResetHour = 0 // 周费用重置时 (0-23)
+      weeklyResetHour = 0, // 周费用重置时 (0-23)
+      enableOpenAIResponsesCodexAdaptation = true,
+      enableOpenAIResponsesPayloadRules = false,
+      openaiResponsesPayloadRules = []
     } = options
+
+    const payloadRulesValidation = requestBodyRuleService.validateAndNormalizeRules(
+      openaiResponsesPayloadRules
+    )
+    if (!payloadRulesValidation.valid) {
+      throw new Error(payloadRulesValidation.error)
+    }
 
     // 生成简单的API Key (64字符十六进制)
     const apiKey = `${this.prefix}${this._generateSecretKey()}`
@@ -217,7 +265,10 @@ class ApiKeyService {
       icon: icon || '', // 新增：图标（base64编码）
       serviceRates: JSON.stringify(serviceRates || {}), // API Key 级别服务倍率
       weeklyResetDay: String(weeklyResetDay || 1), // 周费用重置日 (1-7)
-      weeklyResetHour: String(weeklyResetHour || 0) // 周费用重置时 (0-23)
+      weeklyResetHour: String(weeklyResetHour || 0), // 周费用重置时 (0-23)
+      enableOpenAIResponsesCodexAdaptation: String(enableOpenAIResponsesCodexAdaptation !== false),
+      enableOpenAIResponsesPayloadRules: String(enableOpenAIResponsesPayloadRules === true),
+      openaiResponsesPayloadRules: JSON.stringify(payloadRulesValidation.rules)
     }
 
     // 保存API Key数据并建立哈希映射
@@ -284,7 +335,18 @@ class ApiKeyService {
       createdAt: keyData.createdAt,
       expiresAt: keyData.expiresAt,
       createdBy: keyData.createdBy,
-      serviceRates: JSON.parse(keyData.serviceRates || '{}') // API Key 级别服务倍率
+      serviceRates: JSON.parse(keyData.serviceRates || '{}'), // API Key 级别服务倍率
+      enableOpenAIResponsesCodexAdaptation: parseBooleanWithDefault(
+        keyData.enableOpenAIResponsesCodexAdaptation,
+        true
+      ),
+      enableOpenAIResponsesPayloadRules: parseBooleanWithDefault(
+        keyData.enableOpenAIResponsesPayloadRules,
+        false
+      ),
+      openaiResponsesPayloadRules: parseOpenAIResponsesPayloadRules(
+        keyData.openaiResponsesPayloadRules
+      )
     }
   }
 
@@ -428,6 +490,18 @@ class ApiKeyService {
         // 解析失败使用默认值
       }
 
+      const openaiResponsesPayloadRules = parseOpenAIResponsesPayloadRules(
+        keyData.openaiResponsesPayloadRules
+      )
+      const enableOpenAIResponsesCodexAdaptation = parseBooleanWithDefault(
+        keyData.enableOpenAIResponsesCodexAdaptation,
+        true
+      )
+      const enableOpenAIResponsesPayloadRules = parseBooleanWithDefault(
+        keyData.enableOpenAIResponsesPayloadRules,
+        false
+      )
+
       return {
         valid: true,
         keyData: {
@@ -462,7 +536,10 @@ class ApiKeyService {
           weeklyResetDay: parseInt(keyData.weeklyResetDay || 1),
           weeklyResetHour: parseInt(keyData.weeklyResetHour || 0),
           tags,
-          serviceRates
+          serviceRates,
+          enableOpenAIResponsesCodexAdaptation,
+          enableOpenAIResponsesPayloadRules,
+          openaiResponsesPayloadRules
         }
       }
     } catch (error) {
@@ -553,6 +630,18 @@ class ApiKeyService {
         tags = []
       }
 
+      const openaiResponsesPayloadRules = parseOpenAIResponsesPayloadRules(
+        keyData.openaiResponsesPayloadRules
+      )
+      const enableOpenAIResponsesCodexAdaptation = parseBooleanWithDefault(
+        keyData.enableOpenAIResponsesCodexAdaptation,
+        true
+      )
+      const enableOpenAIResponsesPayloadRules = parseBooleanWithDefault(
+        keyData.enableOpenAIResponsesPayloadRules,
+        false
+      )
+
       return {
         valid: true,
         keyData: {
@@ -596,7 +685,10 @@ class ApiKeyService {
               parseInt(keyData.weeklyResetHour || 0)
             )) || 0,
           tags,
-          usage
+          usage,
+          enableOpenAIResponsesCodexAdaptation,
+          enableOpenAIResponsesPayloadRules,
+          openaiResponsesPayloadRules
         }
       }
     } catch (error) {
@@ -795,6 +887,14 @@ class ApiKeyService {
         key.isActive = key.isActive === 'true'
         key.enableModelRestriction = key.enableModelRestriction === 'true'
         key.enableClientRestriction = key.enableClientRestriction === 'true'
+        key.enableOpenAIResponsesCodexAdaptation = parseBooleanWithDefault(
+          key.enableOpenAIResponsesCodexAdaptation,
+          true
+        )
+        key.enableOpenAIResponsesPayloadRules = parseBooleanWithDefault(
+          key.enableOpenAIResponsesPayloadRules,
+          false
+        )
         key.permissions = normalizePermissions(key.permissions)
         key.dailyCostLimit = parseFloat(key.dailyCostLimit || 0)
         key.totalCostLimit = parseFloat(key.totalCostLimit || 0)
@@ -876,6 +976,9 @@ class ApiKeyService {
         } catch (e) {
           key.tags = []
         }
+        key.openaiResponsesPayloadRules = parseOpenAIResponsesPayloadRules(
+          key.openaiResponsesPayloadRules
+        )
         // 不暴露已弃用字段
         if (Object.prototype.hasOwnProperty.call(key, 'ccrAccountId')) {
           delete key.ccrAccountId
@@ -1048,6 +1151,14 @@ class ApiKeyService {
           key.enableModelRestriction === 'true' || key.enableModelRestriction === true
         key.enableClientRestriction =
           key.enableClientRestriction === 'true' || key.enableClientRestriction === true
+        key.enableOpenAIResponsesCodexAdaptation = parseBooleanWithDefault(
+          key.enableOpenAIResponsesCodexAdaptation,
+          true
+        )
+        key.enableOpenAIResponsesPayloadRules = parseBooleanWithDefault(
+          key.enableOpenAIResponsesPayloadRules,
+          false
+        )
         key.isActivated = key.isActivated === 'true' || key.isActivated === true
         key.permissions = key.permissions || 'all'
         key.activationUnit = key.activationUnit || 'days'
@@ -1125,6 +1236,15 @@ class ApiKeyService {
           }
         } else {
           key.tags = []
+        }
+        if (Array.isArray(key.openaiResponsesPayloadRules)) {
+          // 已解析，保持不变
+        } else if (key.openaiResponsesPayloadRules) {
+          key.openaiResponsesPayloadRules = parseOpenAIResponsesPayloadRules(
+            key.openaiResponsesPayloadRules
+          )
+        } else {
+          key.openaiResponsesPayloadRules = []
         }
 
         // 生成掩码key后再清理敏感字段
@@ -1239,7 +1359,10 @@ class ApiKeyService {
         'createdBy', // 新增：创建者（所有者变更）
         'serviceRates', // API Key 级别服务倍率
         'weeklyResetDay', // 周费用重置日 (1-7)
-        'weeklyResetHour' // 周费用重置时 (0-23)
+        'weeklyResetHour', // 周费用重置时 (0-23)
+        'enableOpenAIResponsesCodexAdaptation',
+        'enableOpenAIResponsesPayloadRules',
+        'openaiResponsesPayloadRules'
       ]
       const updatedData = { ...keyData }
 
@@ -1249,7 +1372,8 @@ class ApiKeyService {
             field === 'restrictedModels' ||
             field === 'allowedClients' ||
             field === 'tags' ||
-            field === 'serviceRates'
+            field === 'serviceRates' ||
+            field === 'openaiResponsesPayloadRules'
           ) {
             // 特殊处理数组/对象字段
             updatedData[field] = JSON.stringify(value || (field === 'serviceRates' ? {} : []))
@@ -1259,7 +1383,9 @@ class ApiKeyService {
           } else if (
             field === 'enableModelRestriction' ||
             field === 'enableClientRestriction' ||
-            field === 'isActivated'
+            field === 'isActivated' ||
+            field === 'enableOpenAIResponsesCodexAdaptation' ||
+            field === 'enableOpenAIResponsesPayloadRules'
           ) {
             // 布尔值转字符串
             updatedData[field] = String(value)
@@ -2320,7 +2446,18 @@ class ApiKeyService {
         bedrockAccountId: keyData.bedrockAccountId,
         droidAccountId: keyData.droidAccountId,
         azureOpenaiAccountId: keyData.azureOpenaiAccountId,
-        ccrAccountId: keyData.ccrAccountId
+        ccrAccountId: keyData.ccrAccountId,
+        enableOpenAIResponsesCodexAdaptation: parseBooleanWithDefault(
+          keyData.enableOpenAIResponsesCodexAdaptation,
+          true
+        ),
+        enableOpenAIResponsesPayloadRules: parseBooleanWithDefault(
+          keyData.enableOpenAIResponsesPayloadRules,
+          false
+        ),
+        openaiResponsesPayloadRules: parseOpenAIResponsesPayloadRules(
+          keyData.openaiResponsesPayloadRules
+        )
       }
     } catch (error) {
       logger.error('❌ Failed to get API key by ID:', error)

--- a/src/services/requestBodyRuleService.js
+++ b/src/services/requestBodyRuleService.js
@@ -1,0 +1,192 @@
+const VALID_VALUE_TYPES = ['string', 'number', 'boolean', 'json']
+
+function isNumericSegment(segment) {
+  return /^\d+$/.test(segment)
+}
+
+function validatePath(path) {
+  if (typeof path !== 'string' || !path.trim()) {
+    return 'Rule path must be a non-empty string'
+  }
+
+  const segments = path.split('.')
+  if (segments.some((segment) => !segment.trim())) {
+    return 'Rule path cannot contain empty segments'
+  }
+
+  return null
+}
+
+function normalizeRule(rawRule = {}) {
+  if (!rawRule || typeof rawRule !== 'object' || Array.isArray(rawRule)) {
+    return null
+  }
+
+  const path = typeof rawRule.path === 'string' ? rawRule.path.trim() : ''
+  if (!path) {
+    return null
+  }
+
+  return {
+    path,
+    valueType: typeof rawRule.valueType === 'string' ? rawRule.valueType.trim().toLowerCase() : '',
+    value: rawRule.value === undefined || rawRule.value === null ? '' : String(rawRule.value)
+  }
+}
+
+function coerceRuleValue(rule) {
+  if (!rule || typeof rule !== 'object') {
+    throw new Error('Invalid rule')
+  }
+
+  if (rule.value === '') {
+    return ''
+  }
+
+  switch (rule.valueType) {
+    case 'string':
+      return rule.value
+    case 'number': {
+      const parsed = Number(rule.value)
+      if (!Number.isFinite(parsed)) {
+        throw new Error(`Rule path "${rule.path}" expects a valid number`)
+      }
+      return parsed
+    }
+    case 'boolean': {
+      const normalized = rule.value.trim().toLowerCase()
+      if (normalized !== 'true' && normalized !== 'false') {
+        throw new Error(`Rule path "${rule.path}" expects "true" or "false"`)
+      }
+      return normalized === 'true'
+    }
+    case 'json':
+      try {
+        return JSON.parse(rule.value)
+      } catch (error) {
+        throw new Error(`Rule path "${rule.path}" expects valid JSON`)
+      }
+    default:
+      throw new Error(`Rule path "${rule.path}" has unsupported valueType "${rule.valueType}"`)
+  }
+}
+
+function validateAndNormalizeRules(rules) {
+  if (rules === undefined || rules === null) {
+    return { valid: true, rules: [] }
+  }
+
+  if (!Array.isArray(rules)) {
+    return { valid: false, error: 'Payload rules must be an array' }
+  }
+
+  const normalizedRules = []
+
+  for (let i = 0; i < rules.length; i++) {
+    const rawRule = rules[i]
+    if (!rawRule || typeof rawRule !== 'object' || Array.isArray(rawRule)) {
+      return {
+        valid: false,
+        error: `Payload rule #${i + 1} must be an object`
+      }
+    }
+
+    const normalizedRule = normalizeRule(rawRule)
+    if (!normalizedRule) {
+      continue
+    }
+
+    const pathError = validatePath(normalizedRule.path)
+    if (pathError) {
+      return {
+        valid: false,
+        error: `Payload rule #${i + 1}: ${pathError}`
+      }
+    }
+
+    if (!VALID_VALUE_TYPES.includes(normalizedRule.valueType)) {
+      return {
+        valid: false,
+        error: `Payload rule #${i + 1} has invalid valueType`
+      }
+    }
+
+    try {
+      coerceRuleValue(normalizedRule)
+    } catch (error) {
+      return {
+        valid: false,
+        error: `Payload rule #${i + 1}: ${error.message}`
+      }
+    }
+
+    normalizedRules.push(normalizedRule)
+  }
+
+  return {
+    valid: true,
+    rules: normalizedRules
+  }
+}
+
+function setValueAtPath(node, segments, value) {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    return value
+  }
+
+  const [segment, ...rest] = segments
+  const isIndex = isNumericSegment(segment)
+
+  if (isIndex) {
+    const index = Number(segment)
+    const nextNode = Array.isArray(node) ? [...node] : []
+
+    if (rest.length === 0) {
+      nextNode[index] = value
+      return nextNode
+    }
+
+    nextNode[index] = setValueAtPath(nextNode[index], rest, value)
+    return nextNode
+  }
+
+  const nextNode = node && typeof node === 'object' && !Array.isArray(node) ? { ...node } : {}
+
+  if (rest.length === 0) {
+    nextNode[segment] = value
+    return nextNode
+  }
+
+  nextNode[segment] = setValueAtPath(nextNode[segment], rest, value)
+  return nextNode
+}
+
+function applyRules(body, rules) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return body
+  }
+
+  const validation = validateAndNormalizeRules(rules)
+  if (!validation.valid) {
+    const error = new Error(validation.error)
+    error.statusCode = 500
+    throw error
+  }
+
+  let nextBody =
+    typeof structuredClone === 'function' ? structuredClone(body) : JSON.parse(JSON.stringify(body))
+
+  for (const rule of validation.rules) {
+    nextBody = setValueAtPath(nextBody, rule.path.split('.'), coerceRuleValue(rule))
+  }
+
+  return nextBody
+}
+
+module.exports = {
+  VALID_VALUE_TYPES,
+  applyRules,
+  coerceRuleValue,
+  normalizeRule,
+  validateAndNormalizeRules
+}

--- a/tests/adminApiKeysPayloadRulesRoute.test.js
+++ b/tests/adminApiKeysPayloadRulesRoute.test.js
@@ -1,0 +1,171 @@
+const mockRouter = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn()
+}
+
+jest.mock(
+  'express',
+  () => ({
+    Router: () => mockRouter
+  }),
+  { virtual: true }
+)
+
+jest.mock('../src/middleware/auth', () => ({
+  authenticateAdmin: jest.fn((_req, _res, next) => next())
+}))
+
+jest.mock('../src/services/apiKeyService', () => ({
+  updateApiKey: jest.fn()
+}))
+
+jest.mock('../src/models/redis', () => ({}))
+
+jest.mock('../src/utils/logger', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  success: jest.fn()
+}))
+
+jest.mock('../src/utils/costCalculator', () => ({
+  calculateCost: jest.fn(),
+  formatCost: jest.fn()
+}))
+
+jest.mock(
+  '../config/config',
+  () => ({
+    system: {
+      timezoneOffset: 8
+    }
+  }),
+  { virtual: true }
+)
+
+jest.mock('../src/services/requestBodyRuleService', () => ({
+  validateAndNormalizeRules: jest.fn()
+}))
+
+const apiKeyService = require('../src/services/apiKeyService')
+const requestBodyRuleService = require('../src/services/requestBodyRuleService')
+require('../src/routes/admin/apiKeys')
+
+function createResponse() {
+  const res = {
+    statusCode: 200,
+    body: null,
+    json: jest.fn((payload) => {
+      res.body = payload
+      return res
+    }),
+    status: jest.fn((code) => {
+      res.statusCode = code
+      return res
+    })
+  }
+
+  return res
+}
+
+function findPutHandler(path) {
+  const route = mockRouter.put.mock.calls.find((call) => call[0] === path)
+  return route?.[2]
+}
+
+describe('admin api keys route payload rule updates', () => {
+  beforeEach(() => {
+    apiKeyService.updateApiKey.mockReset()
+    apiKeyService.updateApiKey.mockResolvedValue()
+
+    requestBodyRuleService.validateAndNormalizeRules.mockReset()
+    requestBodyRuleService.validateAndNormalizeRules.mockImplementation((rules) => ({
+      valid: true,
+      rules
+    }))
+  })
+
+  test('does not clear stored payload rules when the toggle is disabled without sending rules', async () => {
+    const handler = findPutHandler('/api-keys/:keyId')
+    const res = createResponse()
+
+    await handler(
+      {
+        params: { keyId: 'key-1' },
+        body: {
+          name: 'Renamed Key',
+          enableOpenAIResponsesPayloadRules: false
+        }
+      },
+      res
+    )
+
+    expect(requestBodyRuleService.validateAndNormalizeRules).not.toHaveBeenCalled()
+
+    const updates = apiKeyService.updateApiKey.mock.calls[0][1]
+    expect(updates).toEqual({
+      name: 'Renamed Key',
+      enableOpenAIResponsesPayloadRules: false
+    })
+    expect(updates).not.toHaveProperty('openaiResponsesPayloadRules')
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.body).toEqual({
+      success: true,
+      message: 'API key updated successfully'
+    })
+  })
+
+  test('accepts payload rules even when the toggle is disabled', async () => {
+    const handler = findPutHandler('/api-keys/:keyId')
+    const res = createResponse()
+    const rules = [{ path: 'model', valueType: 'string', value: 'gpt-5' }]
+
+    await handler(
+      {
+        params: { keyId: 'key-2' },
+        body: {
+          enableOpenAIResponsesPayloadRules: false,
+          openaiResponsesPayloadRules: rules
+        }
+      },
+      res
+    )
+
+    expect(requestBodyRuleService.validateAndNormalizeRules).toHaveBeenCalledWith(rules)
+    expect(apiKeyService.updateApiKey).toHaveBeenCalledWith('key-2', {
+      enableOpenAIResponsesPayloadRules: false,
+      openaiResponsesPayloadRules: rules
+    })
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.body.success).toBe(true)
+  })
+
+  test('allows explicitly clearing payload rules with an empty array', async () => {
+    const handler = findPutHandler('/api-keys/:keyId')
+    const res = createResponse()
+
+    await handler(
+      {
+        params: { keyId: 'key-3' },
+        body: {
+          openaiResponsesPayloadRules: []
+        }
+      },
+      res
+    )
+
+    expect(requestBodyRuleService.validateAndNormalizeRules).toHaveBeenCalledWith([])
+    expect(apiKeyService.updateApiKey).toHaveBeenCalledWith('key-3', {
+      openaiResponsesPayloadRules: []
+    })
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.body.success).toBe(true)
+  })
+})

--- a/tests/apiKeyServiceOpenAIResponsesConfig.test.js
+++ b/tests/apiKeyServiceOpenAIResponsesConfig.test.js
@@ -1,0 +1,126 @@
+jest.mock(
+  '../config/config',
+  () => ({
+    security: {
+      apiKeyPrefix: 'cr_'
+    }
+  }),
+  { virtual: true }
+)
+
+jest.mock('../src/models/redis', () => ({
+  setApiKey: jest.fn(),
+  getApiKey: jest.fn()
+}))
+
+jest.mock('../src/services/costRankService', () => ({
+  addKeyToIndexes: jest.fn()
+}))
+
+jest.mock('../src/services/apiKeyIndexService', () => ({
+  addToIndex: jest.fn(),
+  updateIndex: jest.fn()
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  success: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+
+jest.mock('../src/services/serviceRatesService', () => ({}))
+jest.mock('../src/services/requestDetailService', () => ({}))
+jest.mock('../src/utils/modelHelper', () => ({
+  isClaudeFamilyModel: jest.fn(() => false)
+}))
+jest.mock('../src/utils/requestDetailHelper', () => ({
+  finalizeRequestDetailMeta: jest.fn((value) => value)
+}))
+
+const redis = require('../src/models/redis')
+const apiKeyService = require('../src/services/apiKeyService')
+
+describe('apiKeyService openai responses config', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('generateApiKey stores default toggle values', async () => {
+    redis.setApiKey.mockResolvedValue()
+
+    const result = await apiKeyService.generateApiKey({ name: 'Test Key' })
+    const [, storedKeyData] = redis.setApiKey.mock.calls[0]
+
+    expect(storedKeyData.enableOpenAIResponsesCodexAdaptation).toBe('true')
+    expect(storedKeyData.enableOpenAIResponsesPayloadRules).toBe('false')
+    expect(storedKeyData.openaiResponsesPayloadRules).toBe('[]')
+
+    expect(result.enableOpenAIResponsesCodexAdaptation).toBe(true)
+    expect(result.enableOpenAIResponsesPayloadRules).toBe(false)
+    expect(result.openaiResponsesPayloadRules).toEqual([])
+  })
+
+  test('updateApiKey serializes toggle and payload rule fields', async () => {
+    redis.getApiKey.mockResolvedValue({
+      id: 'key-1',
+      apiKey: 'hashed-key',
+      name: 'Old Key',
+      isActive: 'true',
+      tags: '[]'
+    })
+    redis.setApiKey.mockResolvedValue()
+
+    await apiKeyService.updateApiKey('key-1', {
+      enableOpenAIResponsesCodexAdaptation: false,
+      enableOpenAIResponsesPayloadRules: true,
+      openaiResponsesPayloadRules: [{ path: 'model', valueType: 'string', value: 'gpt-5' }]
+    })
+
+    const [, storedKeyData] = redis.setApiKey.mock.calls[0]
+    expect(storedKeyData.enableOpenAIResponsesCodexAdaptation).toBe('false')
+    expect(storedKeyData.enableOpenAIResponsesPayloadRules).toBe('true')
+    expect(storedKeyData.openaiResponsesPayloadRules).toBe(
+      JSON.stringify([{ path: 'model', valueType: 'string', value: 'gpt-5' }])
+    )
+  })
+
+  test('getApiKeyById returns parsed toggle and rule values', async () => {
+    redis.getApiKey.mockResolvedValue({
+      id: 'key-1',
+      name: 'Key',
+      apiKey: 'hashed-key',
+      tokenLimit: '0',
+      isActive: 'true',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      lastUsedAt: '',
+      expiresAt: '',
+      userId: '',
+      userUsername: '',
+      createdBy: 'admin',
+      permissions: '[]',
+      dailyCostLimit: '0',
+      totalCostLimit: '0',
+      claudeAccountId: '',
+      claudeConsoleAccountId: '',
+      geminiAccountId: '',
+      openaiAccountId: '',
+      bedrockAccountId: '',
+      droidAccountId: '',
+      azureOpenaiAccountId: '',
+      ccrAccountId: '',
+      enableOpenAIResponsesCodexAdaptation: 'false',
+      enableOpenAIResponsesPayloadRules: 'true',
+      openaiResponsesPayloadRules: JSON.stringify([
+        { path: 'model', valueType: 'string', value: 'gpt-5' }
+      ])
+    })
+
+    const result = await apiKeyService.getApiKeyById('key-1')
+
+    expect(result.enableOpenAIResponsesCodexAdaptation).toBe(false)
+    expect(result.enableOpenAIResponsesPayloadRules).toBe(true)
+    expect(result.openaiResponsesPayloadRules).toEqual([
+      { path: 'model', valueType: 'string', value: 'gpt-5' }
+    ])
+  })
+})

--- a/tests/openaiResponsesPayloadToggles.test.js
+++ b/tests/openaiResponsesPayloadToggles.test.js
@@ -1,0 +1,325 @@
+const crypto = require('crypto')
+
+const mockRouter = {
+  get: jest.fn(),
+  post: jest.fn()
+}
+
+jest.mock(
+  'express',
+  () => ({
+    Router: () => mockRouter
+  }),
+  { virtual: true }
+)
+
+jest.mock(
+  '../config/config',
+  () => ({
+    requestTimeout: 1000
+  }),
+  { virtual: true }
+)
+
+jest.mock('../src/middleware/auth', () => ({
+  authenticateApiKey: jest.fn((_req, _res, next) => next())
+}))
+
+jest.mock('axios', () => ({
+  post: jest.fn()
+}))
+
+jest.mock('../src/services/scheduler/unifiedOpenAIScheduler', () => ({
+  selectAccountForApiKey: jest.fn(),
+  markAccountRateLimited: jest.fn(),
+  isAccountRateLimited: jest.fn().mockResolvedValue(false),
+  removeAccountRateLimit: jest.fn(),
+  markAccountUnauthorized: jest.fn()
+}))
+
+jest.mock('../src/services/account/openaiAccountService', () => ({
+  getAccount: jest.fn(),
+  decrypt: jest.fn(),
+  isTokenExpired: jest.fn(() => false),
+  refreshAccountToken: jest.fn(),
+  updateCodexUsageSnapshot: jest.fn()
+}))
+
+jest.mock('../src/services/account/openaiResponsesAccountService', () => ({
+  getAccount: jest.fn()
+}))
+
+jest.mock('../src/services/relay/openaiResponsesRelayService', () => ({
+  handleRequest: jest.fn()
+}))
+
+jest.mock('../src/services/apiKeyService', () => ({
+  hasPermission: jest.fn(() => true),
+  recordUsage: jest.fn()
+}))
+
+jest.mock('../src/models/redis', () => ({
+  getUsageStats: jest.fn()
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  api: jest.fn(),
+  security: jest.fn()
+}))
+
+jest.mock('../src/utils/proxyHelper', () => ({
+  createProxyAgent: jest.fn(() => null),
+  getProxyDescription: jest.fn(() => 'none')
+}))
+
+jest.mock('../src/utils/rateLimitHelper', () => ({
+  updateRateLimitCounters: jest.fn()
+}))
+
+jest.mock('../src/utils/sseParser', () => ({
+  IncrementalSSEParser: jest.fn().mockImplementation(() => ({
+    feed: jest.fn(() => []),
+    getRemaining: jest.fn(() => '')
+  }))
+}))
+
+jest.mock('../src/utils/errorSanitizer', () => ({
+  getSafeMessage: jest.fn((error) => error?.message || 'error')
+}))
+
+jest.mock('../src/utils/requestDetailHelper', () => ({
+  createRequestDetailMeta: jest.fn(() => null),
+  extractOpenAICacheReadTokens: jest.fn(() => 0)
+}))
+
+const unifiedOpenAIScheduler = require('../src/services/scheduler/unifiedOpenAIScheduler')
+const openaiResponsesAccountService = require('../src/services/account/openaiResponsesAccountService')
+const openaiResponsesRelayService = require('../src/services/relay/openaiResponsesRelayService')
+const openaiRoutes = require('../src/routes/openaiRoutes')
+
+function createHash(value) {
+  return crypto.createHash('sha256').update(value).digest('hex')
+}
+
+function createReq({
+  path = '/v1/responses',
+  body = {},
+  userAgent = 'my-client/1.0',
+  apiKeyOverrides = {},
+  fromUnifiedEndpoint = false
+} = {}) {
+  return {
+    method: 'POST',
+    path,
+    originalUrl: `/openai${path}`,
+    headers: {
+      'user-agent': userAgent
+    },
+    body: JSON.parse(JSON.stringify(body)),
+    apiKey: {
+      id: 'key_1',
+      permissions: ['openai'],
+      enableOpenAIResponsesCodexAdaptation: true,
+      enableOpenAIResponsesPayloadRules: false,
+      openaiResponsesPayloadRules: [],
+      ...apiKeyOverrides
+    },
+    _fromUnifiedEndpoint: fromUnifiedEndpoint
+  }
+}
+
+function createRes() {
+  const res = {
+    statusCode: 200,
+    headers: {},
+    destroyed: false,
+    writableEnded: false,
+    headersSent: false,
+    status: jest.fn((code) => {
+      res.statusCode = code
+      return res
+    }),
+    json: jest.fn((payload) => {
+      res.payload = payload
+      return res
+    }),
+    setHeader: jest.fn((key, value) => {
+      res.headers[key] = value
+    }),
+    set: jest.fn((key, value) => {
+      res.headers[key] = value
+      return res
+    })
+  }
+  return res
+}
+
+describe('openai responses payload toggles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    unifiedOpenAIScheduler.selectAccountForApiKey.mockResolvedValue({
+      accountId: 'resp-1',
+      accountType: 'openai-responses'
+    })
+
+    openaiResponsesAccountService.getAccount.mockResolvedValue({
+      id: 'resp-1',
+      name: 'Responses Account',
+      apiKey: 'sk-responses'
+    })
+
+    openaiResponsesRelayService.handleRequest.mockResolvedValue({ ok: true })
+  })
+
+  test('passes standard responses through unchanged when both toggles are off', async () => {
+    const req = createReq({
+      body: {
+        model: 'gpt-5-2025-08-07',
+        temperature: 0.2,
+        service_tier: 'priority',
+        prompt_cache_key: 'session-a'
+      },
+      apiKeyOverrides: {
+        enableOpenAIResponsesCodexAdaptation: false,
+        enableOpenAIResponsesPayloadRules: false
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(req.body).toEqual({
+      model: 'gpt-5-2025-08-07',
+      temperature: 0.2,
+      service_tier: 'priority',
+      prompt_cache_key: 'session-a'
+    })
+    expect(unifiedOpenAIScheduler.selectAccountForApiKey).toHaveBeenCalledWith(
+      req.apiKey,
+      createHash('session-a'),
+      'gpt-5-2025-08-07'
+    )
+  })
+
+  test('applies Codex adaptation only when adaptation toggle is on', async () => {
+    const req = createReq({
+      body: {
+        model: 'gpt-5-2025-08-07',
+        temperature: 0.2,
+        service_tier: 'priority',
+        prompt_cache_key: 'session-b'
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(req.body.model).toBe('gpt-5')
+    expect(req.body.instructions).toBe(openaiRoutes.CODEX_CLI_INSTRUCTIONS)
+    expect(req.body.temperature).toBeUndefined()
+    expect(req.body.service_tier).toBeUndefined()
+    expect(unifiedOpenAIScheduler.selectAccountForApiKey).toHaveBeenCalledWith(
+      req.apiKey,
+      createHash('session-b'),
+      'gpt-5'
+    )
+  })
+
+  test('applies payload rules directly on the original payload when adaptation is off', async () => {
+    const req = createReq({
+      body: {
+        model: 'gpt-4.1',
+        temperature: 0.5,
+        prompt_cache_key: 'old-key',
+        text: { format: {} }
+      },
+      apiKeyOverrides: {
+        enableOpenAIResponsesCodexAdaptation: false,
+        enableOpenAIResponsesPayloadRules: true,
+        openaiResponsesPayloadRules: [
+          { path: 'model', valueType: 'string', value: 'gpt-5' },
+          { path: 'prompt_cache_key', valueType: 'string', value: 'new-key' },
+          { path: 'text.format.type', valueType: 'string', value: 'json_schema' }
+        ]
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(req.body).toEqual({
+      model: 'gpt-5',
+      temperature: 0.5,
+      prompt_cache_key: 'new-key',
+      text: {
+        format: {
+          type: 'json_schema'
+        }
+      }
+    })
+    expect(req.body.instructions).toBeUndefined()
+    expect(unifiedOpenAIScheduler.selectAccountForApiKey).toHaveBeenCalledWith(
+      req.apiKey,
+      createHash('new-key'),
+      'gpt-5'
+    )
+  })
+
+  test('applies payload rules after Codex adaptation when both toggles are on', async () => {
+    const req = createReq({
+      body: {
+        model: 'gpt-5-2025-08-07',
+        prompt_cache_key: 'legacy-key',
+        temperature: 0.2,
+        instructions: 'raw'
+      },
+      apiKeyOverrides: {
+        enableOpenAIResponsesCodexAdaptation: true,
+        enableOpenAIResponsesPayloadRules: true,
+        openaiResponsesPayloadRules: [
+          { path: 'model', valueType: 'string', value: 'gpt-5-codex' },
+          { path: 'instructions', valueType: 'string', value: 'custom instructions' },
+          { path: 'prompt_cache_key', valueType: 'string', value: 'rule-key' }
+        ]
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(req.body.model).toBe('gpt-5-codex')
+    expect(req.body.instructions).toBe('custom instructions')
+    expect(req.body.temperature).toBeUndefined()
+    expect(unifiedOpenAIScheduler.selectAccountForApiKey).toHaveBeenCalledWith(
+      req.apiKey,
+      createHash('rule-key'),
+      'gpt-5-codex'
+    )
+  })
+
+  test('does not apply the new rule flow to compact responses routes', async () => {
+    const req = createReq({
+      path: '/v1/responses/compact',
+      body: {
+        model: 'o1-mini',
+        prompt_cache_key: 'compact-key',
+        temperature: 0.1
+      },
+      apiKeyOverrides: {
+        enableOpenAIResponsesCodexAdaptation: false,
+        enableOpenAIResponsesPayloadRules: true,
+        openaiResponsesPayloadRules: [
+          { path: 'model', valueType: 'string', value: 'gpt-5' },
+          { path: 'prompt_cache_key', valueType: 'string', value: 'rule-key' }
+        ]
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(req.body.model).toBe('o1-mini')
+    expect(req.body.prompt_cache_key).toBe('compact-key')
+    expect(req.body.instructions).toBe(openaiRoutes.CODEX_CLI_INSTRUCTIONS)
+  })
+})

--- a/tests/openaiResponsesPayloadToggles.test.js
+++ b/tests/openaiResponsesPayloadToggles.test.js
@@ -180,7 +180,7 @@ describe('openai responses payload toggles', () => {
     openaiAccountService.decrypt.mockReturnValue('decrypted-token')
   })
 
-  test('passes standard responses through unchanged when both toggles are off', async () => {
+  test('keeps standard responses payload unchanged for openai-responses when both toggles are off', async () => {
     const req = createReq({
       body: {
         model: 'gpt-5-2025-08-07',
@@ -205,7 +205,7 @@ describe('openai responses payload toggles', () => {
     expect(unifiedOpenAIScheduler.selectAccountForApiKey).toHaveBeenCalledWith(
       req.apiKey,
       createHash('session-a'),
-      'gpt-5-2025-08-07'
+      'gpt-5'
     )
   })
 
@@ -300,6 +300,117 @@ describe('openai responses payload toggles', () => {
       createHash('rule-key'),
       'gpt-5-codex'
     )
+  })
+
+  test('normalizes dated gpt-5 models only for scheduling and upstream openai requests when adaptation is off', async () => {
+    unifiedOpenAIScheduler.selectAccountForApiKey.mockResolvedValue({
+      accountId: 'openai-1',
+      accountType: 'openai'
+    })
+    openaiAccountService.getAccount.mockResolvedValue({
+      id: 'openai-1',
+      name: 'OpenAI Account',
+      accessToken: 'encrypted-token',
+      accountId: 'chatgpt-account-1'
+    })
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        model: 'gpt-5',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 4,
+          total_tokens: 14
+        }
+      },
+      headers: {}
+    })
+
+    const req = createReq({
+      body: {
+        model: 'gpt-5-2025-08-07',
+        service_tier: 'priority',
+        prompt_cache_key: 'compat-key',
+        stream: false
+      },
+      apiKeyOverrides: {
+        enableOpenAIResponsesCodexAdaptation: false,
+        enableOpenAIResponsesPayloadRules: false
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(unifiedOpenAIScheduler.selectAccountForApiKey).toHaveBeenCalledWith(
+      req.apiKey,
+      createHash('compat-key'),
+      'gpt-5'
+    )
+    expect(req.body.model).toBe('gpt-5')
+    expect(req.body.service_tier).toBe('priority')
+    expect(axios.post).toHaveBeenCalled()
+    expect(axios.post.mock.calls[0][1]).toMatchObject({
+      model: 'gpt-5',
+      service_tier: 'priority',
+      store: false
+    })
+  })
+
+  test('normalizes payload-rule gpt-5 aliases for openai scheduling without applying full Codex adaptation', async () => {
+    unifiedOpenAIScheduler.selectAccountForApiKey.mockResolvedValue({
+      accountId: 'openai-1',
+      accountType: 'openai'
+    })
+    openaiAccountService.getAccount.mockResolvedValue({
+      id: 'openai-1',
+      name: 'OpenAI Account',
+      accessToken: 'encrypted-token',
+      accountId: 'chatgpt-account-1'
+    })
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        model: 'gpt-5',
+        usage: {
+          input_tokens: 8,
+          output_tokens: 3,
+          total_tokens: 11
+        }
+      },
+      headers: {}
+    })
+
+    const req = createReq({
+      body: {
+        model: 'gpt-4.1',
+        text: { format: {} },
+        prompt_cache_key: 'rule-model-key',
+        stream: false
+      },
+      apiKeyOverrides: {
+        enableOpenAIResponsesCodexAdaptation: false,
+        enableOpenAIResponsesPayloadRules: true,
+        openaiResponsesPayloadRules: [
+          { path: 'model', valueType: 'string', value: 'gpt-5-2025-08-07' }
+        ]
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(unifiedOpenAIScheduler.selectAccountForApiKey).toHaveBeenCalledWith(
+      req.apiKey,
+      createHash('rule-model-key'),
+      'gpt-5'
+    )
+    expect(req.body.model).toBe('gpt-5')
+    expect(req.body.text).toEqual({ format: {} })
+    expect(req.body.instructions).toBeUndefined()
+    expect(axios.post.mock.calls[0][1]).toMatchObject({
+      model: 'gpt-5',
+      text: { format: {} },
+      store: false
+    })
   })
 
   test('records the mutated service_tier for standard responses sent through openai accounts', async () => {

--- a/tests/openaiResponsesPayloadToggles.test.js
+++ b/tests/openaiResponsesPayloadToggles.test.js
@@ -97,6 +97,9 @@ jest.mock('../src/utils/requestDetailHelper', () => ({
 }))
 
 const unifiedOpenAIScheduler = require('../src/services/scheduler/unifiedOpenAIScheduler')
+const axios = require('axios')
+const apiKeyService = require('../src/services/apiKeyService')
+const openaiAccountService = require('../src/services/account/openaiAccountService')
 const openaiResponsesAccountService = require('../src/services/account/openaiResponsesAccountService')
 const openaiResponsesRelayService = require('../src/services/relay/openaiResponsesRelayService')
 const openaiRoutes = require('../src/routes/openaiRoutes')
@@ -174,6 +177,7 @@ describe('openai responses payload toggles', () => {
     })
 
     openaiResponsesRelayService.handleRequest.mockResolvedValue({ ok: true })
+    openaiAccountService.decrypt.mockReturnValue('decrypted-token')
   })
 
   test('passes standard responses through unchanged when both toggles are off', async () => {
@@ -296,6 +300,116 @@ describe('openai responses payload toggles', () => {
       createHash('rule-key'),
       'gpt-5-codex'
     )
+  })
+
+  test('records the mutated service_tier for standard responses sent through openai accounts', async () => {
+    unifiedOpenAIScheduler.selectAccountForApiKey.mockResolvedValue({
+      accountId: 'openai-1',
+      accountType: 'openai'
+    })
+    openaiAccountService.getAccount.mockResolvedValue({
+      id: 'openai-1',
+      name: 'OpenAI Account',
+      accessToken: 'encrypted-token',
+      accountId: 'chatgpt-account-1'
+    })
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        model: 'gpt-4.1',
+        usage: {
+          input_tokens: 12,
+          output_tokens: 6,
+          total_tokens: 18
+        }
+      },
+      headers: {}
+    })
+
+    const req = createReq({
+      body: {
+        model: 'gpt-4.1',
+        prompt_cache_key: 'tier-rule-key',
+        stream: false
+      },
+      apiKeyOverrides: {
+        enableOpenAIResponsesCodexAdaptation: false,
+        enableOpenAIResponsesPayloadRules: true,
+        openaiResponsesPayloadRules: [
+          { path: 'service_tier', valueType: 'string', value: 'priority' }
+        ]
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(req._serviceTier).toBe('priority')
+    expect(apiKeyService.recordUsage).toHaveBeenCalled()
+    expect(apiKeyService.recordUsage.mock.calls[0][8]).toBe('priority')
+  })
+
+  test('records null service_tier after Codex adaptation removes it for openai accounts', async () => {
+    unifiedOpenAIScheduler.selectAccountForApiKey.mockResolvedValue({
+      accountId: 'openai-1',
+      accountType: 'openai'
+    })
+    openaiAccountService.getAccount.mockResolvedValue({
+      id: 'openai-1',
+      name: 'OpenAI Account',
+      accessToken: 'encrypted-token',
+      accountId: 'chatgpt-account-1'
+    })
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        model: 'gpt-5',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 4,
+          total_tokens: 14
+        }
+      },
+      headers: {}
+    })
+
+    const req = createReq({
+      body: {
+        model: 'gpt-5-2025-08-07',
+        temperature: 0.2,
+        service_tier: 'priority',
+        prompt_cache_key: 'adapt-tier-key',
+        stream: false
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(req.body.service_tier).toBeUndefined()
+    expect(req._serviceTier).toBeNull()
+    expect(apiKeyService.recordUsage).toHaveBeenCalled()
+    expect(apiKeyService.recordUsage.mock.calls[0][8]).toBeNull()
+  })
+
+  test('captures the post-rule service_tier before relaying openai-responses requests', async () => {
+    const req = createReq({
+      body: {
+        model: 'gpt-4.1',
+        prompt_cache_key: 'relay-tier-key'
+      },
+      apiKeyOverrides: {
+        enableOpenAIResponsesCodexAdaptation: false,
+        enableOpenAIResponsesPayloadRules: true,
+        openaiResponsesPayloadRules: [
+          { path: 'service_tier', valueType: 'string', value: 'priority' }
+        ]
+      }
+    })
+
+    await openaiRoutes.handleResponses(req, createRes())
+
+    expect(req._serviceTier).toBe('priority')
+    expect(openaiResponsesRelayService.handleRequest).toHaveBeenCalled()
+    expect(openaiResponsesRelayService.handleRequest.mock.calls[0][0]._serviceTier).toBe('priority')
   })
 
   test('does not apply the new rule flow to compact responses routes', async () => {

--- a/tests/redisApiKeyParse.test.js
+++ b/tests/redisApiKeyParse.test.js
@@ -1,0 +1,45 @@
+jest.mock(
+  '../config/config',
+  () => ({
+    system: {
+      timezoneOffset: 8
+    }
+  }),
+  { virtual: true }
+)
+
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+  debug: jest.fn()
+}))
+
+const redis = require('../src/models/redis')
+
+describe('redis api key parsing', () => {
+  test('parses openai responses toggle and rule fields for list data', () => {
+    const parsed = redis._parseApiKeyData({
+      enableOpenAIResponsesCodexAdaptation: 'false',
+      enableOpenAIResponsesPayloadRules: 'true',
+      openaiResponsesPayloadRules: JSON.stringify([
+        { path: 'model', valueType: 'string', value: 'gpt-5' }
+      ])
+    })
+
+    expect(parsed.enableOpenAIResponsesCodexAdaptation).toBe(false)
+    expect(parsed.enableOpenAIResponsesPayloadRules).toBe(true)
+    expect(parsed.openaiResponsesPayloadRules).toEqual([
+      { path: 'model', valueType: 'string', value: 'gpt-5' }
+    ])
+  })
+
+  test('uses safe defaults for missing openai responses fields', () => {
+    const parsed = redis._parseApiKeyData({})
+
+    expect(parsed.enableOpenAIResponsesCodexAdaptation).toBe(true)
+    expect(parsed.enableOpenAIResponsesPayloadRules).toBe(false)
+    expect(parsed.openaiResponsesPayloadRules).toEqual([])
+  })
+})

--- a/tests/requestBodyRuleService.test.js
+++ b/tests/requestBodyRuleService.test.js
@@ -1,0 +1,88 @@
+const requestBodyRuleService = require('../src/services/requestBodyRuleService')
+
+describe('requestBodyRuleService', () => {
+  test('applies multiple rules with nested paths and typed values', () => {
+    const body = {
+      model: 'gpt-4.1',
+      input: [{ role: 'user' }],
+      metadata: {}
+    }
+
+    const result = requestBodyRuleService.applyRules(body, [
+      { path: 'model', valueType: 'string', value: 'gpt-5' },
+      { path: 'input.0.priority', valueType: 'number', value: '2' },
+      { path: 'metadata.debug', valueType: 'boolean', value: 'true' },
+      { path: 'text.format', valueType: 'json', value: '{"type":"json_schema"}' }
+    ])
+
+    expect(result).toEqual({
+      model: 'gpt-5',
+      input: [{ role: 'user', priority: 2 }],
+      metadata: { debug: true },
+      text: {
+        format: {
+          type: 'json_schema'
+        }
+      }
+    })
+    expect(body).toEqual({
+      model: 'gpt-4.1',
+      input: [{ role: 'user' }],
+      metadata: {}
+    })
+  })
+
+  test('uses empty string when value is omitted for any value type', () => {
+    const result = requestBodyRuleService.applyRules({}, [
+      { path: 'a', valueType: 'string', value: '' },
+      { path: 'b', valueType: 'number', value: '' },
+      { path: 'c', valueType: 'boolean', value: '' },
+      { path: 'd', valueType: 'json', value: '' }
+    ])
+
+    expect(result).toEqual({
+      a: '',
+      b: '',
+      c: '',
+      d: ''
+    })
+  })
+
+  test('keeps the last rule when the same path appears multiple times', () => {
+    const result = requestBodyRuleService.applyRules({ model: 'gpt-4.1' }, [
+      { path: 'model', valueType: 'string', value: 'gpt-5' },
+      { path: 'model', valueType: 'string', value: 'gpt-5-codex' }
+    ])
+
+    expect(result.model).toBe('gpt-5-codex')
+  })
+
+  test('rejects invalid typed values', () => {
+    expect(
+      requestBodyRuleService.validateAndNormalizeRules([
+        { path: 'count', valueType: 'number', value: 'abc' }
+      ])
+    ).toEqual({
+      valid: false,
+      error: 'Payload rule #1: Rule path "count" expects a valid number'
+    })
+
+    expect(
+      requestBodyRuleService.validateAndNormalizeRules([
+        { path: 'flag', valueType: 'boolean', value: 'yes' }
+      ])
+    ).toEqual({
+      valid: false,
+      error: 'Payload rule #1: Rule path "flag" expects "true" or "false"'
+    })
+
+    expect(
+      requestBodyRuleService.validateAndNormalizeRules([
+        { path: 'payload', valueType: 'json', value: '{broken}' }
+      ])
+    ).toEqual({
+      valid: false,
+      error: 'Payload rule #1: Rule path "payload" expects valid JSON'
+    })
+  })
+})

--- a/web/admin-spa/src/components/apikeys/EditApiKeyModal.vue
+++ b/web/admin-spa/src/components/apikeys/EditApiKeyModal.vue
@@ -539,6 +539,172 @@
             </p>
           </div>
 
+          <div
+            class="rounded-lg border border-emerald-200 bg-emerald-50 p-3 dark:border-emerald-700 dark:bg-emerald-900/20"
+          >
+            <div class="mb-3 flex items-center gap-2">
+              <div
+                class="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-emerald-500"
+              >
+                <i class="fas fa-sliders-h text-xs text-white" />
+              </div>
+              <h4 class="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                OpenAI Responses 请求处理
+              </h4>
+            </div>
+
+            <div class="space-y-3">
+              <label class="flex cursor-pointer items-start gap-3">
+                <input
+                  v-model="form.enableOpenAIResponsesCodexAdaptation"
+                  class="mt-0.5 h-4 w-4 rounded border-gray-300 bg-gray-100 text-emerald-600 focus:ring-emerald-500"
+                  type="checkbox"
+                />
+                <span class="flex-1">
+                  <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    非 Codex 请求兼容为 Codex 风格
+                  </span>
+                  <span class="block text-xs text-gray-500 dark:text-gray-400">
+                    只对 `/openai/responses` 和 `/openai/v1/responses`
+                    生效。关闭后将保留原始请求体。
+                  </span>
+                </span>
+              </label>
+
+              <label class="flex cursor-pointer items-start gap-3">
+                <input
+                  v-model="form.enableOpenAIResponsesPayloadRules"
+                  class="mt-0.5 h-4 w-4 rounded border-gray-300 bg-gray-100 text-emerald-600 focus:ring-emerald-500"
+                  type="checkbox"
+                />
+                <span class="flex-1">
+                  <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    启用 Payload 规则
+                  </span>
+                  <span class="block text-xs text-gray-500 dark:text-gray-400">
+                    开启后会按顺序写入字段。只填字段不填值时，会把该字段写成空字符串。
+                  </span>
+                </span>
+              </label>
+
+              <div
+                v-if="form.enableOpenAIResponsesPayloadRules"
+                class="rounded-lg border border-emerald-100 bg-white/70 p-3 dark:border-emerald-800 dark:bg-gray-800/40"
+              >
+                <div class="mb-3 flex items-center justify-between">
+                  <div>
+                    <div class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Payload 规则
+                    </div>
+                    <div class="text-xs text-gray-500 dark:text-gray-400">
+                      两个开关都开时，先做 Codex 风格兼容，再应用这里的规则。
+                    </div>
+                  </div>
+                  <button
+                    class="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-600"
+                    type="button"
+                    @click="addPayloadRule"
+                  >
+                    <i class="fas fa-plus mr-1" />
+                    新增规则
+                  </button>
+                </div>
+
+                <div class="space-y-3">
+                  <div
+                    v-for="(rule, index) in form.openaiResponsesPayloadRules"
+                    :key="`payload-rule-${index}`"
+                    class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/70"
+                  >
+                    <div class="mb-3 flex items-center justify-between">
+                      <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        规则 {{ index + 1 }}
+                      </span>
+                      <button
+                        class="text-sm text-red-500 transition-colors hover:text-red-600"
+                        type="button"
+                        @click="removePayloadRule(index)"
+                      >
+                        <i class="fas fa-trash-alt" />
+                      </button>
+                    </div>
+
+                    <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                      <div>
+                        <label
+                          class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                        >
+                          字段路径
+                        </label>
+                        <input
+                          v-model="rule.path"
+                          class="form-input w-full border-gray-300 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                          placeholder="例如 text.format.type"
+                          type="text"
+                        />
+                      </div>
+
+                      <div>
+                        <label
+                          class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                        >
+                          值类型
+                        </label>
+                        <select
+                          v-model="rule.valueType"
+                          class="form-input w-full border-gray-300 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+                        >
+                          <option
+                            v-for="option in payloadRuleValueTypeOptions"
+                            :key="option.value"
+                            :value="option.value"
+                          >
+                            {{ option.label }}
+                          </option>
+                        </select>
+                      </div>
+                    </div>
+
+                    <div class="mt-3">
+                      <label
+                        class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                      >
+                        值
+                      </label>
+                      <textarea
+                        v-if="rule.valueType === 'json'"
+                        v-model="rule.value"
+                        class="form-input w-full resize-y border-gray-300 font-mono text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                        placeholder='例如 {"type":"json_schema"}'
+                        rows="4"
+                      />
+                      <input
+                        v-else
+                        v-model="rule.value"
+                        class="form-input w-full border-gray-300 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                        :placeholder="
+                          rule.valueType === 'boolean'
+                            ? 'true 或 false'
+                            : rule.valueType === 'number'
+                              ? '例如 123'
+                              : '留空则写入空字符串'
+                        "
+                        type="text"
+                      />
+                    </div>
+                  </div>
+
+                  <div
+                    v-if="form.openaiResponsesPayloadRules.length === 0"
+                    class="rounded-lg border border-dashed border-emerald-200 px-4 py-6 text-center text-sm text-gray-500 dark:border-emerald-800 dark:text-gray-400"
+                  >
+                    还没有规则，点右上角新增一条。
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <div>
             <div class="mb-3 flex items-center justify-between">
               <label class="text-sm font-semibold text-gray-700 dark:text-gray-300"
@@ -813,7 +979,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { showToast } from '@/utils/tools'
 import { useClientsStore } from '@/stores/clients'
 import { useApiKeysStore } from '@/stores/apiKeys'
@@ -923,6 +1089,19 @@ const availableServices = [
   { key: 'ccr', label: 'CCR' }
 ]
 
+const payloadRuleValueTypeOptions = [
+  { value: 'string', label: '字符串' },
+  { value: 'number', label: '数字' },
+  { value: 'boolean', label: '布尔' },
+  { value: 'json', label: 'JSON' }
+]
+
+const createEmptyPayloadRule = () => ({
+  path: '',
+  valueType: 'string',
+  value: ''
+})
+
 // 表单数据
 const form = reactive({
   name: '',
@@ -948,6 +1127,9 @@ const form = reactive({
   modelInput: '',
   enableClientRestriction: false,
   allowedClients: [],
+  enableOpenAIResponsesCodexAdaptation: true,
+  enableOpenAIResponsesPayloadRules: false,
+  openaiResponsesPayloadRules: [],
   tags: [],
   isActive: true,
   ownerId: '' // 新增：所有者ID
@@ -1007,6 +1189,73 @@ const removeTag = (index) => {
   form.tags.splice(index, 1)
 }
 
+const addPayloadRule = () => {
+  form.openaiResponsesPayloadRules.push(createEmptyPayloadRule())
+}
+
+const removePayloadRule = (index) => {
+  form.openaiResponsesPayloadRules.splice(index, 1)
+}
+
+const normalizePayloadRule = (rule = {}) => ({
+  path: typeof rule.path === 'string' ? rule.path.trim() : '',
+  valueType:
+    typeof rule.valueType === 'string' &&
+    payloadRuleValueTypeOptions.some((option) => option.value === rule.valueType)
+      ? rule.valueType
+      : 'string',
+  value: rule.value === undefined || rule.value === null ? '' : String(rule.value)
+})
+
+const buildPayloadRulesForSubmit = () => {
+  const normalizedRules = form.openaiResponsesPayloadRules
+    .map((rule) => normalizePayloadRule(rule))
+    .filter((rule) => rule.path)
+
+  for (const rule of normalizedRules) {
+    if (rule.value === '') {
+      continue
+    }
+
+    if (rule.valueType === 'number') {
+      if (!Number.isFinite(Number(rule.value))) {
+        showToast(`字段 ${rule.path} 的值不是合法数字`, 'error')
+        return null
+      }
+      continue
+    }
+
+    if (rule.valueType === 'boolean') {
+      const normalized = rule.value.trim().toLowerCase()
+      if (normalized !== 'true' && normalized !== 'false') {
+        showToast(`字段 ${rule.path} 的值必须是 true 或 false`, 'error')
+        return null
+      }
+      continue
+    }
+
+    if (rule.valueType === 'json') {
+      try {
+        JSON.parse(rule.value)
+      } catch (error) {
+        showToast(`字段 ${rule.path} 的值不是合法 JSON`, 'error')
+        return null
+      }
+    }
+  }
+
+  return normalizedRules
+}
+
+watch(
+  () => form.enableOpenAIResponsesPayloadRules,
+  (enabled) => {
+    if (enabled && form.openaiResponsesPayloadRules.length === 0) {
+      addPayloadRule()
+    }
+  }
+)
+
 // 更新 API Key
 const updateApiKey = async () => {
   // 检查是否设置了时间窗口但费用限制为0
@@ -1035,6 +1284,12 @@ const updateApiKey = async () => {
           filteredServiceRates[key] = value
         }
       }
+    }
+
+    const payloadRules = buildPayloadRulesForSubmit()
+    if (payloadRules === null) {
+      loading.value = false
+      return
     }
 
     const data = {
@@ -1071,6 +1326,9 @@ const updateApiKey = async () => {
           : 0,
       weeklyResetDay: form.weeklyResetDay,
       weeklyResetHour: form.weeklyResetHour,
+      enableOpenAIResponsesCodexAdaptation: form.enableOpenAIResponsesCodexAdaptation,
+      enableOpenAIResponsesPayloadRules: form.enableOpenAIResponsesPayloadRules,
+      openaiResponsesPayloadRules: form.enableOpenAIResponsesPayloadRules ? payloadRules : [],
       permissions: form.permissions,
       tags: form.tags
     }
@@ -1448,6 +1706,19 @@ onMounted(async () => {
     props.apiKey.enableModelRestriction === true || props.apiKey.enableModelRestriction === 'true'
   form.enableClientRestriction =
     props.apiKey.enableClientRestriction === true || props.apiKey.enableClientRestriction === 'true'
+  form.enableOpenAIResponsesCodexAdaptation =
+    props.apiKey.enableOpenAIResponsesCodexAdaptation === undefined ||
+    props.apiKey.enableOpenAIResponsesCodexAdaptation === true ||
+    props.apiKey.enableOpenAIResponsesCodexAdaptation === 'true'
+  form.enableOpenAIResponsesPayloadRules =
+    props.apiKey.enableOpenAIResponsesPayloadRules === true ||
+    props.apiKey.enableOpenAIResponsesPayloadRules === 'true'
+  form.openaiResponsesPayloadRules = Array.isArray(props.apiKey.openaiResponsesPayloadRules)
+    ? props.apiKey.openaiResponsesPayloadRules.map((rule) => normalizePayloadRule(rule))
+    : []
+  if (form.enableOpenAIResponsesPayloadRules && form.openaiResponsesPayloadRules.length === 0) {
+    addPayloadRule()
+  }
   // 初始化活跃状态，默认为 true（强制转换为布尔值，因为Redis返回字符串）
   form.isActive =
     props.apiKey.isActive === undefined ||

--- a/web/admin-spa/src/components/apikeys/EditApiKeyModal.vue
+++ b/web/admin-spa/src/components/apikeys/EditApiKeyModal.vue
@@ -1368,7 +1368,8 @@ const updateApiKey = async () => {
       weeklyResetHour: form.weeklyResetHour,
       enableOpenAIResponsesCodexAdaptation: form.enableOpenAIResponsesCodexAdaptation,
       enableOpenAIResponsesPayloadRules: form.enableOpenAIResponsesPayloadRules,
-      openaiResponsesPayloadRules: form.enableOpenAIResponsesPayloadRules ? payloadRules : [],
+      // 规则内容独立持久化，关闭开关时也要保留已保存的休眠规则。
+      openaiResponsesPayloadRules: payloadRules,
       permissions: form.permissions,
       tags: form.tags
     }

--- a/web/admin-spa/src/components/apikeys/EditApiKeyModal.vue
+++ b/web/admin-spa/src/components/apikeys/EditApiKeyModal.vue
@@ -562,11 +562,29 @@
                 />
                 <span class="flex-1">
                   <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                    非 Codex 请求兼容为 Codex 风格
-                  </span>
-                  <span class="block text-xs text-gray-500 dark:text-gray-400">
-                    只对 `/openai/responses` 和 `/openai/v1/responses`
-                    生效。关闭后将保留原始请求体。
+                    <span class="inline-flex items-center gap-1">
+                      <span>非 Codex 请求兼容为 Codex 风格</span>
+                      <el-tooltip placement="top">
+                        <template #content>
+                          <div class="w-[250px] space-y-2 text-xs leading-relaxed">
+                            <div>只对 `/openai/responses` 和 `/openai/v1/responses` 生效。</div>
+                            <div>
+                              关闭后不再做 Codex 风格字段改写，会保留原始 `text`、`service_tier`
+                              等字段。
+                            </div>
+                            <div>
+                              普通 OpenAI 账号仍会保留必要的 `gpt-5-*` 模型名兼容，
+                              方便调度和上游请求继续命中 `gpt-5`。
+                            </div>
+                          </div>
+                        </template>
+                        <span class="inline-flex" @click.stop.prevent>
+                          <i
+                            class="fas fa-question-circle cursor-help text-xs text-gray-400 hover:text-gray-600"
+                          />
+                        </span>
+                      </el-tooltip>
+                    </span>
                   </span>
                 </span>
               </label>
@@ -579,10 +597,22 @@
                 />
                 <span class="flex-1">
                   <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                    启用 Payload 规则
-                  </span>
-                  <span class="block text-xs text-gray-500 dark:text-gray-400">
-                    开启后会按顺序写入字段。只填字段不填值时，会把该字段写成空字符串。
+                    <span class="inline-flex items-center gap-1">
+                      <span>启用 Payload 规则</span>
+                      <el-tooltip placement="top">
+                        <template #content>
+                          <div class="w-[240px] space-y-2 text-xs leading-relaxed">
+                            <div>开启后会按顺序写入字段。</div>
+                            <div>只填字段不填值时，会把该字段写成空字符串。</div>
+                          </div>
+                        </template>
+                        <span class="inline-flex" @click.stop.prevent>
+                          <i
+                            class="fas fa-question-circle cursor-help text-xs text-gray-400 hover:text-gray-600"
+                          />
+                        </span>
+                      </el-tooltip>
+                    </span>
                   </span>
                 </span>
               </label>
@@ -592,13 +622,23 @@
                 class="rounded-lg border border-emerald-100 bg-white/70 p-3 dark:border-emerald-800 dark:bg-gray-800/40"
               >
                 <div class="mb-3 flex items-center justify-between">
-                  <div>
-                    <div class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                      Payload 规则
-                    </div>
-                    <div class="text-xs text-gray-500 dark:text-gray-400">
-                      两个开关都开时，先做 Codex 风格兼容，再应用这里的规则。
-                    </div>
+                  <div
+                    class="flex items-center gap-1 text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    <span>Payload 规则</span>
+                    <el-tooltip placement="top">
+                      <template #content>
+                        <div class="w-[240px] space-y-2 text-xs leading-relaxed">
+                          <div>规则会按列表顺序依次执行，后面的规则可以覆盖前面的结果。</div>
+                          <div>两个开关都开启时，先做 Codex 风格兼容，再应用这里的规则。</div>
+                        </div>
+                      </template>
+                      <span class="inline-flex" @click.stop.prevent>
+                        <i
+                          class="fas fa-question-circle cursor-help text-xs text-gray-400 hover:text-gray-600"
+                        />
+                      </span>
+                    </el-tooltip>
                   </div>
                   <button
                     class="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-600"


### PR DESCRIPTION
## Summary

这个 PR 为 API Key 增加了 OpenAI `responses` 请求的独立覆写配置，允许分别控制 Codex 风格改写和 payload 规则处理，同时把这些配置接入了后端存储、鉴权、转发链路和管理端编辑界面。

This PR adds API key-level configuration for OpenAI `responses` requests, allowing Codex-style adaptation and payload-rule processing to be controlled independently. The new settings are wired through backend persistence, auth, relay handling, and the admin UI.

## Backend Changes

  - 为 API Key 新增 `enableOpenAIResponsesCodexAdaptation`、`enableOpenAIResponsesPayloadRules` 和 `openaiResponsesPayloadRules` 字段，并在 admin routes、API key service、Redis 解析与鉴权中保持一致。
  - 在 OpenAI `responses` 转发流程中，将 Codex 改写和 payload rules 处理拆成可独立控制的两个步骤。
  - 在关闭 Codex 改写时，继续保留 GPT-5 相关 model alias 的调度与上游请求归一化逻辑，避免模型名称兼容性出问题。
  - 在 payload 变更完成后记录最终的 `service_tier`，让后续统计和计费读取的是实际发出的请求状态。
  - 对 compact responses 路由保持现有行为，不引入新的 payload rule 流程。
  - 补充测试，覆盖字段存储与解析、规则校验、路由更新，以及不同 toggle 组合下的请求处理行为。
  - 修复编辑 API Key 时关闭 payload rules 开关会误清空已有规则的问题，只有显式传入空数组时才会真正清除规则。

  - Add `enableOpenAIResponsesCodexAdaptation`, `enableOpenAIResponsesPayloadRules`, and `openaiResponsesPayloadRules` to API key configuration, and propagate them through admin routes, API key service, Redis parsing, and auth.
  - Split Codex adaptation and payload-rule processing into two independently controlled steps in the OpenAI `responses` relay flow.
  - Preserve GPT-5 model alias normalization for scheduling and upstream OpenAI requests even when Codex adaptation is disabled, so model compatibility remains intact.
  - Capture the final mutated `service_tier` after payload updates so downstream accounting uses the actual outbound request state.
  - Keep compact responses routes on their existing path without applying the new payload-rule flow.
  - Add regression coverage for field persistence and parsing, rule validation, route update semantics, and request behavior across different toggle combinations.
  - Fix the API key edit flow so disabling payload rules does not silently erase previously saved rules; rules are cleared only when an empty array is submitted explicitly.

## Frontend Changes

  - 在管理端 API Key 编辑弹窗中增加 OpenAI `responses` 相关配置项，支持分别控制 Codex 改写和 payload rules。
  - 在界面中提供 payload rules 的编辑能力，并让已有规则在重新打开弹窗时能够正确回填。
  - 调整保存逻辑，使 payload rules 的启用状态和规则内容分开提交，避免用户在关闭开关或修改其他字段时误删规则。
  - 保持已有配置的兼容性，避免历史数据在编辑过程中被前端重置。

  - Add OpenAI `responses` configuration controls to the API key edit modal, with separate switches for Codex adaptation and payload rules.
  - Provide UI support for editing payload rules and correctly hydrate existing rules when reopening the modal.
  - Update submit behavior so the payload-rules toggle and rule content are sent independently, preventing dormant rules from being removed during ordinary edits.
  - Preserve compatibility with existing saved configuration so legacy data is not reset by the frontend edit flow.

## Validation

  - `npm test -- tests/openaiResponsesPayloadToggles.test.js tests/apiKeyServiceOpenAIResponsesConfig.test.js tests/
  adminApiKeysPayloadRulesRoute.test.js tests/requestBodyRuleService.test.js tests/redisApiKeyParse.test.js --runInBand`
  - `cd web/admin-spa && npm run build`