### PR TITLE
feat(pricing): add per-model custom cache pricing override

### DIFF
--- a/src/models/redis.js
+++ b/src/models/redis.js
@@ -5260,6 +5260,34 @@ redisClient.getApiKeyCount = async function () {
   return { total: keyIds.length, active }
 }
 
+// 💰 自定义模型缓存价格覆盖
+redisClient.getCustomCachePricing = async function () {
+  const client = this.getClientSafe()
+  const raw = await client.hgetall('pricing:custom_cache')
+  const result = {}
+  if (!raw) {
+    return result
+  }
+  for (const [model, value] of Object.entries(raw)) {
+    try {
+      result[model] = JSON.parse(value)
+    } catch (_e) {
+      // 旧数据或损坏数据，忽略
+    }
+  }
+  return result
+}
+
+redisClient.setCustomCachePricing = async function (model, override) {
+  const client = this.getClientSafe()
+  await client.hset('pricing:custom_cache', model, JSON.stringify(override))
+}
+
+redisClient.deleteCustomCachePricing = async function (model) {
+  const client = this.getClientSafe()
+  await client.hdel('pricing:custom_cache', model)
+}
+
 // 清理过期的系统分钟统计数据（启动时调用）
 redisClient.cleanupSystemMetrics = async function () {
   logger.info('🧹 清理过期的系统分钟统计数据...')

--- a/src/routes/admin/system.js
+++ b/src/routes/admin/system.js
@@ -451,4 +451,49 @@ router.post('/models/pricing/refresh', authenticateAdmin, async (req, res) => {
   }
 })
 
+// 获取所有自定义缓存价格覆盖
+router.get('/models/pricing/custom', authenticateAdmin, async (req, res) => {
+  try {
+    const data = pricingService.getCustomCachePricingMap()
+    res.json({ success: true, data })
+  } catch (error) {
+    logger.error('Failed to get custom cache pricing:', error)
+    res.status(500).json({ error: 'Failed to get custom cache pricing', message: error.message })
+  }
+})
+
+// 设置/更新某个模型的自定义缓存价格
+router.put('/models/pricing/custom/:model', authenticateAdmin, async (req, res) => {
+  try {
+    const model = decodeURIComponent(req.params.model || '')
+    if (!model) {
+      return res.status(400).json({ error: 'Model name is required' })
+    }
+    const body = req.body || {}
+    const override = await pricingService.setCustomCachePricing(model, {
+      cacheCreation: body.cacheCreation,
+      cacheRead: body.cacheRead
+    })
+    res.json({ success: true, data: override })
+  } catch (error) {
+    logger.warn('Failed to set custom cache pricing:', error.message)
+    res.status(400).json({ error: 'Invalid custom cache pricing', message: error.message })
+  }
+})
+
+// 清除某个模型的自定义缓存价格
+router.delete('/models/pricing/custom/:model', authenticateAdmin, async (req, res) => {
+  try {
+    const model = decodeURIComponent(req.params.model || '')
+    if (!model) {
+      return res.status(400).json({ error: 'Model name is required' })
+    }
+    await pricingService.deleteCustomCachePricing(model)
+    res.json({ success: true })
+  } catch (error) {
+    logger.error('Failed to delete custom cache pricing:', error)
+    res.status(500).json({ error: 'Failed to delete custom cache pricing', message: error.message })
+  }
+})
+
 module.exports = router

