### PR TITLE
fix: aggregate consecutive OpenAI tool messages

### DIFF
--- a/src/services/openaiToClaude.js
+++ b/src/services/openaiToClaude.js
@@ -183,12 +183,39 @@ class OpenAIToClaudeConverter {
    */
   _convertMessages(messages) {
     const claudeMessages = []
+    let pendingToolResults = []
+
+    const flushPendingToolResults = () => {
+      if (pendingToolResults.length === 0) {
+        return
+      }
+
+      claudeMessages.push({
+        role: 'user',
+        content: pendingToolResults
+      })
+      pendingToolResults = []
+    }
 
     for (const msg of messages) {
       // 跳过系统消息（已经在 system 字段处理）
       if (msg.role === 'system') {
         continue
       }
+
+      // OpenAI chat.completions 会把同一轮多个工具结果拆成连续的 role=tool 消息。
+      // Anthropic 侧要求 tool_use 后的下一条 user message 只包含 tool_result blocks，
+      // 因此这里需要将连续的 tool 消息聚合为单条 user message。
+      if (msg.role === 'tool') {
+        pendingToolResults.push({
+          type: 'tool_result',
+          tool_use_id: msg.tool_call_id,
+          content: msg.content
+        })
+        continue
+      }
+
+      flushPendingToolResults()
 
       // 转换角色名称
       const role = msg.role === 'user' ? 'user' : 'assistant'
@@ -216,20 +243,10 @@ class OpenAIToClaudeConverter {
         claudeMsg.content = this._convertToolCalls(msg.tool_calls)
       }
 
-      // 处理工具响应
-      if (msg.role === 'tool') {
-        claudeMsg.role = 'user'
-        claudeMsg.content = [
-          {
-            type: 'tool_result',
-            tool_use_id: msg.tool_call_id,
-            content: msg.content
-          }
-        ]
-      }
-
       claudeMessages.push(claudeMsg)
     }
+
+    flushPendingToolResults()
 
     return claudeMessages
   }

--- a/tests/openaiToClaudeToolResults.test.js
+++ b/tests/openaiToClaudeToolResults.test.js
@@ -1,0 +1,108 @@
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+  debug: jest.fn()
+}))
+
+const openaiToClaude = require('../src/services/openaiToClaude')
+
+describe('openaiToClaude tool_result aggregation', () => {
+  test('merges consecutive OpenAI tool messages into a single Claude user message with multiple tool_result blocks', () => {
+    const req = {
+      model: 'claude-opus-4-7',
+      stream: false,
+      messages: [
+        { role: 'user', content: 'Call both tools.' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'toolu_a',
+              type: 'function',
+              function: { name: 'get_x', arguments: '{}' }
+            },
+            {
+              id: 'toolu_b',
+              type: 'function',
+              function: { name: 'get_y', arguments: '{}' }
+            }
+          ]
+        },
+        { role: 'tool', tool_call_id: 'toolu_a', content: 'x=1' },
+        { role: 'tool', tool_call_id: 'toolu_b', content: 'y=2' }
+      ]
+    }
+
+    const converted = openaiToClaude.convertRequest(req)
+
+    expect(converted.messages).toHaveLength(3)
+    expect(converted.messages[2]).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_a',
+          content: 'x=1'
+        },
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_b',
+          content: 'y=2'
+        }
+      ]
+    })
+  })
+
+  test('flushes aggregated tool results before the next real user message', () => {
+    const req = {
+      model: 'claude-opus-4-7',
+      stream: false,
+      messages: [
+        { role: 'user', content: 'Call both tools.' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'toolu_a',
+              type: 'function',
+              function: { name: 'get_x', arguments: '{}' }
+            },
+            {
+              id: 'toolu_b',
+              type: 'function',
+              function: { name: 'get_y', arguments: '{}' }
+            }
+          ]
+        },
+        { role: 'tool', tool_call_id: 'toolu_a', content: 'x=1' },
+        { role: 'tool', tool_call_id: 'toolu_b', content: 'y=2' },
+        { role: 'user', content: 'Now explain the results.' }
+      ]
+    }
+
+    const converted = openaiToClaude.convertRequest(req)
+
+    expect(converted.messages).toEqual([
+      { role: 'user', content: 'Call both tools.' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'toolu_a', name: 'get_x', input: {} },
+          { type: 'tool_use', id: 'toolu_b', name: 'get_y', input: {} }
+        ]
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'toolu_a', content: 'x=1' },
+          { type: 'tool_result', tool_use_id: 'toolu_b', content: 'y=2' }
+        ]
+      },
+      { role: 'user', content: 'Now explain the results.' }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- aggregate consecutive OpenAI `role="tool"` messages into one Claude `role="user"` message containing multiple `tool_result` blocks
- add a focused regression test covering both aggregation and flush-before-next-user-message behavior

## Root cause
`openaiToClaude._convertMessages()` currently turns each OpenAI `role="tool"` message into its own Claude user message. When one assistant turn emits multiple tool calls, the later orphan-tool patch path sees only the first user message, incorrectly synthesizes missing `tool_result` blocks, and upstream Anthropic rejects the request because the same `tool_use_id` ends up with multiple results.

## Test plan
- `npx prettier --check src/services/openaiToClaude.js tests/openaiToClaudeToolResults.test.js`
- `npx eslint src/services/openaiToClaude.js`
- `npx jest tests/openaiToClaudeToolResults.test.js --runInBand`

Refs #1159
