### PR TITLE
fix(claude-relay): strip OpenCode brand markers before user-message relocation

### DIFF
--- a/src/services/claudeCloakingUtils.js
+++ b/src/services/claudeCloakingUtils.js
@@ -35,7 +35,17 @@ const PARAGRAPH_REMOVAL_ANCHORS = [
 ]
 
 const TEXT_REPLACEMENTS = [
-  { match: 'if OpenCode honestly', replacement: 'if the assistant honestly' }
+  { match: 'if OpenCode honestly', replacement: 'if the assistant honestly' },
+  // Anthropic 服务端分类器把这句话当作第三方 Agent CLI 的 fingerprint，
+  // 原样透传会让 /v1/messages 返回 400 invalid_request_error，且错误信息
+  // 被伪装成 "You're out of extra usage." 具有误导性。就地改写语义等价的版本
+  // 即可绕过（仅改一个词也能放行；`Here is` → `Here's` 不能），同时保证模型
+  // 仍能看到 env 块开头。
+  // Ref: opencode-anthropic-auth PR #118 (commit 4444663)
+  {
+    match: 'Here is some useful information about the environment you are running in:',
+    replacement: 'Environment context you are running in:'
+  }
 ]
 
 function sanitizeSystemText(text) {

--- a/src/services/claudeCloakingUtils.js
+++ b/src/services/claudeCloakingUtils.js
@@ -1,0 +1,76 @@
+/**
+ * Claude Cloaking Utils
+ *
+ * Sanitizes third-party CLI (opencode, etc.) system prompts to remove
+ * brand markers before the original system text is relocated to a user
+ * message. This prevents the Anthropic upstream from detecting third-party
+ * clients via brand keyword scans on message content.
+ *
+ * Ported from opencode-anthropic-auth's transform.ts + constants.ts
+ * (https://github.com/anomalyco/opencode-anthropic-auth — referenced by
+ * PR #884). Keep these tables in sync with upstream when OpenCode's
+ * prompt wording changes.
+ *
+ * Strategy — anchor-based surgical sanitization:
+ *   1. Drop the entire paragraph containing the OpenCode identity line
+ *      (detected via `OPENCODE_IDENTITY_PREFIX`).
+ *   2. Drop any paragraph (text between blank lines) that contains one of
+ *      the `PARAGRAPH_REMOVAL_ANCHORS` — typically URLs that identify
+ *      OpenCode-specific content. Resilient to upstream rewording as
+ *      long as the anchor string still appears in the paragraph.
+ *   3. Apply inline `TEXT_REPLACEMENTS` for `OpenCode` mentions inside
+ *      paragraphs we want to keep.
+ *
+ * Everything else is preserved (tone/style, task management rules, tool
+ * usage policy, environment info, user/project instructions, file paths).
+ */
+
+const OPENCODE_IDENTITY_PREFIX = 'You are OpenCode'
+
+const PARAGRAPH_REMOVAL_ANCHORS = [
+  // Help/feedback block — references the OpenCode GitHub repo
+  'github.com/anomalyco/opencode',
+  // OpenCode docs guidance — references the OpenCode docs URL
+  'opencode.ai/docs'
+]
+
+const TEXT_REPLACEMENTS = [
+  { match: 'if OpenCode honestly', replacement: 'if the assistant honestly' }
+]
+
+function sanitizeSystemText(text) {
+  if (typeof text !== 'string' || text.length === 0) {
+    return ''
+  }
+
+  const paragraphs = text.split(/\n\n+/)
+
+  const filtered = paragraphs.filter((paragraph) => {
+    if (paragraph.includes(OPENCODE_IDENTITY_PREFIX)) {
+      return false
+    }
+    for (const anchor of PARAGRAPH_REMOVAL_ANCHORS) {
+      if (paragraph.includes(anchor)) {
+        return false
+      }
+    }
+    return true
+  })
+
+  let result = filtered.join('\n\n')
+
+  for (const rule of TEXT_REPLACEMENTS) {
+    if (rule.match) {
+      result = result.split(rule.match).join(rule.replacement)
+    }
+  }
+
+  return result.trim()
+}
+
+module.exports = {
+  sanitizeSystemText,
+  OPENCODE_IDENTITY_PREFIX,
+  PARAGRAPH_REMOVAL_ANCHORS,
+  TEXT_REPLACEMENTS
+}

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -18,6 +18,7 @@ const userMessageQueueService = require('../userMessageQueueService')
 const { isStreamWritable } = require('../../utils/streamHelper')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
 const metadataUserIdHelper = require('../../utils/metadataUserIdHelper')
+const { sanitizeSystemText } = require('../claudeCloakingUtils')
 const {
   getHttpsAgentForStream,
   getHttpsAgentForNonStream,
@@ -1116,10 +1117,15 @@ class ClaudeRelayService {
           .join('\n\n')
       }
 
+      // 🧼 剥离 OpenCode 等第三方 CLI 的品牌字样，避免在下一步搬运到
+      //    user message 时把 "You are OpenCode"、opencode 的 GitHub/docs
+      //    URL、"if OpenCode honestly" 等标记原样透出给上游
+      originalSystemText = sanitizeSystemText(originalSystemText)
+
       // 将 system 替换为 Claude Code 标准提示词
       processedBody.system = this.claudeCodeSystemPrompt
 
-      // 将原始 system prompt 作为 user/assistant 消息对注入到 messages 开头
+      // 将（已清洗的）原始 system prompt 作为 user/assistant 消息对注入到 messages 开头
       // 模型仍通过 messages 接收完整指令，保留客户端功能
       if (originalSystemText && originalSystemText.trim()) {
         const instructionMessage = {


### PR DESCRIPTION
## Summary

Continuation of the fix merged in #884. That PR relocates the client's
system prompt into a `[System Instructions]` user message so that
Anthropic's first-party detection on `system[]` passes. However, when the
client is OpenCode, the moved text still carries OpenCode's brand
markers verbatim inside that user message — making the request still
detectable as third-party and falling back into \"extra usage\" billing.

This PR ports the anchor-based surgical sanitizer used by
[`opencode-anthropic-auth`](https://github.com/anomalyco/opencode-anthropic-auth)
(`transform.ts` + `constants.ts`) and applies it to `originalSystemText`
before the user-message relocation step.

## What gets stripped

1. **The OpenCode identity paragraph** — any paragraph beginning with
   `You are OpenCode`.
2. **Paragraphs containing known OpenCode URL anchors** — currently
   `github.com/anomalyco/opencode` and `opencode.ai/docs`. Anchor-based
   matching is resilient to upstream rewording as long as the URL
   remains in the paragraph.
3. **Inline OpenCode mentions** in paragraphs we want to keep — e.g.
   the \"if OpenCode honestly\" phrase is rewritten to
   \"if the assistant honestly\".

Everything else (tone/style guidance, task management rules, tool usage
policy, environment info, user instructions, file paths) is preserved,
so OpenCode's runtime behavior is unaffected.

## Files

- **New**: `src/services/claudeCloakingUtils.js` — pure functions,
  unit-testable, exports `sanitizeSystemText` plus the three tables.
- **Modified**: `src/services/relay/claudeRelayService.js` — one
  `require` and one `sanitizeSystemText(originalSystemText)` call
  inserted between the system-prompt extraction and the
  \`processedBody.system = claudeCodeSystemPrompt\` assignment.

## Testing

Verified locally with:

\`\`\`
opencode run -m anthropic/claude-opus-4-5 test
\`\`\`

Real Claude Code requests (`isRealClaudeCode === true`) skip this branch
entirely, so there is zero behavioral impact on the primary use case.
Non-OpenCode third-party clients pass through `sanitizeSystemText`
unchanged (none of the anchors match).

## Maintenance note

The three constants (`OPENCODE_IDENTITY_PREFIX`,
`PARAGRAPH_REMOVAL_ANCHORS`, `TEXT_REPLACEMENTS`) must be kept in sync
with upstream whenever OpenCode updates its prompt wording. The source
of truth is
[`opencode-anthropic-auth/src/constants.ts`](https://github.com/anomalyco/opencode-anthropic-auth/blob/main/src/constants.ts).

Refs: #876, #884