--- a/src/services/pricingService.js
+++ b/src/services/pricingService.js
@@ -20,6 +20,7 @@ class PricingService {
     this.localHashFile = path.join(this.dataDir, 'model_pricing.sha256')
     this.pricingData = null
     this.lastUpdated = null
+    this.customCachePricing = {} // 模型名 -> { cacheCreation, cacheRead, updatedAt }
     this.updateInterval = 24 * 60 * 60 * 1000 // 24小时
     this.hashCheckInterval = 10 * 60 * 1000 // 10分钟哈希校验
     this.fileWatcher = null // 文件监听器
@@ -57,6 +58,9 @@ class PricingService {
 
       // 初次启动时执行一次哈希校验，确保与远端保持一致
       await this.syncWithRemoteHash()
+
+      // 加载自定义缓存价格覆盖
+      await this.loadCustomCachePricing()
 
       // 设置定时更新
       if (this.updateTimer) {
@@ -360,7 +364,7 @@ class PricingService {
     // 尝试直接匹配
     if (this.pricingData[modelName]) {
       logger.debug(`💰 Found exact pricing match for ${modelName}`)
-      return this.pricingData[modelName]
+      return this.applyCustomCacheOverride(this.pricingData[modelName], modelName)
     }
 
     // 特殊处理：gpt-5-codex 回退到 gpt-5
@@ -368,7 +372,7 @@ class PricingService {
       const fallbackPricing = this.pricingData['gpt-5']
       if (fallbackPricing) {
         logger.info(`💰 Using gpt-5 pricing as fallback for ${modelName}`)
-        return fallbackPricing
+        return this.applyCustomCacheOverride(fallbackPricing, 'gpt-5')
       }
     }
 
@@ -381,7 +385,7 @@ class PricingService {
         logger.debug(
           `💰 Found pricing for ${modelName} by removing region prefix: ${withoutRegion}`
         )
-        return this.pricingData[withoutRegion]
+        return this.applyCustomCacheOverride(this.pricingData[withoutRegion], withoutRegion)
       }
     }
 
@@ -392,7 +396,7 @@ class PricingService {
       const normalizedKey = key.toLowerCase().replace(/[_-]/g, '')
       if (normalizedKey.includes(normalizedModel) || normalizedModel.includes(normalizedKey)) {
         logger.debug(`💰 Found pricing for ${modelName} using fuzzy match: ${key}`)
-        return value
+        return this.applyCustomCacheOverride(value, key)
       }
     }
 
@@ -404,7 +408,7 @@ class PricingService {
       for (const [key, value] of Object.entries(this.pricingData)) {
         if (key.includes(coreModel) || key.replace('anthropic.', '').includes(coreModel)) {
           logger.debug(`💰 Found pricing for ${modelName} using Bedrock core model match: ${key}`)
-          return value
+          return this.applyCustomCacheOverride(value, key)
         }
       }
     }
@@ -427,6 +431,95 @@ class PricingService {
       pricing.cache_read_input_token_cost = pricing.input_cost_per_token * 0.1
     }
     return pricing
+  }
+
+  // 将自定义缓存价格覆盖应用到返回的价格对象
+  applyCustomCacheOverride(pricing, matchedKey) {
+    if (!pricing || !matchedKey) {
+      return pricing
+    }
+    const override = this.customCachePricing[matchedKey]
+    if (!override) {
+      return pricing
+    }
+    const hasCreation = Number.isFinite(override.cacheCreation) && override.cacheCreation >= 0
+    const hasRead = Number.isFinite(override.cacheRead) && override.cacheRead >= 0
+    if (!hasCreation && !hasRead) {
+      return pricing
+    }
+    const merged = { ...pricing }
+    if (hasCreation) {
+      merged.cache_creation_input_token_cost = override.cacheCreation
+    }
+    if (hasRead) {
+      merged.cache_read_input_token_cost = override.cacheRead
+    }
+    return merged
+  }
+
+  // 从 Redis 加载自定义缓存价格覆盖
+  async loadCustomCachePricing() {
+    try {
+      const redis = require('../models/redis')
+      const overrides = await redis.getCustomCachePricing()
+      this.customCachePricing = overrides || {}
+      const count = Object.keys(this.customCachePricing).length
+      if (count > 0) {
+        logger.info(`💰 Loaded ${count} custom cache pricing override(s)`)
+      }
+    } catch (error) {
+      logger.warn(`⚠️  Failed to load custom cache pricing: ${error.message}`)
+      this.customCachePricing = {}
+    }
+  }
+
+  // 校验并规范化单个覆盖字段（允许 null，其余必须为有限非负数）
+  _normalizeCacheOverrideField(value) {
+    if (value === null || value === undefined || value === '') {
+      return null
+    }
+    const num = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(num) || num < 0) {
+      throw new Error('Cache pricing override must be a finite non-negative number or null')
+    }
+    return num
+  }
+
+  // 设置/更新某个模型的自定义缓存价格覆盖
+  async setCustomCachePricing(modelName, { cacheCreation, cacheRead } = {}) {
+    if (!modelName || typeof modelName !== 'string') {
+      throw new Error('Model name is required')
+    }
+    const normalized = {
+      cacheCreation: this._normalizeCacheOverrideField(cacheCreation),
+      cacheRead: this._normalizeCacheOverrideField(cacheRead)
+    }
+    if (normalized.cacheCreation === null && normalized.cacheRead === null) {
+      throw new Error('At least one of cacheCreation / cacheRead must be provided')
+    }
+    normalized.updatedAt = new Date().toISOString()
+
+    const redis = require('../models/redis')
+    await redis.setCustomCachePricing(modelName, normalized)
+    this.customCachePricing[modelName] = normalized
+    logger.info(`💰 Set custom cache pricing for ${modelName}`)
+    return normalized
+  }
+
+  // 删除某个模型的自定义缓存价格覆盖
+  async deleteCustomCachePricing(modelName) {
+    if (!modelName || typeof modelName !== 'string') {
+      throw new Error('Model name is required')
+    }
+    const redis = require('../models/redis')
+    await redis.deleteCustomCachePricing(modelName)
+    delete this.customCachePricing[modelName]
+    logger.info(`💰 Removed custom cache pricing for ${modelName}`)
+  }
+
+  // 返回当前所有覆盖（供管理 UI 展示）
+  getCustomCachePricingMap() {
+    return { ...this.customCachePricing }
   }
 
   // 从 usage 对象中提取 beta 特性列表（小写）

--- a/src/services/pricingService.js
+++ b/src/services/pricingService.js
@@ -447,13 +447,20 @@ class PricingService {
     if (!hasCreation && !hasRead) {
       return pricing
     }
-    const merged = { ...pricing }
+    const merged = { ...pricing, _customCacheOverride: {} }
     if (hasCreation) {
       merged.cache_creation_input_token_cost = override.cacheCreation
+      merged._customCacheOverride.cacheCreation = true
     }
     if (hasRead) {
       merged.cache_read_input_token_cost = override.cacheRead
+      merged._customCacheOverride.cacheRead = true
     }
+    logger.debug(
+      `💰 Custom cache override applied to ${matchedKey}: ` +
+        `creation=${hasCreation ? override.cacheCreation : 'official'}, ` +
+        `read=${hasRead ? override.cacheRead : 'official'}`
+    )
     return merged
   }
 
@@ -734,11 +741,13 @@ class PricingService {
 
     // Claude 兜底：pricing 字段缺失时用倍率从 actualInputPrice 推导
     // 此时 actualInputPrice 尚未含 fastMultiplier，下方统一应用
+    // 自定义覆盖已生效的字段不再走兜底（即使覆盖值为 0 也保留）
+    const customCacheOverride = pricing._customCacheOverride || {}
     if (isClaudeModel) {
-      if (!actualCacheCreatePrice) {
+      if (!actualCacheCreatePrice && !customCacheOverride.cacheCreation) {
         actualCacheCreatePrice = actualInputPrice * this.claudeCacheMultipliers.write5m
       }
-      if (!actualCacheReadPrice) {
+      if (!actualCacheReadPrice && !customCacheOverride.cacheRead) {
         actualCacheReadPrice = actualInputPrice * this.claudeCacheMultipliers.read
       }
       if (!actualEphemeral1hPrice) {

--- a/web/admin-spa/src/components/settings/ModelPricingSection.vue
+++ b/web/admin-spa/src/components/settings/ModelPricingSection.vue
@@ -119,6 +119,11 @@
             >
               上下文窗口
             </th>
+            <th
+              class="hidden px-3 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 md:table-cell"
+            >
+              自定义缓存 $/MTok
+            </th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
@@ -156,9 +161,60 @@
             >
               {{ formatContext(model.maxTokens) }}
             </td>
+            <td class="hidden whitespace-nowrap px-3 py-2.5 md:table-cell">
+              <div class="flex items-center justify-end gap-2">
+                <div class="flex flex-col gap-1">
+                  <input
+                    v-model="customDraft[model.name].cacheCreation"
+                    :placeholder="placeholderFor(model.cacheCreateCost)"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    class="w-24 rounded-md border border-gray-200 bg-white px-2 py-1 text-right font-mono text-xs text-gray-700 placeholder-gray-300 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500/30 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:placeholder-gray-600"
+                    title="自定义缓存创建价格 ($/MTok)"
+                  />
+                  <input
+                    v-model="customDraft[model.name].cacheRead"
+                    :placeholder="placeholderFor(model.cacheReadCost)"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    class="w-24 rounded-md border border-gray-200 bg-white px-2 py-1 text-right font-mono text-xs text-gray-700 placeholder-gray-300 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500/30 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:placeholder-gray-600"
+                    title="自定义缓存读取价格 ($/MTok)"
+                  />
+                </div>
+                <div class="flex flex-col gap-1">
+                  <button
+                    :disabled="!canSaveCustom(model.name) || savingModel === model.name"
+                    :class="[
+                      'rounded-md px-2 py-1 text-xs font-medium transition',
+                      canSaveCustom(model.name) && savingModel !== model.name
+                        ? 'bg-blue-500 text-white hover:bg-blue-600'
+                        : 'cursor-not-allowed bg-gray-200 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
+                    ]"
+                    @click="saveCustom(model.name)"
+                  >
+                    <i v-if="savingModel === model.name" class="fas fa-spinner fa-spin" />
+                    <span v-else>保存</span>
+                  </button>
+                  <button
+                    :disabled="!hasCustom(model.name) || savingModel === model.name"
+                    :class="[
+                      'rounded-md px-2 py-1 text-xs font-medium transition',
+                      hasCustom(model.name) && savingModel !== model.name
+                        ? 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+                        : 'cursor-not-allowed bg-gray-50 text-gray-300 dark:bg-gray-800 dark:text-gray-600'
+                    ]"
+                    @click="resetCustom(model.name)"
+                  >
+                    重置
+                  </button>
+                </div>
+              </div>
+            </td>
           </tr>
           <tr v-if="sortedModels.length === 0">
-            <td class="px-3 py-8 text-center text-gray-500 dark:text-gray-400" colspan="6">
+            <td class="px-3 py-8 text-center text-gray-500 dark:text-gray-400" colspan="7">
               <i class="fas fa-search mb-2 text-2xl text-gray-300 dark:text-gray-600" />
               <p>没有匹配的模型</p>
             </td>
@@ -175,11 +231,14 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted, watch } from 'vue'
 import {
   getModelPricingApi,
   getModelPricingStatusApi,
-  refreshModelPricingApi
+  refreshModelPricingApi,
+  getCustomCachePricingApi,
+  setCustomCachePricingApi,
+  deleteCustomCachePricingApi
 } from '@/utils/http_apis'
 import { showToast } from '@/utils/tools'
 
@@ -188,6 +247,9 @@ const loading = ref(false)
 const refreshing = ref(false)
 const pricingData = ref({})
 const pricingStatus = ref({})
+const customCachePricing = ref({}) // model -> { cacheCreation, cacheRead, updatedAt } (per-token)
+const customDraft = reactive({}) // model -> { cacheCreation: string, cacheRead: string } ($/MTok)
+const savingModel = ref('')
 const searchQuery = ref('')
 const activePlatform = ref('all')
 const sortField = ref('name')
@@ -320,9 +382,10 @@ const toggleSort = (field) => {
 
 const loadData = async () => {
   loading.value = true
-  const [pricingResult, statusResult] = await Promise.all([
+  const [pricingResult, statusResult, customResult] = await Promise.all([
     getModelPricingApi(),
-    getModelPricingStatusApi()
+    getModelPricingStatusApi(),
+    getCustomCachePricingApi()
   ])
   if (pricingResult.success) {
     pricingData.value = pricingResult.data
@@ -334,6 +397,10 @@ const loadData = async () => {
   } else {
     showToast(statusResult.message || '获取价格状态失败', 'error')
   }
+  if (customResult && customResult.success) {
+    customCachePricing.value = customResult.data || {}
+  }
+  syncCustomDraft()
   loading.value = false
 }
 
@@ -347,6 +414,116 @@ const handleRefresh = async () => {
     showToast(result.message || '刷新失败', 'error')
   }
   refreshing.value = false
+}
+
+// ========== 自定义缓存价格 ==========
+const perTokenToMTok = (v) => {
+  if (v === null || v === undefined) return ''
+  const n = Number(v) * 1e6
+  if (!Number.isFinite(n)) return ''
+  // 去除无用的尾零
+  return Number(n.toFixed(6)).toString()
+}
+
+const ensureDraft = (name) => {
+  if (!customDraft[name]) {
+    customDraft[name] = { cacheCreation: '', cacheRead: '' }
+  }
+  return customDraft[name]
+}
+
+const syncCustomDraft = () => {
+  // 为所有模型预建 draft 行（保证模板中 customDraft[model.name] 可访问）
+  for (const name of Object.keys(pricingData.value)) {
+    const override = customCachePricing.value[name]
+    customDraft[name] = {
+      cacheCreation: override ? perTokenToMTok(override.cacheCreation) : '',
+      cacheRead: override ? perTokenToMTok(override.cacheRead) : ''
+    }
+  }
+}
+
+watch(
+  () => Object.keys(pricingData.value).length,
+  () => syncCustomDraft()
+)
+
+const placeholderFor = (mtokPrice) => {
+  if (!mtokPrice || mtokPrice === 0) return '官方价'
+  if (mtokPrice < 0.01) return mtokPrice.toFixed(4)
+  if (mtokPrice < 1) return mtokPrice.toFixed(3)
+  return mtokPrice.toFixed(2)
+}
+
+const parseMTokInput = (value) => {
+  if (value === '' || value === null || value === undefined) return null
+  const n = Number(value)
+  if (!Number.isFinite(n) || n < 0) return NaN
+  return n / 1e6
+}
+
+const hasCustom = (name) => Boolean(customCachePricing.value[name])
+
+const canSaveCustom = (name) => {
+  const draft = ensureDraft(name)
+  const create = parseMTokInput(draft.cacheCreation)
+  const read = parseMTokInput(draft.cacheRead)
+  if (Number.isNaN(create) || Number.isNaN(read)) return false
+  if (create === null && read === null) return false
+  const override = customCachePricing.value[name]
+  if (!override) return true
+  return create !== (override.cacheCreation ?? null) || read !== (override.cacheRead ?? null)
+}
+
+const saveCustom = async (name) => {
+  const draft = ensureDraft(name)
+  const create = parseMTokInput(draft.cacheCreation)
+  const read = parseMTokInput(draft.cacheRead)
+  if (Number.isNaN(create) || Number.isNaN(read)) {
+    showToast('请输入有效的非负数', 'error')
+    return
+  }
+  if (create === null && read === null) {
+    showToast('请至少填写一个字段', 'error')
+    return
+  }
+  savingModel.value = name
+  try {
+    const result = await setCustomCachePricingApi(name, {
+      cacheCreation: create,
+      cacheRead: read
+    })
+    if (result.success) {
+      customCachePricing.value = { ...customCachePricing.value, [name]: result.data }
+      showToast('已保存', 'success')
+    } else {
+      showToast(result.message || '保存失败', 'error')
+    }
+  } catch (error) {
+    showToast(error?.message || '保存失败', 'error')
+  } finally {
+    savingModel.value = ''
+  }
+}
+
+const resetCustom = async (name) => {
+  savingModel.value = name
+  try {
+    const result = await deleteCustomCachePricingApi(name)
+    if (result.success) {
+      const next = { ...customCachePricing.value }
+      delete next[name]
+      customCachePricing.value = next
+      customDraft[name] = { cacheCreation: '', cacheRead: '' }
+      showToast('已重置为官方价', 'success')
+    } else {
+      showToast(result.message || '重置失败', 'error')
+    }
+  } catch (error) {
+    showToast(error?.message || '重置失败', 'error')
+  } finally {
+    savingModel.value = ''
+  }
 }
 
 onMounted(loadData)

--- a/web/admin-spa/src/utils/http_apis.js
+++ b/web/admin-spa/src/utils/http_apis.js
@@ -9,6 +9,19 @@ export const getModelPricingStatusApi = () =>
   request({ url: '/admin/models/pricing/status', method: 'GET' })
 export const refreshModelPricingApi = () =>
   request({ url: '/admin/models/pricing/refresh', method: 'POST' })
+export const getCustomCachePricingApi = () =>
+  request({ url: '/admin/models/pricing/custom', method: 'GET' })
+export const setCustomCachePricingApi = (model, data) =>
+  request({
+    url: `/admin/models/pricing/custom/${encodeURIComponent(model)}`,
+    method: 'PUT',
+    data
+  })
+export const deleteCustomCachePricingApi = (model) =>
+  request({
+    url: `/admin/models/pricing/custom/${encodeURIComponent(model)}`,
+    method: 'DELETE'
+  })
 
 // API Stats
 export const getKeyIdApi = (apiKey) =>


### PR DESCRIPTION
Let admins globally override cache_creation_input_token_cost and cache_read_input_token_cost per model so billing uses the custom values without being clobbered by remote pricing refreshes.

- redis: 3 methods on hash pricing:custom_cache
- pricingService: load overrides at init, apply via shallow copy in getModelPricing so calculateCost picks them up transparently
- admin: GET/PUT/DELETE /admin/models/pricing/custom[/:model]
- UI: new editable "custom cache \$/MTok" column with save/reset