### PR TITLE
fix: skip tool name transformation for provider-defined tools

### DIFF
--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -258,6 +258,10 @@ class ClaudeRelayService {
 
     if (Array.isArray(body.tools)) {
       body.tools.forEach((tool) => {
+        if (!tool) return
+        // Skip provider-defined tools (tool_search, code_execution, etc.)
+        // whose names are fixed by the Anthropic API and must not be renamed.
+        if (tool.type && tool.type !== 'custom' && !tool.input_schema) return
         if (tool && typeof tool.name === 'string') {
           tool.name = transformName(tool.name)
         }


### PR DESCRIPTION
## Summary
- Anthropic's provider-defined tools (tool_search_tool_bm25/regex, code_execution, etc.) have fixed names mandated by the API
- The proxy's `_transformToolNamesInRequestBody()` was applying PascalCase transformation to ALL tool names, including these special tools
- This caused API validation errors like: `tools.0.tool_search_tool_bm25_20251119.name: Input should be 'tool_search_tool_bm25'`

## Fix
Skip tools where `type` is not `custom` and has no `input_schema` — these are provider-defined tools whose names must not be modified.

## Test plan
- [x] Verified `tool_search_tool_bm25_20251119` works through proxy with Sonnet 4.5
- [x] Verified `defer_loading: true` works through proxy
- [x] Verified regular tools still get name transformation applied