### PR TITLE
perf(request-details): reuse and harden query snapshots across pagination

### DIFF
--- a/.github/workflows/pr-lint-check.yml
+++ b/.github/workflows/pr-lint-check.yml
@@ -26,7 +26,7 @@ jobs:
   lint-and-format:
     runs-on: ubuntu-latest
     name: Check Code Quality
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,11 +86,11 @@ jobs:
         run: |
           echo "🔍 Checking Prettier formatting for changed files..."
           echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
-          
+
           # 初始化标志
           PRETTIER_FAILED=false
           PRETTIER_OUTPUT=""
-          
+
           # 检查每个改变的文件
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if [ -f "$file" ]; then
@@ -127,7 +127,7 @@ jobs:
               fi
             fi
           done
-          
+
           # 输出结果
           if [ "$PRETTIER_FAILED" = true ]; then
             echo "prettier_failed=true" >> $GITHUB_OUTPUT
@@ -145,11 +145,11 @@ jobs:
         id: eslint-check
         run: |
           echo "🔍 Running ESLint on changed files..."
-          
+
           # 分离前端和后端文件
           BACKEND_FILES=""
           FRONTEND_FILES=""
-          
+
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if [[ "$file" =~ \.(js|jsx|vue|cjs|mjs)$ ]] && [ -f "$file" ]; then
               if [[ "$file" == web/admin-spa/* ]]; then
@@ -159,10 +159,10 @@ jobs:
               fi
             fi
           done
-          
+
           ESLINT_FAILED=false
           ESLINT_OUTPUT=""
-          
+
           # 检查后端文件
           if [ -n "$BACKEND_FILES" ]; then
             echo "Linting backend files: $BACKEND_FILES"
@@ -176,7 +176,7 @@ jobs:
               ESLINT_OUTPUT="${ESLINT_OUTPUT}### Backend ESLint Issues\n\`\`\`\n${BACKEND_OUTPUT}\n\`\`\`\n\n"
             fi
           fi
-          
+
           # 检查前端文件
           if [ -n "$FRONTEND_FILES" ]; then
             echo "Linting frontend files: $FRONTEND_FILES"
@@ -192,7 +192,7 @@ jobs:
               ESLINT_OUTPUT="${ESLINT_OUTPUT}### Frontend ESLint Issues\n\`\`\`\n${FRONTEND_OUTPUT}\n\`\`\`\n\n"
             fi
           fi
-          
+
           # 输出结果
           if [ "$ESLINT_FAILED" = true ]; then
             echo "eslint_failed=true" >> $GITHUB_OUTPUT
@@ -224,14 +224,14 @@ jobs:
 
       - name: Comment PR with results
         if: failure()
-        continue-on-error: true  # 即使评论失败也继续
+        continue-on-error: true # 即使评论失败也继续
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             let comment = '## 🚨 Code Quality Check Failed\n\n';
-            
+
             // 读取 Prettier 报告
             if (fs.existsSync('prettier-report.md')) {
               const prettierReport = fs.readFileSync('prettier-report.md', 'utf8');
@@ -239,14 +239,14 @@ jobs:
               comment += prettierReport;
               comment += '\n**Fix command:**\n```bash\nnpm run format\n```\n\n';
             }
-            
+
             // 读取 ESLint 报告
             if (fs.existsSync('eslint-report.md')) {
               const eslintReport = fs.readFileSync('eslint-report.md', 'utf8');
               comment += '### ESLint Issues\n\n';
               comment += eslintReport;
             }
-            
+
             comment += '\n---\n';
             comment += '💡 **提示**: 在本地运行以下命令来自动修复大部分问题:\n';
             comment += '```bash\n';
@@ -259,19 +259,19 @@ jobs:
             comment += 'npm run format    # 修复前端 Prettier 格式问题\n';
             comment += 'npm run lint      # 修复前端 ESLint 问题\n';
             comment += '```\n';
-            
+
             // 查找是否已有机器人评论
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            
+
             const botComment = comments.find(comment => 
               comment.user.type === 'Bot' && 
               comment.body.includes('Code Quality Check Failed')
             );
-            
+
             if (botComment) {
               // 更新现有评论
               await github.rest.issues.updateComment({
@@ -292,7 +292,7 @@ jobs:
 
       - name: Success comment
         if: success() && steps.changed-files.outputs.any_changed == 'true'
-        continue-on-error: true  # 即使评论失败也继续
+        continue-on-error: true # 即使评论失败也继续
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
@@ -303,12 +303,12 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            
+
             const botComment = comments.find(comment => 
               comment.user.type === 'Bot' && 
               comment.body.includes('Code Quality Check Failed')
             );
-            
+
             if (botComment) {
               // 如果之前有失败评论，更新为成功
               await github.rest.issues.updateComment({

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -1084,17 +1084,28 @@ class RequestDetailService {
       return null
     }
 
-    const rawSnapshot = await client.get(`${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`)
+    let rawSnapshot
+    try {
+      rawSnapshot = await client.get(`${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`)
+    } catch (error) {
+      logger.warn(`⚠️ Failed to read request detail query snapshot: ${error.message}`)
+      return null
+    }
+
     const parsedSnapshot = safeJsonParse(rawSnapshot, 'request detail query snapshot')
     if (!parsedSnapshot || parsedSnapshot.filterSignature !== filterSignature) {
       return null
     }
 
     if (typeof client.expire === 'function') {
-      await client.expire(
-        `${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`,
-        REQUEST_DETAIL_QUERY_SNAPSHOT_TTL_SECONDS
-      )
+      try {
+        await client.expire(
+          `${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`,
+          REQUEST_DETAIL_QUERY_SNAPSHOT_TTL_SECONDS
+        )
+      } catch (error) {
+        logger.warn(`⚠️ Failed to renew request detail query snapshot TTL: ${error.message}`)
+      }
     }
 
     return {
@@ -1141,12 +1152,17 @@ class RequestDetailService {
     }
 
     const snapshotId = makeRequestDetailQuerySnapshotId()
-    await client.set(
-      `${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`,
-      serializedSnapshot,
-      'EX',
-      REQUEST_DETAIL_QUERY_SNAPSHOT_TTL_SECONDS
-    )
+    try {
+      await client.set(
+        `${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`,
+        serializedSnapshot,
+        'EX',
+        REQUEST_DETAIL_QUERY_SNAPSHOT_TTL_SECONDS
+      )
+    } catch (error) {
+      logger.warn(`⚠️ Failed to store request detail query snapshot: ${error.message}`)
+      return null
+    }
 
     return snapshotId
   }
@@ -1215,6 +1231,8 @@ class RequestDetailService {
     )
     const filterSignature = createRequestDetailFilterSignature({
       ...filters,
+      startDate: effectiveStart.toISOString(),
+      endDate: effectiveEnd.toISOString(),
       sortOrder
     })
 

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -20,10 +20,14 @@ const {
 
 const REQUEST_DETAIL_ITEM_PREFIX = 'request_detail:item:'
 const REQUEST_DETAIL_DAY_INDEX_PREFIX = 'request_detail:index:day:'
+const REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX = 'request_detail:query_snapshot:'
 const DEFAULT_RETENTION_HOURS = 6
 const MAX_RETENTION_HOURS = 30 * 24
 const REQUEST_DETAIL_QUERY_BATCH_SIZE = 200
 const REQUEST_DETAIL_SCAN_BATCH_SIZE = 200
+const REQUEST_DETAIL_QUERY_SNAPSHOT_TTL_SECONDS = 30
+const MAX_REQUEST_DETAIL_SNAPSHOT_POINTERS = 25000
+const MAX_REQUEST_DETAIL_SNAPSHOT_BYTES = 2 * 1024 * 1024
 
 const accountTypeNames = {
   claude: 'Claude官方',
@@ -121,7 +125,7 @@ function toMillis(value) {
   return date.getTime()
 }
 
-function safeJsonParse(value) {
+function safeJsonParse(value, label = 'request detail record') {
   if (!value) {
     return null
   }
@@ -129,13 +133,73 @@ function safeJsonParse(value) {
   try {
     return JSON.parse(value)
   } catch (error) {
-    logger.warn(`⚠️ Failed to parse request detail record: ${error.message}`)
+    logger.warn(`⚠️ Failed to parse ${label}: ${error.message}`)
     return null
   }
 }
 
 function makeRequestDetailId() {
   return `rd_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
+}
+
+function makeRequestDetailQuerySnapshotId() {
+  return `rds_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
+}
+
+function normalizeOptionalFilterValue(value) {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const normalized = String(value).trim()
+  return normalized ? normalized : null
+}
+
+function createRequestDetailFilterSignature(filters = {}) {
+  return JSON.stringify({
+    startDate: toIsoString(filters.startDate),
+    endDate: toIsoString(filters.endDate),
+    keyword: normalizeOptionalFilterValue(filters.keyword),
+    apiKeyId: normalizeOptionalFilterValue(filters.apiKeyId),
+    accountId: normalizeOptionalFilterValue(filters.accountId),
+    model: normalizeOptionalFilterValue(filters.model),
+    endpoint: normalizeOptionalFilterValue(filters.endpoint),
+    sortOrder: filters.sortOrder === 'asc' ? 'asc' : 'desc'
+  })
+}
+
+function flattenMatchedPointers(pointers = []) {
+  const flattened = []
+
+  for (const pointer of pointers) {
+    const requestId = pointer?.requestId || null
+    const timestampMs = Number(pointer?.timestampMs)
+
+    if (!requestId || !Number.isFinite(timestampMs)) {
+      continue
+    }
+
+    flattened.push(requestId, timestampMs)
+  }
+
+  return flattened
+}
+
+function inflateMatchedPointers(flattened = []) {
+  const pointers = []
+
+  for (let index = 0; index < flattened.length; index += 2) {
+    const requestId = flattened[index]
+    const timestampMs = Number(flattened[index + 1])
+
+    if (!requestId || !Number.isFinite(timestampMs)) {
+      continue
+    }
+
+    pointers.push({ requestId, timestampMs })
+  }
+
+  return pointers
 }
 
 class RequestDetailValidationError extends Error {
@@ -337,6 +401,7 @@ class RequestDetailService {
       captureEnabled: settings.captureEnabled,
       retentionHours: settings.retentionHours,
       bodyPreviewEnabled: settings.bodyPreviewEnabled,
+      snapshotId: null,
       records: [],
       pagination: {
         currentPage: 1,
@@ -803,6 +868,322 @@ class RequestDetailService {
     )
   }
 
+  _matchesStructuredFilters(record, filters = {}) {
+    if (filters.apiKeyId && record.apiKeyId !== filters.apiKeyId) {
+      return false
+    }
+    if (filters.accountId && record.accountId !== filters.accountId) {
+      return false
+    }
+    if (filters.model && record.model !== filters.model) {
+      return false
+    }
+    if (filters.endpoint && record.endpoint !== filters.endpoint) {
+      return false
+    }
+
+    return true
+  }
+
+  _buildResponseFilters(filters, effectiveStart, effectiveEnd, sortOrder) {
+    return {
+      startDate: effectiveStart.toISOString(),
+      endDate: effectiveEnd.toISOString(),
+      keyword: filters.keyword || null,
+      apiKeyId: filters.apiKeyId || null,
+      accountId: filters.accountId || null,
+      model: filters.model || null,
+      endpoint: filters.endpoint || null,
+      hasCustomDateRange: Boolean(filters.startDate || filters.endDate),
+      sortOrder
+    }
+  }
+
+  _hydrateRawRecord(rawItem, pointer = {}) {
+    const parsed = restoreRecordTimestamp(
+      safeJsonParse(rawItem),
+      Number(pointer?.timestampMs) || Date.now()
+    )
+
+    if (!parsed) {
+      return null
+    }
+
+    if (!parsed.requestId && pointer?.requestId) {
+      parsed.requestId = pointer.requestId
+    }
+
+    return parsed
+  }
+
+  async _loadPointerBatchRecords(pointerBatch = [], client = redis.getClient()) {
+    if (!client || !Array.isArray(pointerBatch) || pointerBatch.length === 0) {
+      return []
+    }
+
+    const itemKeys = pointerBatch.map(
+      ({ requestId }) => `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
+    )
+    const rawItems = await client.mget(itemKeys)
+    const records = []
+
+    rawItems.forEach((rawItem, index) => {
+      const pointer = pointerBatch[index]
+      const record = this._hydrateRawRecord(rawItem, pointer)
+      if (record) {
+        records.push({ record, pointer })
+      }
+    })
+
+    return records
+  }
+
+  async _loadRecordsForPointers(pointers = [], client = redis.getClient()) {
+    const recordItems = await this._loadPointerBatchRecords(pointers, client)
+    return recordItems.map(({ record }) => record)
+  }
+
+  _paginateMatchedPointers(matchedPointers = [], requestedPage = 1, pageSize = 50) {
+    const totalRecords = matchedPointers.length
+    const totalPages = totalRecords > 0 ? Math.ceil(totalRecords / pageSize) : 0
+    const currentPage = totalPages > 0 ? Math.min(requestedPage, totalPages) : 1
+    const pageStart = (currentPage - 1) * pageSize
+    const pageEnd = pageStart + pageSize
+
+    return {
+      currentPage,
+      totalRecords,
+      totalPages,
+      pagePointers: matchedPointers.slice(pageStart, pageEnd)
+    }
+  }
+
+  async _buildPageRecords(pagePointers = []) {
+    if (!Array.isArray(pagePointers) || pagePointers.length === 0) {
+      return []
+    }
+
+    const rawRecords = await this._loadRecordsForPointers(pagePointers)
+    const enrichedRecords = await this._enrichRecords(rawRecords)
+
+    return enrichedRecords.map((record) => ({
+      ...record,
+      requestBodySnapshot: undefined
+    }))
+  }
+
+  async _buildListQueryData(filters, effectiveStart, effectiveEnd, sortOrder) {
+    const requestPointers = await this._loadRequestPointersInRange(effectiveStart, effectiveEnd)
+    if (requestPointers.length === 0) {
+      return {
+        hasSourceRecords: false,
+        matchedPointers: [],
+        availableFilters: {
+          apiKeys: [],
+          accounts: [],
+          models: [],
+          endpoints: [],
+          dateRange: {
+            earliest: null,
+            latest: null
+          }
+        },
+        summary: finalizeSummary(createSummaryAccumulator())
+      }
+    }
+
+    requestPointers.sort((a, b) =>
+      sortOrder === 'asc' ? a.timestampMs - b.timestampMs : b.timestampMs - a.timestampMs
+    )
+
+    const availableFilterAccumulator = createAvailableFilterAccumulator()
+    const summaryAccumulator = createSummaryAccumulator()
+    const matchedPointers = []
+    const client = redis.getClient()
+    const hasKeyword = Boolean(filters.keyword?.trim())
+
+    if (hasKeyword) {
+      const apiKeyCache = new Map()
+      const accountCache = new Map()
+
+      for (
+        let startIndex = 0;
+        startIndex < requestPointers.length;
+        startIndex += REQUEST_DETAIL_QUERY_BATCH_SIZE
+      ) {
+        const pointerBatch = requestPointers.slice(
+          startIndex,
+          startIndex + REQUEST_DETAIL_QUERY_BATCH_SIZE
+        )
+        const recordItems = await this._loadPointerBatchRecords(pointerBatch, client)
+        const enrichedBatch = await this._enrichRecords(
+          recordItems.map(({ record }) => record),
+          apiKeyCache,
+          accountCache
+        )
+
+        enrichedBatch.forEach((record, index) => {
+          updateAvailableFilterAccumulator(availableFilterAccumulator, record)
+
+          if (
+            !this._matchesStructuredFilters(record, filters) ||
+            !this._matchesKeyword(record, filters.keyword)
+          ) {
+            return
+          }
+
+          updateSummaryAccumulator(summaryAccumulator, record)
+
+          matchedPointers.push({
+            requestId: record.requestId,
+            timestampMs: toMillis(record.timestamp) ?? recordItems[index].pointer.timestampMs
+          })
+        })
+      }
+    } else {
+      for (
+        let startIndex = 0;
+        startIndex < requestPointers.length;
+        startIndex += REQUEST_DETAIL_QUERY_BATCH_SIZE
+      ) {
+        const pointerBatch = requestPointers.slice(
+          startIndex,
+          startIndex + REQUEST_DETAIL_QUERY_BATCH_SIZE
+        )
+        const recordItems = await this._loadPointerBatchRecords(pointerBatch, client)
+
+        for (const { record, pointer } of recordItems) {
+          updateAvailableFilterAccumulatorRaw(availableFilterAccumulator, record)
+
+          if (!this._matchesStructuredFilters(record, filters)) {
+            continue
+          }
+
+          updateSummaryAccumulator(summaryAccumulator, record)
+
+          matchedPointers.push({
+            requestId: record.requestId,
+            timestampMs: toMillis(record.timestamp) ?? pointer.timestampMs
+          })
+        }
+      }
+
+      await this._resolveFilterDisplayNames(availableFilterAccumulator)
+    }
+
+    return {
+      hasSourceRecords: true,
+      matchedPointers,
+      availableFilters: finalizeAvailableFilters(availableFilterAccumulator),
+      summary: finalizeSummary(summaryAccumulator)
+    }
+  }
+
+  async _loadQuerySnapshot(snapshotId, filterSignature, client = redis.getClient()) {
+    if (!snapshotId || !client || typeof client.get !== 'function') {
+      return null
+    }
+
+    const rawSnapshot = await client.get(`${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`)
+    const parsedSnapshot = safeJsonParse(rawSnapshot, 'request detail query snapshot')
+    if (!parsedSnapshot || parsedSnapshot.filterSignature !== filterSignature) {
+      return null
+    }
+
+    if (typeof client.expire === 'function') {
+      await client.expire(
+        `${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`,
+        REQUEST_DETAIL_QUERY_SNAPSHOT_TTL_SECONDS
+      )
+    }
+
+    return {
+      snapshotId,
+      matchedPointers: inflateMatchedPointers(parsedSnapshot.matchedPointers),
+      availableFilters: parsedSnapshot.availableFilters || {
+        apiKeys: [],
+        accounts: [],
+        models: [],
+        endpoints: [],
+        dateRange: {
+          earliest: null,
+          latest: null
+        }
+      },
+      summary: parsedSnapshot.summary || finalizeSummary(createSummaryAccumulator()),
+      filters: parsedSnapshot.filters || null
+    }
+  }
+
+  async _storeQuerySnapshot(filterSignature, queryData, responseFilters, sortOrder) {
+    const client = redis.getClient()
+    if (!client || typeof client.set !== 'function') {
+      return null
+    }
+
+    if (queryData.matchedPointers.length > MAX_REQUEST_DETAIL_SNAPSHOT_POINTERS) {
+      return null
+    }
+
+    const snapshotPayload = {
+      filterSignature,
+      matchedPointers: flattenMatchedPointers(queryData.matchedPointers),
+      summary: queryData.summary,
+      availableFilters: queryData.availableFilters,
+      filters: responseFilters,
+      sortOrder,
+      createdAt: new Date().toISOString()
+    }
+
+    const serializedSnapshot = JSON.stringify(snapshotPayload)
+    if (Buffer.byteLength(serializedSnapshot, 'utf8') > MAX_REQUEST_DETAIL_SNAPSHOT_BYTES) {
+      return null
+    }
+
+    const snapshotId = makeRequestDetailQuerySnapshotId()
+    await client.set(
+      `${REQUEST_DETAIL_QUERY_SNAPSHOT_PREFIX}${snapshotId}`,
+      serializedSnapshot,
+      'EX',
+      REQUEST_DETAIL_QUERY_SNAPSHOT_TTL_SECONDS
+    )
+
+    return snapshotId
+  }
+
+  async _buildListResponse({
+    settings,
+    responseFilters,
+    matchedPointers,
+    availableFilters,
+    summary,
+    page,
+    pageSize,
+    snapshotId = null
+  }) {
+    const pagination = this._paginateMatchedPointers(matchedPointers, page, pageSize)
+    const pageRecords = await this._buildPageRecords(pagination.pagePointers)
+
+    return {
+      captureEnabled: settings.captureEnabled,
+      retentionHours: settings.retentionHours,
+      bodyPreviewEnabled: settings.bodyPreviewEnabled,
+      snapshotId,
+      records: pageRecords,
+      pagination: {
+        currentPage: pagination.currentPage,
+        pageSize,
+        totalRecords: pagination.totalRecords,
+        totalPages: pagination.totalPages,
+        hasNextPage: pagination.totalPages > 0 && pagination.currentPage < pagination.totalPages,
+        hasPreviousPage: pagination.totalPages > 0 && pagination.currentPage > 1
+      },
+      filters: responseFilters,
+      availableFilters,
+      summary
+    }
+  }
+
   async listRequestDetails(filters = {}) {
     const settings = await this.getSettings()
     const emptyResult = this._emptyListResult(settings, filters)
@@ -826,190 +1207,65 @@ class RequestDetailService {
     const page = Math.max(Number.parseInt(filters.page, 10) || 1, 1)
     const pageSize = Math.min(Math.max(Number.parseInt(filters.pageSize, 10) || 50, 1), 200)
     const sortOrder = filters.sortOrder === 'asc' ? 'asc' : 'desc'
+    const responseFilters = this._buildResponseFilters(
+      filters,
+      effectiveStart,
+      effectiveEnd,
+      sortOrder
+    )
+    const filterSignature = createRequestDetailFilterSignature({
+      ...filters,
+      sortOrder
+    })
 
-    const requestPointers = await this._loadRequestPointersInRange(effectiveStart, effectiveEnd)
-    if (requestPointers.length === 0) {
+    const snapshot = await this._loadQuerySnapshot(filters.snapshotId, filterSignature)
+    if (snapshot) {
+      return this._buildListResponse({
+        settings,
+        responseFilters: snapshot.filters || responseFilters,
+        matchedPointers: snapshot.matchedPointers,
+        availableFilters: snapshot.availableFilters,
+        summary: snapshot.summary,
+        page,
+        pageSize,
+        snapshotId: snapshot.snapshotId
+      })
+    }
+
+    const queryData = await this._buildListQueryData(
+      filters,
+      effectiveStart,
+      effectiveEnd,
+      sortOrder
+    )
+    if (!queryData.hasSourceRecords) {
       return {
         ...emptyResult,
         captureEnabled: settings.captureEnabled,
         retentionHours: settings.retentionHours,
         bodyPreviewEnabled: settings.bodyPreviewEnabled,
-        filters: {
-          ...emptyResult.filters,
-          startDate: effectiveStart.toISOString(),
-          endDate: effectiveEnd.toISOString(),
-          hasCustomDateRange: Boolean(filters.startDate || filters.endDate)
-        }
+        snapshotId: null,
+        filters: responseFilters
       }
     }
 
-    requestPointers.sort((a, b) =>
-      sortOrder === 'asc' ? a.timestampMs - b.timestampMs : b.timestampMs - a.timestampMs
+    const snapshotId = await this._storeQuerySnapshot(
+      filterSignature,
+      queryData,
+      responseFilters,
+      sortOrder
     )
 
-    const availableFilterAccumulator = createAvailableFilterAccumulator()
-    const summaryAccumulator = createSummaryAccumulator()
-    const client = redis.getClient()
-    const requestedPageStart = (page - 1) * pageSize
-    const requestedPageEnd = requestedPageStart + pageSize
-    const pageRecords = []
-    let totalRecords = 0
-
-    const hasKeyword = Boolean(filters.keyword?.trim())
-
-    if (hasKeyword) {
-      // keyword 搜索需要 enriched 字段（apiKeyName, accountName），走全量 enrichment 路径
-      const apiKeyCache = new Map()
-      const accountCache = new Map()
-
-      for (
-        let startIndex = 0;
-        startIndex < requestPointers.length;
-        startIndex += REQUEST_DETAIL_QUERY_BATCH_SIZE
-      ) {
-        const pointerBatch = requestPointers.slice(
-          startIndex,
-          startIndex + REQUEST_DETAIL_QUERY_BATCH_SIZE
-        )
-        const itemKeys = pointerBatch.map(
-          ({ requestId }) => `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
-        )
-        const rawItems = await client.mget(itemKeys)
-        const parsedBatch = rawItems
-          .map((rawItem, index) =>
-            restoreRecordTimestamp(safeJsonParse(rawItem), pointerBatch[index].timestampMs)
-          )
-          .filter(Boolean)
-
-        const enrichedBatch = await this._enrichRecords(parsedBatch, apiKeyCache, accountCache)
-
-        for (const record of enrichedBatch) {
-          updateAvailableFilterAccumulator(availableFilterAccumulator, record)
-
-          if (filters.apiKeyId && record.apiKeyId !== filters.apiKeyId) {
-            continue
-          }
-          if (filters.accountId && record.accountId !== filters.accountId) {
-            continue
-          }
-          if (filters.model && record.model !== filters.model) {
-            continue
-          }
-          if (filters.endpoint && record.endpoint !== filters.endpoint) {
-            continue
-          }
-          if (!this._matchesKeyword(record, filters.keyword)) {
-            continue
-          }
-
-          updateSummaryAccumulator(summaryAccumulator, record)
-
-          if (totalRecords >= requestedPageStart && totalRecords < requestedPageEnd) {
-            pageRecords.push({
-              ...record,
-              requestBodySnapshot: undefined
-            })
-          }
-
-          totalRecords += 1
-        }
-      }
-    } else {
-      // 无 keyword：延迟 enrichment，只对当前页记录做 enrichment
-      const pageRawRecords = []
-
-      for (
-        let startIndex = 0;
-        startIndex < requestPointers.length;
-        startIndex += REQUEST_DETAIL_QUERY_BATCH_SIZE
-      ) {
-        const pointerBatch = requestPointers.slice(
-          startIndex,
-          startIndex + REQUEST_DETAIL_QUERY_BATCH_SIZE
-        )
-        const itemKeys = pointerBatch.map(
-          ({ requestId }) => `${REQUEST_DETAIL_ITEM_PREFIX}${requestId}`
-        )
-        const rawItems = await client.mget(itemKeys)
-        const parsedBatch = rawItems
-          .map((rawItem, index) =>
-            restoreRecordTimestamp(safeJsonParse(rawItem), pointerBatch[index].timestampMs)
-          )
-          .filter(Boolean)
-
-        for (const record of parsedBatch) {
-          updateAvailableFilterAccumulatorRaw(availableFilterAccumulator, record)
-
-          if (filters.apiKeyId && record.apiKeyId !== filters.apiKeyId) {
-            continue
-          }
-          if (filters.accountId && record.accountId !== filters.accountId) {
-            continue
-          }
-          if (filters.model && record.model !== filters.model) {
-            continue
-          }
-          if (filters.endpoint && record.endpoint !== filters.endpoint) {
-            continue
-          }
-
-          updateSummaryAccumulator(summaryAccumulator, record)
-
-          if (totalRecords >= requestedPageStart && totalRecords < requestedPageEnd) {
-            pageRawRecords.push(record)
-          }
-
-          totalRecords += 1
-        }
-      }
-
-      const enrichedPageRecords = await this._enrichRecords(pageRawRecords)
-      for (const record of enrichedPageRecords) {
-        pageRecords.push({
-          ...record,
-          requestBodySnapshot: undefined
-        })
-      }
-
-      await this._resolveFilterDisplayNames(availableFilterAccumulator)
-    }
-
-    const totalPages = totalRecords > 0 ? Math.ceil(totalRecords / pageSize) : 0
-    if (totalPages > 0 && page > totalPages) {
-      return this.listRequestDetails({
-        ...filters,
-        page: totalPages,
-        pageSize
-      })
-    }
-
-    return {
-      captureEnabled: settings.captureEnabled,
-      retentionHours: settings.retentionHours,
-      bodyPreviewEnabled: settings.bodyPreviewEnabled,
-      records: pageRecords,
-      pagination: {
-        currentPage: totalPages > 0 ? Math.min(page, totalPages) : 1,
-        pageSize,
-        totalRecords,
-        totalPages,
-        hasNextPage: totalPages > 0 && page < totalPages,
-        hasPreviousPage: totalPages > 0 && page > 1
-      },
-      filters: {
-        startDate: effectiveStart.toISOString(),
-        endDate: effectiveEnd.toISOString(),
-        keyword: filters.keyword || null,
-        apiKeyId: filters.apiKeyId || null,
-        accountId: filters.accountId || null,
-        model: filters.model || null,
-        endpoint: filters.endpoint || null,
-        hasCustomDateRange: Boolean(filters.startDate || filters.endDate),
-        sortOrder
-      },
-      availableFilters: finalizeAvailableFilters(availableFilterAccumulator),
-      summary: finalizeSummary(summaryAccumulator)
-    }
+    return this._buildListResponse({
+      settings,
+      responseFilters,
+      matchedPointers: queryData.matchedPointers,
+      availableFilters: queryData.availableFilters,
+      summary: queryData.summary,
+      page,
+      pageSize,
+      snapshotId
+    })
   }
 
   async getRequestDetail(requestId) {

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -155,17 +155,141 @@ function normalizeOptionalFilterValue(value) {
   return normalized ? normalized : null
 }
 
-function createRequestDetailFilterSignature(filters = {}) {
-  return JSON.stringify({
-    startDate: toIsoString(filters.startDate),
-    endDate: toIsoString(filters.endDate),
+function createRequestDetailDateBoundarySignature(type, rawValue, effectiveValue, boundaryValue) {
+  if (!rawValue) {
+    return {
+      mode: 'absent',
+      value: null
+    }
+  }
+
+  const rawDate = rawValue instanceof Date ? rawValue : new Date(rawValue)
+  const effectiveIso = toIsoString(effectiveValue)
+  if (type === 'start') {
+    const floorDate =
+      boundaryValue instanceof Date ? boundaryValue : new Date(boundaryValue || Date.now())
+    if (rawDate.getTime() <= floorDate.getTime()) {
+      return {
+        mode: 'retention_floor',
+        value: effectiveIso
+      }
+    }
+  }
+
+  if (type === 'end') {
+    const ceilingDate =
+      boundaryValue instanceof Date ? boundaryValue : new Date(boundaryValue || Date.now())
+    if (rawDate.getTime() >= ceilingDate.getTime()) {
+      return {
+        mode: 'now_cap',
+        value: effectiveIso
+      }
+    }
+  }
+
+  return {
+    mode: 'fixed',
+    value: rawDate.toISOString()
+  }
+}
+
+function normalizeRequestDetailDateBoundarySignature(boundary = {}, legacyValue = null) {
+  if (!boundary || typeof boundary !== 'object' || Array.isArray(boundary)) {
+    return {
+      mode: legacyValue ? 'fixed' : 'absent',
+      value: toIsoString(legacyValue)
+    }
+  }
+
+  const allowedModes = new Set(['absent', 'fixed', 'retention_floor', 'now_cap'])
+  const mode = allowedModes.has(boundary.mode) ? boundary.mode : legacyValue ? 'fixed' : 'absent'
+  return {
+    mode,
+    value: toIsoString(boundary.value)
+  }
+}
+
+function createRequestDetailFilterSignature(
+  filters = {},
+  dateBoundarySignature = {},
+  retentionHours = null
+) {
+  return {
     keyword: normalizeOptionalFilterValue(filters.keyword),
     apiKeyId: normalizeOptionalFilterValue(filters.apiKeyId),
     accountId: normalizeOptionalFilterValue(filters.accountId),
     model: normalizeOptionalFilterValue(filters.model),
     endpoint: normalizeOptionalFilterValue(filters.endpoint),
-    sortOrder: filters.sortOrder === 'asc' ? 'asc' : 'desc'
-  })
+    sortOrder: filters.sortOrder === 'asc' ? 'asc' : 'desc',
+    retentionHours:
+      retentionHours !== null && retentionHours !== undefined ? Number(retentionHours) : null,
+    startBoundary: normalizeRequestDetailDateBoundarySignature(dateBoundarySignature.startBoundary),
+    endBoundary: normalizeRequestDetailDateBoundarySignature(dateBoundarySignature.endBoundary)
+  }
+}
+
+function requestDetailDateBoundarySignaturesMatch(snapshotBoundary, currentBoundary, type) {
+  if (snapshotBoundary.mode === currentBoundary.mode) {
+    if (snapshotBoundary.mode === 'fixed') {
+      return snapshotBoundary.value === currentBoundary.value
+    }
+    return true
+  }
+
+  if (type === 'end') {
+    return (
+      snapshotBoundary.mode === 'now_cap' &&
+      currentBoundary.mode === 'fixed' &&
+      snapshotBoundary.value === currentBoundary.value
+    )
+  }
+
+  return false
+}
+
+function requestDetailFilterSignaturesMatch(snapshotSignature, currentSignature) {
+  const normalizedSnapshot = createRequestDetailFilterSignature(
+    snapshotSignature,
+    {
+      startBoundary: snapshotSignature?.startBoundary || {
+        mode: snapshotSignature?.startDate ? 'fixed' : 'absent',
+        value: snapshotSignature?.startDate || null
+      },
+      endBoundary: snapshotSignature?.endBoundary || {
+        mode: snapshotSignature?.endDate ? 'fixed' : 'absent',
+        value: snapshotSignature?.endDate || null
+      }
+    },
+    snapshotSignature?.retentionHours
+  )
+  const normalizedCurrent = createRequestDetailFilterSignature(
+    currentSignature,
+    {
+      startBoundary: currentSignature?.startBoundary,
+      endBoundary: currentSignature?.endBoundary
+    },
+    currentSignature?.retentionHours
+  )
+
+  return (
+    normalizedSnapshot.keyword === normalizedCurrent.keyword &&
+    normalizedSnapshot.apiKeyId === normalizedCurrent.apiKeyId &&
+    normalizedSnapshot.accountId === normalizedCurrent.accountId &&
+    normalizedSnapshot.model === normalizedCurrent.model &&
+    normalizedSnapshot.endpoint === normalizedCurrent.endpoint &&
+    normalizedSnapshot.sortOrder === normalizedCurrent.sortOrder &&
+    normalizedSnapshot.retentionHours === normalizedCurrent.retentionHours &&
+    requestDetailDateBoundarySignaturesMatch(
+      normalizedSnapshot.startBoundary,
+      normalizedCurrent.startBoundary,
+      'start'
+    ) &&
+    requestDetailDateBoundarySignaturesMatch(
+      normalizedSnapshot.endBoundary,
+      normalizedCurrent.endBoundary,
+      'end'
+    )
+  )
 }
 
 function flattenMatchedPointers(pointers = []) {
@@ -1093,7 +1217,10 @@ class RequestDetailService {
     }
 
     const parsedSnapshot = safeJsonParse(rawSnapshot, 'request detail query snapshot')
-    if (!parsedSnapshot || parsedSnapshot.filterSignature !== filterSignature) {
+    if (
+      !parsedSnapshot ||
+      !requestDetailFilterSignaturesMatch(parsedSnapshot.filterSignature, filterSignature)
+    ) {
       return null
     }
 
@@ -1201,6 +1328,13 @@ class RequestDetailService {
   }
 
   async listRequestDetails(filters = {}) {
+    filters = {
+      ...filters,
+      apiKeyId: normalizeOptionalFilterValue(filters.apiKeyId),
+      accountId: normalizeOptionalFilterValue(filters.accountId),
+      model: normalizeOptionalFilterValue(filters.model),
+      endpoint: normalizeOptionalFilterValue(filters.endpoint)
+    }
     const settings = await this.getSettings()
     const emptyResult = this._emptyListResult(settings, filters)
 
@@ -1229,12 +1363,24 @@ class RequestDetailService {
       effectiveEnd,
       sortOrder
     )
-    const filterSignature = createRequestDetailFilterSignature({
-      ...filters,
-      startDate: effectiveStart.toISOString(),
-      endDate: effectiveEnd.toISOString(),
-      sortOrder
-    })
+    const filterSignature = createRequestDetailFilterSignature(
+      filters,
+      {
+        startBoundary: createRequestDetailDateBoundarySignature(
+          'start',
+          filters.startDate,
+          effectiveStart,
+          retentionStart
+        ),
+        endBoundary: createRequestDetailDateBoundarySignature(
+          'end',
+          filters.endDate,
+          effectiveEnd,
+          now
+        )
+      },
+      settings.retentionHours
+    )
 
     const snapshot = await this._loadQuerySnapshot(filters.snapshotId, filterSignature)
     if (snapshot) {

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -681,35 +681,33 @@ describe('requestDetailService', () => {
     redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
     openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
 
-    const records = []
+    const recordsByKey = {}
     const pointerEntries = []
     for (let i = 0; i < 5; i++) {
       const ts = 1775563200000 + i * 3600000
       pointerEntries.push(`req_${i}`, String(ts))
-      records.push(
-        JSON.stringify({
-          requestId: `req_${i}`,
-          timestamp: new Date(ts).toISOString(),
-          endpoint: '/openai/v1/responses',
-          method: 'POST',
-          apiKeyId: 'key_1',
-          accountId: 'acct_1',
-          accountType: 'openai',
-          model: 'gpt-5.4',
-          inputTokens: 100,
-          outputTokens: 50,
-          cacheReadTokens: 0,
-          cacheCreateTokens: 0,
-          totalTokens: 150,
-          cost: 0.5,
-          durationMs: 1200
-        })
-      )
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 0,
+        cacheCreateTokens: 0,
+        totalTokens: 150,
+        cost: 0.5,
+        durationMs: 1200
+      })
     }
 
     redis.getClient.mockReturnValue({
       zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
-      mget: jest.fn().mockResolvedValue(records)
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null))
     })
 
     const result = await requestDetailService.listRequestDetails({
@@ -725,6 +723,330 @@ describe('requestDetailService', () => {
     expect(result.records[0].accountName).toBe('OpenAI Main')
     expect(result.availableFilters.models).toEqual(['gpt-5.4'])
     expect(result.summary.totalRequests).toBe(5)
+  })
+
+  test('listRequestDetails creates a snapshot and reuses it across pages', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 4; i++) {
+      const ts = 1775563200000 + i * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        cost: 0.5,
+        durationMs: 1200
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const firstPage = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-08T23:59:59.000Z',
+      pageSize: 2,
+      page: 1
+    })
+
+    expect(firstPage.snapshotId).toBeTruthy()
+    expect(firstPage.records.map((record) => record.requestId)).toEqual(['req_3', 'req_2'])
+    expect(client.set).toHaveBeenCalledWith(
+      expect.stringMatching(/^request_detail:query_snapshot:/),
+      expect.any(String),
+      'EX',
+      30
+    )
+
+    const secondPage = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-08T23:59:59.000Z',
+      pageSize: 2,
+      page: 2,
+      snapshotId: firstPage.snapshotId
+    })
+
+    expect(secondPage.snapshotId).toBe(firstPage.snapshotId)
+    expect(secondPage.records.map((record) => record.requestId)).toEqual(['req_1', 'req_0'])
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
+    expect(client.get).toHaveBeenCalledWith(
+      `request_detail:query_snapshot:${firstPage.snapshotId}`
+    )
+    expect(client.expire).toHaveBeenCalledWith(
+      `request_detail:query_snapshot:${firstPage.snapshotId}`,
+      30
+    )
+  })
+
+  test('listRequestDetails rebuilds the snapshot when filters change', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockImplementation(async (keyId) => ({ name: `Key ${keyId}` }))
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const recordsByKey = {
+      'request_detail:item:req_1': JSON.stringify({
+        requestId: 'req_1',
+        timestamp: '2026-04-07T12:00:00.000Z',
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cost: 0.1,
+        durationMs: 400
+      }),
+      'request_detail:item:req_2': JSON.stringify({
+        requestId: 'req_2',
+        timestamp: '2026-04-07T13:00:00.000Z',
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_2',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 20,
+        outputTokens: 5,
+        totalTokens: 25,
+        cost: 0.2,
+        durationMs: 500
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest
+        .fn()
+        .mockResolvedValue(['req_1', '1775563200000', 'req_2', '1775566800000']),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const firstQuery = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z',
+      apiKeyId: 'key_1'
+    })
+
+    const secondQuery = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z',
+      apiKeyId: 'key_2',
+      snapshotId: firstQuery.snapshotId
+    })
+
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(2)
+    expect(secondQuery.records).toHaveLength(1)
+    expect(secondQuery.records[0].apiKeyId).toBe('key_2')
+    expect(secondQuery.snapshotId).toBeTruthy()
+    expect(secondQuery.snapshotId).not.toBe(firstQuery.snapshotId)
+  })
+
+  test('listRequestDetails skips snapshot creation when result count exceeds the limit', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    const client = {
+      set: jest.fn()
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const buildQuerySpy = jest
+      .spyOn(requestDetailService, '_buildListQueryData')
+      .mockResolvedValue({
+        hasSourceRecords: true,
+        matchedPointers: Array.from({ length: 25001 }, (_, index) => ({
+          requestId: `req_${index}`,
+          timestampMs: 1775563200000 + index
+        })),
+        availableFilters: {
+          apiKeys: [],
+          accounts: [],
+          models: [],
+          endpoints: [],
+          dateRange: {
+            earliest: null,
+            latest: null
+          }
+        },
+        summary: {
+          totalRequests: 25001,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          totalCost: 0,
+          avgDurationMs: 0,
+          cacheHitRate: 0,
+          cacheCreateNotApplicable: false
+        }
+      })
+    const buildPageSpy = jest.spyOn(requestDetailService, '_buildPageRecords').mockResolvedValue([])
+
+    try {
+      const result = await requestDetailService.listRequestDetails({
+        startDate: '2026-04-07T00:00:00.000Z',
+        endDate: '2026-04-07T23:59:59.000Z'
+      })
+
+      expect(result.snapshotId).toBeNull()
+      expect(client.set).not.toHaveBeenCalled()
+    } finally {
+      buildQuerySpy.mockRestore()
+      buildPageSpy.mockRestore()
+    }
+  })
+
+  test('listRequestDetails skips snapshot creation when payload size exceeds the limit', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    const client = {
+      set: jest.fn()
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const buildQuerySpy = jest
+      .spyOn(requestDetailService, '_buildListQueryData')
+      .mockResolvedValue({
+        hasSourceRecords: true,
+        matchedPointers: [{ requestId: 'req_1', timestampMs: 1775563200000 }],
+        availableFilters: {
+          apiKeys: [],
+          accounts: [],
+          models: [`model_${'x'.repeat(2 * 1024 * 1024)}`],
+          endpoints: [],
+          dateRange: {
+            earliest: null,
+            latest: null
+          }
+        },
+        summary: {
+          totalRequests: 1,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          totalCost: 0,
+          avgDurationMs: 0,
+          cacheHitRate: 0,
+          cacheCreateNotApplicable: false
+        }
+      })
+    const buildPageSpy = jest.spyOn(requestDetailService, '_buildPageRecords').mockResolvedValue([])
+
+    try {
+      const result = await requestDetailService.listRequestDetails({
+        startDate: '2026-04-07T00:00:00.000Z',
+        endDate: '2026-04-07T23:59:59.000Z'
+      })
+
+      expect(result.snapshotId).toBeNull()
+      expect(client.set).not.toHaveBeenCalled()
+    } finally {
+      buildQuerySpy.mockRestore()
+      buildPageSpy.mockRestore()
+    }
+  })
+
+  test('listRequestDetails clamps out-of-range pages without rerunning the full query', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 3; i++) {
+      const ts = 1775563200000 + i * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cost: 0.1,
+        durationMs: 400
+      })
+    }
+
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn().mockResolvedValue('OK')
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-08T23:59:59.000Z',
+      pageSize: 2,
+      page: 9
+    })
+
+    expect(result.pagination.currentPage).toBe(2)
+    expect(result.pagination.totalPages).toBe(2)
+    expect(result.records.map((record) => record.requestId)).toEqual(['req_0'])
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
   })
 
   test('listRequestDetails backfills invalid timestamps from day-index scores', async () => {

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -882,6 +882,328 @@ describe('requestDetailService', () => {
     expect(secondQuery.snapshotId).not.toBe(firstQuery.snapshotId)
   })
 
+  test('listRequestDetails rejects stale snapshot when explicit date range changes', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'Acct' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 2; i++) {
+      const ts = Date.now() - (1 - i) * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/v1/messages',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'claude',
+        model: 'claude-sonnet-4-20250514',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cost: 0.1,
+        durationMs: 300
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const now = Date.now()
+    const rangeA = {
+      startDate: new Date(now - 5 * 3600000).toISOString(),
+      endDate: new Date(now - 3 * 3600000).toISOString()
+    }
+    const rangeB = {
+      startDate: new Date(now - 2 * 3600000).toISOString(),
+      endDate: new Date(now - 1 * 3600000).toISOString()
+    }
+
+    const firstQuery = await requestDetailService.listRequestDetails(rangeA)
+
+    expect(firstQuery.snapshotId).toBeTruthy()
+
+    // Same non-date filters, different date range, stale snapshotId —
+    // must NOT reuse the old snapshot.
+    const secondQuery = await requestDetailService.listRequestDetails({
+      ...rangeB,
+      snapshotId: firstQuery.snapshotId
+    })
+
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(2)
+    expect(secondQuery.snapshotId).toBeTruthy()
+    expect(secondQuery.snapshotId).not.toBe(firstQuery.snapshotId)
+  })
+
+  test('listRequestDetails reuses snapshot for startDate-only queries after time advances', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'Acct' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 2; i++) {
+      const ts = Date.now() - (1 - i) * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/v1/messages',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'claude',
+        model: 'claude-sonnet-4-20250514',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cost: 0.1,
+        durationMs: 300
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    // Only startDate, no endDate — the start is clipped to retentionStart
+    // and would drift without moving-boundary-aware snapshot matching.
+    const startOnly = {
+      startDate: '2020-01-01T00:00:00.000Z',
+      pageSize: 1
+    }
+
+    const firstQuery = await requestDetailService.listRequestDetails(startOnly)
+    expect(firstQuery.snapshotId).toBeTruthy()
+
+    jest.advanceTimersByTime(10000)
+
+    // Page 2 with the same startDate-only filter after time advances —
+    // the snapshot should still be reused.
+    const secondQuery = await requestDetailService.listRequestDetails({
+      ...startOnly,
+      snapshotId: firstQuery.snapshotId,
+      page: 2
+    })
+
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
+    expect(secondQuery.snapshotId).toBe(firstQuery.snapshotId)
+  })
+
+  test('listRequestDetails reuses snapshot for endDate-only future queries after time advances', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'Acct' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 2; i++) {
+      const ts = Date.now() - (1 - i) * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/v1/messages',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'claude',
+        model: 'claude-sonnet-4-20250514',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cost: 0.1,
+        durationMs: 300
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const endOnly = {
+      endDate: new Date(Date.now() + 3600000).toISOString(),
+      pageSize: 1
+    }
+
+    const firstQuery = await requestDetailService.listRequestDetails(endOnly)
+    expect(firstQuery.snapshotId).toBeTruthy()
+
+    jest.advanceTimersByTime(10000)
+
+    const secondQuery = await requestDetailService.listRequestDetails({
+      ...endOnly,
+      snapshotId: firstQuery.snapshotId,
+      page: 2
+    })
+
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
+    expect(secondQuery.snapshotId).toBe(firstQuery.snapshotId)
+  })
+
+  test('listRequestDetails invalidates snapshot when retentionHours changes', async () => {
+    const makeConfig = (hours) => ({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: hours,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    claudeRelayConfigService.getConfig.mockResolvedValue(makeConfig(6))
+
+    redis.getApiKey.mockResolvedValue({ name: 'Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'Acct' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 4; i++) {
+      const ts = Date.now() - (3 - i) * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/v1/messages',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'claude',
+        model: 'claude-sonnet-4-20250514',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cost: 0.1,
+        durationMs: 300
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    // Page 1 with retentionHours=6
+    const firstQuery = await requestDetailService.listRequestDetails({
+      pageSize: 2,
+      page: 1
+    })
+    expect(firstQuery.snapshotId).toBeTruthy()
+
+    // Admin changes retention from 6 to 2 while snapshot is alive
+    claudeRelayConfigService.getConfig.mockResolvedValue(makeConfig(2))
+
+    // Page 2 with stale snapshotId — must NOT reuse old snapshot
+    const secondQuery = await requestDetailService.listRequestDetails({
+      pageSize: 2,
+      page: 2,
+      snapshotId: firstQuery.snapshotId
+    })
+
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(2)
+    expect(secondQuery.snapshotId).not.toBe(firstQuery.snapshotId)
+  })
+
+  test('listRequestDetails normalizes whitespace in structured filter values', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'Acct' })
+
+    const ts = Date.now() - 3600000
+    const pointerEntries = ['req_0', String(ts)]
+    const recordsByKey = {
+      'request_detail:item:req_0': JSON.stringify({
+        requestId: 'req_0',
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/v1/messages',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'claude',
+        model: 'claude-sonnet-4-20250514',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cost: 0.1,
+        durationMs: 300
+      })
+    }
+
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn().mockResolvedValue('OK'),
+      get: jest.fn().mockResolvedValue(null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    // Filter with leading/trailing whitespace must still match records
+    const result = await requestDetailService.listRequestDetails({
+      apiKeyId: '  key_1  '
+    })
+
+    expect(result.pagination.totalRecords).toBe(1)
+    expect(result.records).toHaveLength(1)
+    expect(result.filters.apiKeyId).toBe('key_1')
+  })
+
   test('listRequestDetails skips snapshot creation when result count exceeds the limit', async () => {
     claudeRelayConfigService.getConfig.mockResolvedValue({
       requestDetailCaptureEnabled: true,
@@ -1216,6 +1538,8 @@ describe('requestDetailService', () => {
     // The response echoes back the trimmed start date
     const trimmedStart = firstPage.filters.startDate
 
+    jest.advanceTimersByTime(10000)
+
     // Second request uses trimmed dates (as the frontend would after syncResponseState)
     const secondPage = await requestDetailService.listRequestDetails({
       startDate: trimmedStart,
@@ -1227,6 +1551,74 @@ describe('requestDetailService', () => {
 
     expect(secondPage.snapshotId).toBe(firstPage.snapshotId)
     // Full query should run only once
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
+  })
+
+  test('listRequestDetails reuses snapshot for default time window without explicit dates', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 4; i++) {
+      const ts = Date.now() - (3 - i) * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        cost: 0.5,
+        durationMs: 1200
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    // First page — no startDate / endDate (default rolling window)
+    const firstPage = await requestDetailService.listRequestDetails({
+      pageSize: 2,
+      page: 1
+    })
+
+    expect(firstPage.snapshotId).toBeTruthy()
+
+    jest.advanceTimersByTime(10000)
+
+    // Second page — still no dates, only snapshotId; the server's new Date()
+    // will produce different effective timestamps, but the snapshot should
+    // still be reused because dates are excluded from the filter signature.
+    const secondPage = await requestDetailService.listRequestDetails({
+      pageSize: 2,
+      page: 2,
+      snapshotId: firstPage.snapshotId
+    })
+
+    expect(secondPage.snapshotId).toBe(firstPage.snapshotId)
     expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -797,9 +797,7 @@ describe('requestDetailService', () => {
     expect(secondPage.snapshotId).toBe(firstPage.snapshotId)
     expect(secondPage.records.map((record) => record.requestId)).toEqual(['req_1', 'req_0'])
     expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
-    expect(client.get).toHaveBeenCalledWith(
-      `request_detail:query_snapshot:${firstPage.snapshotId}`
-    )
+    expect(client.get).toHaveBeenCalledWith(`request_detail:query_snapshot:${firstPage.snapshotId}`)
     expect(client.expire).toHaveBeenCalledWith(
       `request_detail:query_snapshot:${firstPage.snapshotId}`,
       30
@@ -995,6 +993,241 @@ describe('requestDetailService', () => {
       buildQuerySpy.mockRestore()
       buildPageSpy.mockRestore()
     }
+  })
+
+  test('listRequestDetails degrades gracefully when snapshot write fails', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const ts = 1775563200000
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(['req_1', String(ts)]),
+      mget: jest.fn().mockResolvedValue([
+        JSON.stringify({
+          requestId: 'req_1',
+          timestamp: new Date(ts).toISOString(),
+          endpoint: '/openai/v1/responses',
+          method: 'POST',
+          apiKeyId: 'key_1',
+          accountId: 'acct_1',
+          accountType: 'openai',
+          model: 'gpt-5.4',
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+          cost: 0.1,
+          durationMs: 400
+        })
+      ]),
+      set: jest.fn().mockRejectedValue(new Error('READONLY'))
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+
+    expect(result.snapshotId).toBeNull()
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].requestId).toBe('req_1')
+  })
+
+  test('listRequestDetails falls back to full query when snapshot read fails', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 3; i++) {
+      const ts = 1775563200000 + i * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cost: 0.1,
+        durationMs: 400
+      })
+    }
+
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      get: jest.fn().mockRejectedValue(new Error('ETIMEDOUT')),
+      set: jest.fn().mockResolvedValue('OK')
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-08T23:59:59.000Z',
+      snapshotId: 'rds_stale_id'
+    })
+
+    expect(result.records).toHaveLength(3)
+    expect(client.get).toHaveBeenCalledWith('request_detail:query_snapshot:rds_stale_id')
+    // Falls back to full query, so zrangebyscore must have been called
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
+  })
+
+  test('listRequestDetails still returns snapshot data when TTL renewal fails', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 4; i++) {
+      const ts = 1775563200000 + i * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        cost: 0.5,
+        durationMs: 1200
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockRejectedValue(new Error('NOPERM'))
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const firstPage = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-08T23:59:59.000Z',
+      pageSize: 2,
+      page: 1
+    })
+
+    expect(firstPage.snapshotId).toBeTruthy()
+
+    const secondPage = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-08T23:59:59.000Z',
+      pageSize: 2,
+      page: 2,
+      snapshotId: firstPage.snapshotId
+    })
+
+    expect(secondPage.snapshotId).toBe(firstPage.snapshotId)
+    expect(secondPage.records.map((record) => record.requestId)).toEqual(['req_1', 'req_0'])
+    // Snapshot was reused despite expire failure — no full re-query
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
+  })
+
+  test('listRequestDetails reuses snapshot after time-window trimming', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Primary Key' })
+    openaiAccountService.getAccount.mockResolvedValue({ name: 'OpenAI Main' })
+
+    const recordsByKey = {}
+    const pointerEntries = []
+    for (let i = 0; i < 4; i++) {
+      const ts = 1775563200000 + i * 3600000
+      pointerEntries.push(`req_${i}`, String(ts))
+      recordsByKey[`request_detail:item:req_${i}`] = JSON.stringify({
+        requestId: `req_${i}`,
+        timestamp: new Date(ts).toISOString(),
+        endpoint: '/openai/v1/responses',
+        method: 'POST',
+        apiKeyId: 'key_1',
+        accountId: 'acct_1',
+        accountType: 'openai',
+        model: 'gpt-5.4',
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        cost: 0.5,
+        durationMs: 1200
+      })
+    }
+
+    const snapshots = new Map()
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(pointerEntries),
+      mget: jest.fn(async (keys) => keys.map((key) => recordsByKey[key] || null)),
+      set: jest.fn(async (key, value) => {
+        snapshots.set(key, value)
+        return 'OK'
+      }),
+      get: jest.fn(async (key) => snapshots.get(key) || null),
+      expire: jest.fn().mockResolvedValue(1)
+    }
+    redis.getClient.mockReturnValue(client)
+
+    // First request with startDate far before retention window — will be trimmed
+    const firstPage = await requestDetailService.listRequestDetails({
+      startDate: '2020-01-01T00:00:00.000Z',
+      endDate: '2026-04-08T23:59:59.000Z',
+      pageSize: 2,
+      page: 1
+    })
+
+    expect(firstPage.snapshotId).toBeTruthy()
+    // The response echoes back the trimmed start date
+    const trimmedStart = firstPage.filters.startDate
+
+    // Second request uses trimmed dates (as the frontend would after syncResponseState)
+    const secondPage = await requestDetailService.listRequestDetails({
+      startDate: trimmedStart,
+      endDate: firstPage.filters.endDate,
+      pageSize: 2,
+      page: 2,
+      snapshotId: firstPage.snapshotId
+    })
+
+    expect(secondPage.snapshotId).toBe(firstPage.snapshotId)
+    // Full query should run only once
+    expect(client.zrangebyscore).toHaveBeenCalledTimes(1)
   })
 
   test('listRequestDetails clamps out-of-range pages without rerunning the full query', async () => {

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -750,6 +750,7 @@ const syncResponseState = (data) => {
       nextRange.every(Boolean) &&
       !areDateRangesEqual(filters.dateRange || [], nextRange)
     ) {
+      suppressDateRangeWatch = true
       filters.dateRange = nextRange
     }
   }
@@ -770,6 +771,8 @@ const syncResponseState = (data) => {
   summary.cacheHitRate = summaryData.cacheHitRate || 0
   summary.cacheCreateNotApplicable = summaryData.cacheCreateNotApplicable === true
 }
+
+let suppressDateRangeWatch = false
 
 const invalidateSnapshot = () => {
   activeSnapshotId.value = null
@@ -1026,6 +1029,10 @@ watch(
 watch(
   () => filters.dateRange,
   () => {
+    if (suppressDateRangeWatch) {
+      suppressDateRangeWatch = false
+      return
+    }
     pagination.currentPage = 1
     invalidateSnapshot()
     fetchRecords(1)

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -604,6 +604,7 @@ const exporting = ref(false)
 const requestDetailBodyPreviewPurging = ref(false)
 const detailVisible = ref(false)
 const activeRequestId = ref('')
+const activeSnapshotId = ref(null)
 const captureEnabled = ref(false)
 const retentionHours = ref(6)
 const bodyPreviewEnabled = ref(false)
@@ -695,7 +696,7 @@ const areDateRangesEqual = (currentRange = [], nextRange = []) => {
   )
 }
 
-const buildParams = (page) => {
+const buildParams = (page, snapshotId = activeSnapshotId.value) => {
   const params = {
     page,
     pageSize: pagination.pageSize,
@@ -718,6 +719,8 @@ const buildParams = (page) => {
     }
   }
 
+  if (snapshotId) params.snapshotId = snapshotId
+
   return params
 }
 
@@ -725,6 +728,7 @@ const syncResponseState = (data) => {
   captureEnabled.value = data.captureEnabled === true
   retentionHours.value = data.retentionHours || 6
   bodyPreviewEnabled.value = data.bodyPreviewEnabled === true
+  activeSnapshotId.value = data.snapshotId || null
   records.value = data.records || []
 
   const pageInfo = data.pagination || {}
@@ -767,6 +771,10 @@ const syncResponseState = (data) => {
   summary.cacheCreateNotApplicable = summaryData.cacheCreateNotApplicable === true
 }
 
+const invalidateSnapshot = () => {
+  activeSnapshotId.value = null
+}
+
 const fetchRecords = async (page = pagination.currentPage) => {
   debouncedKeywordFetch.cancel()
   const version = ++fetchVersion
@@ -801,10 +809,12 @@ const handleSizeChange = (size) => {
 }
 
 const refreshRecords = () => {
+  invalidateSnapshot()
   fetchRecords(pagination.currentPage)
 }
 
 const resetFilters = () => {
+  invalidateSnapshot()
   filters.dateRange = null
   filters.keyword = ''
   filters.apiKeyId = ''
@@ -876,14 +886,16 @@ const exportCsv = async () => {
     let page = 1
     let totalPages = 1
     let totalRecords = 0
+    let snapshotId = activeSnapshotId.value
     const maxPages = 100
 
     while (page <= totalPages && page <= maxPages) {
       const response = await getRequestDetailsApi({
-        ...buildParams(page),
+        ...buildParams(page, snapshotId),
         pageSize: 200
       })
       const payload = response.data || {}
+      snapshotId = payload.snapshotId || null
       aggregated.push(...(payload.records || []))
       totalPages = payload.pagination?.totalPages || 1
       if (page === 1) {
@@ -990,6 +1002,7 @@ const formatReasoning = (value) => value || '-'
 
 const debouncedKeywordFetch = debounce(() => {
   pagination.currentPage = 1
+  invalidateSnapshot()
   fetchRecords(1)
 }, 300)
 
@@ -1005,6 +1018,7 @@ watch(
   () => {
     debouncedKeywordFetch.cancel()
     pagination.currentPage = 1
+    invalidateSnapshot()
     fetchRecords(1)
   }
 )
@@ -1013,6 +1027,7 @@ watch(
   () => filters.dateRange,
   () => {
     pagination.currentPage = 1
+    invalidateSnapshot()
     fetchRecords(1)
   },
   { deep: true }


### PR DESCRIPTION
## Summary

This PR adds short-lived query snapshots for Request Details so pagination and CSV export can reuse a previously computed match set instead of rescanning the full retention window on every follow-up request.
这个 PR 为 Request Details （请求明细页） 新增了 query snapshot。这样分页和 CSV 导出可以复用已经算好的匹配结果，后续请求不需要每次都重新扫描整个 retention window，从而降低性能压力。

It also hardens snapshot matching around date boundaries, retention changes, and normalized structured filters, and updates the admin page to keep snapshot state in sync without triggering duplicate reloads.
这次也加强了 snapshot 的匹配规则，覆盖日期边界、retention 配置变化、结构化筛选值归一化等场景，并更新了管理端页面的状态同步逻辑，避免同步服务端返回值时触发重复加载。

## Why

Request Details previously rebuilt the full query result on every page change, which became expensive for larger retention windows and made pagination and export noisier than necessary.
此前 Request Details 在每次翻页时都会重新构建整套查询结果。retention window 变大后，容易导致CPU负载增加，分页和导出的体验也会变得更差。

After introducing snapshot reuse, we also needed stricter matching rules so stale snapshots would not be reused after the effective query semantics changed.
引入 snapshot 复用后，还需要更严格的匹配规则。这样当查询语义已经变化时，旧 snapshot 不会错误地继续被复用。

## Changes

### Backend

- Added Redis-backed request detail query snapshots with a 30-second TTL so matched pointer sets can be reused across pagination and export. 新增基于 Redis 的 request detail query snapshot，TTL 为 30 秒，用来在分页和导出之间复用匹配到的指针集合。
- Refactored `listRequestDetails` to separate full-query building, snapshot load/store, page slicing, and page record hydration/enrichment. 重构了 `listRequestDetails`，把全量查询构建、snapshot 读写、分页切片、页面记录 hydrate/enrich 拆开。
- Added snapshot size guards to skip snapshot creation when the pointer count or serialized payload is too large. 增加了 snapshot 大小保护。当指针数量过多或序列化后的 payload 过大时，会直接跳过 snapshot 创建。
- Added graceful fallback paths when snapshot read, write, or TTL renewal fails. 增加了 snapshot 读失败、写失败、TTL 续期失败时的降级路径，接口仍然可以返回结果。
- Introduced normalized filter signatures for `keyword`, `apiKeyId`, `accountId`, `model`, `endpoint`, `sortOrder`, `retentionHours`, and date boundary modes. 引入了归一化后的 filter signature，覆盖 `keyword`, `apiKeyId`, `accountId`, `model`, `endpoint`, `sortOrder`, `retentionHours` 以及日期边界模式。
- Added date-boundary-aware snapshot matching so default rolling windows and server-trimmed ranges can still reuse the
  same snapshot, while truly changed explicit ranges invalidate it. 增加了基于日期边界语义的 snapshot 匹配逻辑。默认滚动时间窗和服务端裁剪后的日期范围仍可复用同一个 snapshot；显式日期范围变化时失效。
- Invalidated stale snapshots when `retentionHours` changes. 当 `retentionHours` 变化时，旧 snapshot 会被判定为失效。
- Normalized whitespace in structured filter values before matching and signature generation. 在结构化筛选值参与匹配和 signature 生成前，先做首尾空白归一化。
- Expanded regression coverage for pagination reuse, explicit date changes, start-only and end-only ranges, default rolling windows, retention changes, whitespace-normalized filters, oversize snapshot protection, snapshot failure fallback, TTL renewal failure, and out-of-range page clamping. 补充了回归测试，覆盖分页复用、显式日期变化、仅 startDate、仅 endDate、默认滚动时间窗、retention 变化、带空白的结构化筛选、超大 snapshot 保护、snapshot 失败降级、TTL 续期失败、超范围页码裁剪等场景。

### Frontend

- Added `snapshotId` state to `RequestDetailsView` and passed it through pagination and CSV export requests. 在 `RequestDetailsView` 中新增了 `snapshotId` 状态，并在分页和 CSV 导出请求里持续透传。
- Invalidated the active snapshot when filters change, including refresh, reset, keyword changes, and date-range changes. 当筛选条件变化时，会主动清空当前 snapshot，包括 refresh、reset、关键词变化和日期范围变化等场景。
- Prevented duplicate reloads when the UI syncs server-normalized date ranges back into the form. 当页面把服务端规范化后的日期范围同步回表单时，避免再次触发重复加载。
- Kept pagination and export aligned with the server-returned snapshot so follow-up requests can reuse the same matched result set.让分页和导出都跟随服务端返回的 snapshot，使后续请求可以持续复用同一份匹配结果。

## API / Behavior Notes

Request detail list responses now include an optional `snapshotId`, and follow-up page or export requests can send that `snapshotId` back to reuse the cached match set.
Request detail 列表接口现在会返回可选的 `snapshotId`。后续分页或导出请求可以把这个 `snapshotId` 带回，复用缓存的匹配结果集合。

If the snapshot is missing, expired, too large to cache, or fails to load, the API falls back to the existing full-query path.
如果 snapshot 缺失、过期、体积过大无法缓存，或者加载失败，接口会回退到原来的全量查询路径。

## Validation

- `cd web/admin-spa && npx prettier --check src/views/RequestDetailsView.vue`
- `npx eslint src/services/requestDetailService.js tests/requestDetailService.test.js --format stylish`
- `cd web/admin-spa && npx eslint src/views/RequestDetailsView.vue --format stylish`
- `npx jest tests/requestDetailService.test.js --runInBand`
