### PR TITLE
fix: read model pricing from runtime data directory

### DIFF
--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -1269,7 +1269,7 @@ class ClaudeRelayService {
 
     try {
       // 使用缓存的定价数据
-      const pricingFilePath = path.join(__dirname, '../../data/model_pricing.json')
+      const pricingFilePath = path.join(process.cwd(), 'data', 'model_pricing.json')
       const pricingData = getPricingData(pricingFilePath)
 
       if (!pricingData) {

--- a/tests/claudeRelayService.pricingPath.test.js
+++ b/tests/claudeRelayService.pricingPath.test.js
@@ -1,0 +1,74 @@
+const path = require('path')
+
+const mockGetPricingData = jest.fn()
+
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+
+jest.mock('../src/utils/proxyHelper', () => ({}))
+jest.mock('../src/utils/headerFilter', () => ({ filterForClaude: jest.fn() }))
+jest.mock('../src/services/account/claudeAccountService', () => ({}))
+jest.mock('../src/services/scheduler/unifiedClaudeScheduler', () => ({}))
+jest.mock('../src/utils/sessionHelper', () => ({}))
+jest.mock(
+  '../config/config',
+  () => ({
+    claude: {
+      apiVersion: '2023-06-01',
+      betaHeader: 'test-beta',
+      systemPrompt: ''
+    }
+  }),
+  { virtual: true }
+)
+jest.mock('../src/services/claudeCodeHeadersService', () => ({}))
+jest.mock('../src/models/redis', () => ({}))
+jest.mock('../src/validators/clients/claudeCodeValidator', () => ({}))
+jest.mock('../src/utils/dateHelper', () => ({ formatDateWithTimezone: jest.fn(() => 'mock-date') }))
+jest.mock('../src/services/requestIdentityService', () => ({}))
+jest.mock('../src/utils/testPayloadHelper', () => ({ createClaudeTestPayload: jest.fn() }))
+jest.mock('../src/services/userMessageQueueService', () => ({}))
+jest.mock('../src/utils/streamHelper', () => ({ isStreamWritable: jest.fn(() => true) }))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({}))
+jest.mock('../src/utils/metadataUserIdHelper', () => ({}))
+jest.mock('../src/utils/performanceOptimizer', () => ({
+  getHttpsAgentForStream: jest.fn(),
+  getHttpsAgentForNonStream: jest.fn(),
+  getPricingData: mockGetPricingData
+}))
+
+const claudeRelayService = require('../src/services/relay/claudeRelayService')
+
+describe('claudeRelayService._validateAndLimitMaxTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('reads model_pricing.json from the runtime data directory when validating max_tokens', () => {
+    const expectedPricingPath = path.join(process.cwd(), 'data', 'model_pricing.json')
+    mockGetPricingData.mockImplementation((pricingPath) => {
+      if (pricingPath === expectedPricingPath) {
+        return {
+          'claude-sonnet-4-20250514': {
+            max_tokens: 8192
+          }
+        }
+      }
+      return null
+    })
+
+    const body = {
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 999999
+    }
+
+    claudeRelayService._validateAndLimitMaxTokens(body)
+
+    expect(mockGetPricingData).toHaveBeenCalledWith(expectedPricingPath)
+    expect(body.max_tokens).toBe(8192)
+  })
+})


### PR DESCRIPTION
## Bug Description

Refs #1159.

In the Docker runtime path, upstream `docker-compose.yml` mounts runtime pricing data at `/app/data`, but `src/services/relay/claudeRelayService.js::_validateAndLimitMaxTokens()` currently reads:

```js
path.join(__dirname, '../../data/model_pricing.json')
```

Inside the container that resolves to `/app/src/data/model_pricing.json`, which is a different path.

As a result, `max_tokens` validation can silently skip with:

```text
Model pricing file not found, skipping max_tokens validation
```

unless operators add an extra local bind mount to mirror `./data` into `/app/src/data`.

## Root Cause

There is a path convention mismatch:

- Docker runtime data is mounted at `/app/data`
- `pricingService.js` already uses `process.cwd()/data/model_pricing.json`
- but `claudeRelayService.js` used a source-relative path that resolves to `/app/src/data/model_pricing.json`

So the relay's max-token validation path is inconsistent with the rest of the runtime.

## Fix

- change `_validateAndLimitMaxTokens()` to read pricing data from:

```js
path.join(process.cwd(), 'data', 'model_pricing.json')
```

This matches the Docker `WORKDIR`, the compose mount, and the existing `pricingService.js` convention.

## How to Verify

1. `npm ci`
2. `cp config/config.example.js config/config.js`
3. `npm test -- --runInBand tests/claudeRelayService.pricingPath.test.js`
4. Optional: `npm test -- --runInBand`

## Test Plan

- [x] Added regression test proving `_validateAndLimitMaxTokens()` reads `process.cwd()/data/model_pricing.json`
- [x] New targeted test passes
- [x] Full Jest suite passes

## Risk Assessment

Low — this is a one-line path correction scoped to model-pricing lookup inside max-token validation. It aligns this code path with the repo's existing runtime data convention rather than introducing a new one.
