### PR TITLE
fix: tolerate empty or malformed replayed tool arguments

### DIFF
--- a/src/services/openaiToClaude.js
+++ b/src/services/openaiToClaude.js
@@ -331,12 +331,22 @@ class OpenAIToClaudeConverter {
    * 转换工具调用
    */
   _convertToolCalls(toolCalls) {
-    return toolCalls.map((tc) => ({
-      type: 'tool_use',
-      id: tc.id,
-      name: tc.function.name,
-      input: JSON.parse(tc.function.arguments)
-    }))
+    return toolCalls.map((tc) => {
+      let input
+
+      try {
+        input = JSON.parse(tc.function.arguments || '{}')
+      } catch {
+        input = tc.function.arguments ? { _raw: tc.function.arguments } : {}
+      }
+
+      return {
+        type: 'tool_use',
+        id: tc.id,
+        name: tc.function.name,
+        input
+      }
+    })
   }
 
   /**

--- a/tests/openaiToClaude.test.js
+++ b/tests/openaiToClaude.test.js
@@ -1,0 +1,82 @@
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+
+const converter = require('../src/services/openaiToClaude')
+
+describe('OpenAIToClaudeConverter', () => {
+  it('should treat empty replayed tool arguments as an empty object', () => {
+    const converted = converter.convertRequest({
+      model: 'claude-opus-4-1',
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'toolu_empty',
+              type: 'function',
+              function: {
+                name: 'get_weather',
+                arguments: ''
+              }
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(converted.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_empty',
+            name: 'get_weather',
+            input: {}
+          }
+        ]
+      }
+    ])
+  })
+
+  it('should preserve malformed replayed tool arguments in _raw', () => {
+    const converted = converter.convertRequest({
+      model: 'claude-opus-4-1',
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'toolu_bad',
+              type: 'function',
+              function: {
+                name: 'get_weather',
+                arguments: '{bad json'
+              }
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(converted.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_bad',
+            name: 'get_weather',
+            input: { _raw: '{bad json' }
+          }
+        ]
+      }
+    ])
+  })
+})


### PR DESCRIPTION
## Bug Description

Follow-up to #1159. This parser-robustness bug came up during that investigation and was explicitly noted there as out of scope for the multi-tool `tool_result` fix.

When a client replays an assistant message with `tool_calls`, `src/services/openaiToClaude.js` currently does a blind `JSON.parse(tc.function.arguments)` inside `_convertToolCalls()`.

If `tc.function.arguments` is an empty string or malformed JSON, CRS throws locally and returns a 500 before the request ever reaches the upstream Claude API.

## Root Cause

The OpenAI → Claude conversion path assumes replayed `tool_calls[*].function.arguments` is always valid JSON.

That assumption does not hold for some streamed / replayed payloads, where the stored argument string can be empty or malformed.

## Fix

- parse `tc.function.arguments || '{}'` in a `try/catch`
- map empty strings to `{}`
- preserve malformed non-empty payloads as `{ _raw: <original> }`
- add regression tests for both empty and malformed replayed arguments

## How to Verify

1. `npm ci`
2. `cp config/config.example.js config/config.js`
3. `npm test -- --runInBand tests/openaiToClaude.test.js`
4. Optional: `npm test -- --runInBand`

## Test Plan

- [x] Added regression test for empty string replayed arguments
- [x] Added regression test for malformed replayed arguments
- [x] Existing tests still pass (`cp config/config.example.js config/config.js && npm test -- --runInBand`)

## Risk Assessment

Low — this only touches replayed assistant `tool_calls` argument parsing in the OpenAI → Claude conversion path. Valid JSON behavior is unchanged.
