### PR TITLE
feat: add customer billing privacy option

### DIFF
--- a/src/routes/apiStats.js
+++ b/src/routes/apiStats.js
@@ -14,6 +14,48 @@ const {
 const modelsConfig = require('../../config/models')
 const { getSafeMessage } = require('../utils/errorSanitizer')
 
+const TRUE_ENV_VALUES = new Set(['true', '1', 'yes', 'on'])
+
+const isCustomerBillingDetailsHidden = () =>
+  TRUE_ENV_VALUES.has(
+    String(process.env.HIDE_CUSTOMER_BILLING_DETAILS || '')
+      .trim()
+      .toLowerCase()
+  )
+
+const firstFiniteNumber = (...values) => {
+  for (const value of values) {
+    if (value === undefined || value === null) {
+      continue
+    }
+
+    const number = Number(value)
+    if (Number.isFinite(number)) {
+      return number
+    }
+  }
+
+  return 0
+}
+
+const buildCustomerBillingCostFields = (costData = {}) => {
+  if (!isCustomerBillingDetailsHidden()) {
+    return {
+      costs: costData.costs,
+      formatted: costData.formatted,
+      pricing: costData.pricing
+    }
+  }
+
+  const costs = costData.costs || {}
+  const total = firstFiniteNumber(costs.rated, costs.total, costs.real)
+
+  return {
+    costs: { total },
+    formatted: { total: CostCalculator.formatCost(total) }
+  }
+}
+
 const router = express.Router()
 
 // 📋 获取可用模型列表（公开接口）
@@ -557,10 +599,12 @@ router.post('/api/user-stats', async (req, res) => {
         restrictedModels: fullKeyData.restrictedModels || [],
         enableClientRestriction: fullKeyData.enableClientRestriction || false,
         allowedClients: fullKeyData.allowedClients || []
-      },
+      }
+    }
 
+    if (!isCustomerBillingDetailsHidden()) {
       // Key 级别的服务倍率
-      serviceRates: (() => {
+      responseData.serviceRates = (() => {
         try {
           return fullKeyData.serviceRates
             ? typeof fullKeyData.serviceRates === 'string'
@@ -905,6 +949,8 @@ router.post('/api/batch-model-stats', async (req, res) => {
         costData.formatted.total = `$${costData.costs.real.toFixed(6)}`
       }
 
+      const billingCostFields = buildCustomerBillingCostFields(costData)
+
       modelStats.push({
         model,
         requests: usage.requests,
@@ -913,9 +959,9 @@ router.post('/api/batch-model-stats', async (req, res) => {
         cacheCreateTokens: usage.cacheCreateTokens,
         cacheReadTokens: usage.cacheReadTokens,
         allTokens: usage.allTokens,
-        costs: costData.costs,
-        formatted: costData.formatted,
-        pricing: costData.pricing,
+        costs: billingCostFields.costs,
+        formatted: billingCostFields.formatted,
+        ...(billingCostFields.pricing ? { pricing: billingCostFields.pricing } : {}),
         isLegacy: !hasStoredCost
       })
     }
@@ -1469,6 +1515,8 @@ router.post('/api/user-model-stats', async (req, res) => {
               usage.cache_read_input_tokens
             : parseInt(data.allTokens) || 0
 
+        const billingCostFields = buildCustomerBillingCostFields(costData)
+
         modelStats.push({
           model,
           requests: parseInt(data.requests) || 0,
@@ -1477,9 +1525,9 @@ router.post('/api/user-model-stats', async (req, res) => {
           cacheCreateTokens: usage.cache_creation_input_tokens,
           cacheReadTokens: usage.cache_read_input_tokens,
           allTokens,
-          costs: costData.costs,
-          formatted: costData.formatted,
-          pricing: costData.pricing,
+          costs: billingCostFields.costs,
+          formatted: billingCostFields.formatted,
+          ...(billingCostFields.pricing ? { pricing: billingCostFields.pricing } : {}),
           isLegacy: !hasStoredCost
         })
       }
@@ -1510,6 +1558,14 @@ router.post('/api/user-model-stats', async (req, res) => {
 
 // 📊 获取服务倍率配置（公开接口）
 router.get('/service-rates', async (req, res) => {
+  if (isCustomerBillingDetailsHidden()) {
+    return res.json({
+      success: false,
+      data: null,
+      billingDetailsHidden: true
+    })
+  }
+
   try {
     const rates = await serviceRatesService.getRates()
     res.json({

--- a/tests/apiStatsBillingPrivacy.test.js
+++ b/tests/apiStatsBillingPrivacy.test.js
@@ -1,0 +1,245 @@
+const express = require('express')
+const request = require('supertest')
+
+const TEST_API_ID = '123e4567-e89b-12d3-a456-426614174000'
+const TEST_MONTH = '2026-04'
+const TEST_MODEL = 'claude-3-5-sonnet-20241022'
+
+jest.mock('../src/models/redis', () => ({
+  getApiKey: jest.fn(),
+  getUsageStats: jest.fn(),
+  getDailyCost: jest.fn(),
+  getCostStats: jest.fn(),
+  getWeeklyOpusCost: jest.fn(),
+  getClientSafe: jest.fn(),
+  scanAndGetAllChunked: jest.fn(),
+  getDateInTimezone: jest.fn(),
+  getDateStringInTimezone: jest.fn()
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  api: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  security: jest.fn()
+}))
+
+jest.mock('../src/services/apiKeyService', () => ({
+  validateApiKey: jest.fn(),
+  validateApiKeyForStats: jest.fn()
+}))
+
+jest.mock('../src/services/account/claudeAccountService', () => ({
+  getAccountOverview: jest.fn()
+}))
+
+jest.mock('../src/services/account/openaiAccountService', () => ({
+  getAccountOverview: jest.fn()
+}))
+
+jest.mock('../src/services/serviceRatesService', () => ({
+  getRates: jest.fn()
+}))
+
+jest.mock('../src/utils/costCalculator', () => ({
+  calculateCost: jest.fn(() => ({
+    costs: {
+      input: 0.25,
+      output: 0.75,
+      total: 1,
+      real: 1,
+      rated: 1.5
+    },
+    formatted: {
+      input: '$0.250000',
+      output: '$0.750000',
+      total: '$1.000000'
+    },
+    pricing: {
+      input: 3,
+      output: 15,
+      cacheWrite: 3.75,
+      cacheRead: 0.3
+    }
+  })),
+  formatCost: jest.fn((cost) => `$${Number(cost || 0).toFixed(6)}`)
+}))
+
+jest.mock('../src/utils/testPayloadHelper', () => ({
+  createClaudeTestPayload: jest.fn(),
+  extractErrorMessage: jest.fn(),
+  sanitizeErrorMsg: jest.fn(),
+  sendStreamTestRequest: jest.fn()
+}))
+
+jest.mock('../config/models', () => ({
+  CLAUDE_MODELS: [],
+  GEMINI_MODELS: [],
+  OPENAI_MODELS: [],
+  OTHER_MODELS: [],
+  PLATFORM_TEST_MODELS: {},
+  getModelsByService: jest.fn(() => []),
+  getAllModels: jest.fn(() => [])
+}))
+
+jest.mock('../src/utils/errorSanitizer', () => ({
+  getSafeMessage: jest.fn((message) => message)
+}))
+
+const redis = require('../src/models/redis')
+const serviceRatesService = require('../src/services/serviceRatesService')
+const apiStatsRouter = require('../src/routes/apiStats')
+
+const buildApp = () => {
+  const app = express()
+  app.use(express.json())
+  app.use('/apiStats', apiStatsRouter)
+  return app
+}
+
+const buildKeyData = () => ({
+  id: TEST_API_ID,
+  name: 'Customer Key',
+  description: 'customer-visible key',
+  isActive: 'true',
+  createdAt: '2026-04-01T00:00:00.000Z',
+  expiresAt: null,
+  permissions: ['claude'],
+  tokenLimit: '0',
+  concurrencyLimit: '0',
+  rateLimitWindow: '0',
+  rateLimitRequests: '0',
+  dailyCostLimit: '0',
+  totalCostLimit: '0',
+  weeklyOpusCostLimit: '0',
+  weeklyResetDay: '1',
+  weeklyResetHour: '0',
+  enableModelRestriction: 'false',
+  enableClientRestriction: 'false',
+  serviceRates: JSON.stringify({ claude: 1.5 })
+})
+
+const modelUsageData = () => ({
+  requests: '2',
+  inputTokens: '1000',
+  outputTokens: '500',
+  cacheCreateTokens: '0',
+  cacheReadTokens: '0',
+  ephemeral5mTokens: '0',
+  ephemeral1hTokens: '0',
+  allTokens: '1500',
+  realCostMicro: '1000000',
+  ratedCostMicro: '1500000'
+})
+
+const setupRedisFixtures = () => {
+  const client = {
+    get: jest.fn(async (key) => (key === `usage:cost:total:${TEST_API_ID}` ? '1.5' : '0'))
+  }
+
+  redis.getApiKey.mockResolvedValue(buildKeyData())
+  redis.getUsageStats.mockResolvedValue({
+    total: { requests: 2, inputTokens: 1000, outputTokens: 500, allTokens: 1500 },
+    daily: { requests: 1, inputTokens: 500, outputTokens: 250, allTokens: 750 },
+    monthly: { requests: 2, inputTokens: 1000, outputTokens: 500, allTokens: 1500 }
+  })
+  redis.getDailyCost.mockResolvedValue(0)
+  redis.getCostStats.mockResolvedValue({ daily: 0, monthly: 1.5, total: 1.5 })
+  redis.getWeeklyOpusCost.mockResolvedValue(0)
+  redis.getClientSafe.mockReturnValue(client)
+  redis.getDateInTimezone.mockReturnValue(new Date('2026-04-29T00:00:00.000Z'))
+  redis.getDateStringInTimezone.mockReturnValue('2026-04-29')
+  redis.scanAndGetAllChunked.mockImplementation(async (pattern) => {
+    if (pattern.includes(':model:monthly:')) {
+      return [
+        {
+          key: `usage:${TEST_API_ID}:model:monthly:${TEST_MODEL}:${TEST_MONTH}`,
+          data: modelUsageData()
+        }
+      ]
+    }
+    return []
+  })
+  serviceRatesService.getRates.mockResolvedValue({
+    baseService: 'claude',
+    rates: { claude: 1.5, codex: 1 },
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    updatedBy: 'admin'
+  })
+}
+
+describe('apiStats customer billing privacy switch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.env.HIDE_CUSTOMER_BILLING_DETAILS
+    setupRedisFixtures()
+  })
+
+  it('keeps existing billing details visible by default', async () => {
+    const app = buildApp()
+
+    const statsResponse = await request(app)
+      .post('/apiStats/api/user-stats')
+      .send({ apiId: TEST_API_ID })
+
+    expect(statsResponse.status).toBe(200)
+    expect(statsResponse.body.data.serviceRates).toEqual({ claude: 1.5 })
+
+    const ratesResponse = await request(app).get('/apiStats/service-rates')
+
+    expect(ratesResponse.status).toBe(200)
+    expect(ratesResponse.body).toMatchObject({
+      success: true,
+      data: { rates: { claude: 1.5 } }
+    })
+
+    const modelResponse = await request(app)
+      .post('/apiStats/api/user-model-stats')
+      .send({ apiId: TEST_API_ID, period: 'monthly' })
+
+    expect(modelResponse.status).toBe(200)
+    expect(modelResponse.body.data[0].costs).toMatchObject({ real: 1, rated: 1.5 })
+    expect(modelResponse.body.data[0].pricing).toMatchObject({ input: 3, output: 15 })
+  })
+
+  it('hides customer billing details when HIDE_CUSTOMER_BILLING_DETAILS is enabled', async () => {
+    process.env.HIDE_CUSTOMER_BILLING_DETAILS = 'true'
+    const app = buildApp()
+
+    const statsResponse = await request(app)
+      .post('/apiStats/api/user-stats')
+      .send({ apiId: TEST_API_ID })
+
+    expect(statsResponse.status).toBe(200)
+    expect(statsResponse.body.data).not.toHaveProperty('serviceRates')
+
+    const ratesResponse = await request(app).get('/apiStats/service-rates')
+
+    expect(ratesResponse.status).toBe(200)
+    expect(ratesResponse.body).toEqual({
+      success: false,
+      data: null,
+      billingDetailsHidden: true
+    })
+
+    const modelResponse = await request(app)
+      .post('/apiStats/api/user-model-stats')
+      .send({ apiId: TEST_API_ID, period: 'monthly' })
+
+    expect(modelResponse.status).toBe(200)
+    expect(modelResponse.body.data[0]).not.toHaveProperty('pricing')
+    expect(modelResponse.body.data[0].costs).toEqual({ total: 1.5 })
+    expect(modelResponse.body.data[0].formatted).toEqual({ total: '$1.500000' })
+
+    const batchModelResponse = await request(app)
+      .post('/apiStats/api/batch-model-stats')
+      .send({ apiIds: [TEST_API_ID], period: 'monthly' })
+
+    expect(batchModelResponse.status).toBe(200)
+    expect(batchModelResponse.body.data[0]).not.toHaveProperty('pricing')
+    expect(batchModelResponse.body.data[0].costs).toEqual({ total: 1.5 })
+    expect(batchModelResponse.body.data[0].formatted).toEqual({ total: '$1.500000' })
+  })
+})

--- a/tests/apiStatsBillingPrivacyUiSource.test.js
+++ b/tests/apiStatsBillingPrivacyUiSource.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs')
+const path = require('path')
+
+const read = (relativePath) => fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8')
+
+describe('API stats billing privacy UI wiring', () => {
+  it('keeps the model cost label conditional instead of changing the default wording', () => {
+    const component = read('web/admin-spa/src/components/apistats/ModelUsageStats.vue')
+
+    expect(component).toContain('billingDetailsHidden')
+    expect(component).toContain('costLabel')
+    expect(component).toContain("billingDetailsHidden.value ? '使用费用' : '官方API'")
+  })
+
+  it('tracks the backend billingDetailsHidden response flag in the API stats store', () => {
+    const store = read('web/admin-spa/src/stores/apistats.js')
+
+    expect(store).toContain('const billingDetailsHidden = ref(false)')
+    expect(store).toContain('result?.billingDetailsHidden === true')
+    expect(store).toContain('billingDetailsHidden,')
+  })
+})

--- a/web/admin-spa/src/components/apistats/ModelUsageStats.vue
+++ b/web/admin-spa/src/components/apistats/ModelUsageStats.vue
@@ -48,11 +48,11 @@
             </div>
           </div>
           <div class="flex-shrink-0 text-xs sm:text-sm">
-            <span class="text-gray-500">官方API</span>
+            <span class="text-gray-500">{{ costLabel }}</span>
             <span class="ml-1 font-semibold text-green-600">
               {{ model.formatted?.total || '$0.00' }}
             </span>
-            <template v-if="serviceRates?.rates">
+            <template v-if="!billingDetailsHidden && serviceRates?.rates">
               <span class="ml-2 text-gray-500">计费</span>
               <span class="ml-1 font-semibold text-amber-600 dark:text-amber-400">
                 {{ calculateCcCost(model) }}
@@ -86,8 +86,14 @@ const props = defineProps({
 })
 
 const apiStatsStore = useApiStatsStore()
-const { dailyModelStats, monthlyModelStats, alltimeModelStats, modelStatsLoading, serviceRates } =
-  storeToRefs(apiStatsStore)
+const {
+  dailyModelStats,
+  monthlyModelStats,
+  alltimeModelStats,
+  modelStatsLoading,
+  serviceRates,
+  billingDetailsHidden
+} = storeToRefs(apiStatsStore)
 
 // 根据 period 选择对应的数据
 const stats = computed(() => {
@@ -98,6 +104,8 @@ const stats = computed(() => {
 })
 
 const loading = computed(() => modelStatsLoading.value)
+
+const costLabel = computed(() => (billingDetailsHidden.value ? '使用费用' : '官方API'))
 
 const periodLabel = computed(() => {
   if (props.period === 'daily') return '今日'

--- a/web/admin-spa/src/components/apistats/ServiceCostCards.vue
+++ b/web/admin-spa/src/components/apistats/ServiceCostCards.vue
@@ -1,5 +1,8 @@
 <template>
-  <div v-if="serviceRates && modelStats.length > 0" class="card p-3 sm:p-4 md:p-6">
+  <div
+    v-if="!billingDetailsHidden && serviceRates && modelStats.length > 0"
+    class="card p-3 sm:p-4 md:p-6"
+  >
     <h3
       class="mb-2 flex items-center justify-between text-base font-bold text-gray-900 dark:text-gray-100 sm:mb-3 sm:text-lg md:mb-4 md:text-xl"
     >
@@ -118,7 +121,8 @@ import { storeToRefs } from 'pinia'
 import { useApiStatsStore } from '@/stores/apistats'
 
 const apiStatsStore = useApiStatsStore()
-const { modelStats, serviceRates, keyServiceRates, multiKeyMode } = storeToRefs(apiStatsStore)
+const { modelStats, serviceRates, keyServiceRates, multiKeyMode, billingDetailsHidden } =
+  storeToRefs(apiStatsStore)
 
 // 服务标签映射
 const serviceLabels = {

--- a/web/admin-spa/src/components/apistats/StatsOverview.vue
+++ b/web/admin-spa/src/components/apistats/StatsOverview.vue
@@ -311,7 +311,8 @@ const {
   multiKeyMode,
   aggregatedStats,
   individualStats,
-  invalidKeys
+  invalidKeys,
+  billingDetailsHidden
 } = storeToRefs(apiStatsStore)
 
 const topContributors = computed(() => {
@@ -323,7 +324,11 @@ const topContributors = computed(() => {
 
 // 是否有自定义服务倍率
 const hasServiceRates = computed(() => {
-  return statsData.value?.serviceRates && Object.keys(statsData.value.serviceRates).length > 0
+  return (
+    !billingDetailsHidden.value &&
+    statsData.value?.serviceRates &&
+    Object.keys(statsData.value.serviceRates).length > 0
+  )
 })
 
 const calculateContribution = (stat) => {

--- a/web/admin-spa/src/stores/apistats.js
+++ b/web/admin-spa/src/stores/apistats.js
@@ -36,6 +36,7 @@ export const useApiStatsStore = defineStore('apistats', () => {
 
   // 服务倍率配置
   const serviceRates = ref(null)
+  const billingDetailsHidden = ref(false)
 
   // Key 级别的服务倍率
   const keyServiceRates = ref({})
@@ -140,7 +141,9 @@ export const useApiStatsStore = defineStore('apistats', () => {
           statsData.value = statsResult.data
 
           // 保存 Key 级别的服务倍率
-          keyServiceRates.value = statsResult.data.serviceRates || {}
+          keyServiceRates.value = billingDetailsHidden.value
+            ? {}
+            : statsResult.data.serviceRates || {}
 
           // 同时加载今日和本月的统计数据
           await loadAllPeriodStats()
@@ -323,7 +326,7 @@ export const useApiStatsStore = defineStore('apistats', () => {
         statsData.value = result.data
 
         // 保存 Key 级别的服务倍率
-        keyServiceRates.value = result.data.serviceRates || {}
+        keyServiceRates.value = billingDetailsHidden.value ? {} : result.data.serviceRates || {}
 
         // 调试：打印返回的限制数据
         console.log('API Stats - Full response:', result.data)
@@ -374,12 +377,12 @@ export const useApiStatsStore = defineStore('apistats', () => {
   async function loadServiceRates() {
     try {
       const result = await httpApis.getServiceRatesApi()
-      if (result && result.success && result.data) {
-        serviceRates.value = result.data
-      }
+      billingDetailsHidden.value = result?.billingDetailsHidden === true
+      serviceRates.value = result && result.success && result.data ? result.data : null
     } catch (err) {
       console.error('Error loading service rates:', err)
       serviceRates.value = null
+      billingDetailsHidden.value = false
     }
   }
 
@@ -599,6 +602,7 @@ export const useApiStatsStore = defineStore('apistats', () => {
     individualStats,
     invalidKeys,
     serviceRates,
+    billingDetailsHidden,
     keyServiceRates,
 
     // Computed


### PR DESCRIPTION
## Summary
- Add `HIDE_CUSTOMER_BILLING_DETAILS` as an opt-in environment flag for API stats privacy.
- When enabled, customer stats responses no longer expose service rate multipliers or raw/rated/pricing breakdowns, while preserving the customer-billed total.
- Update the admin SPA to suppress service-rate UI and use neutral "使用费用" cost labeling when billing details are hidden.

## Behavior
Default behavior is unchanged. The privacy mode is only enabled when `HIDE_CUSTOMER_BILLING_DETAILS` is set to a true-like value: `true`, `1`, `yes`, or `on`.

When enabled:
- `/apiStats/api/user-stats` omits `serviceRates`.
- `/apiStats/service-rates` returns `billingDetailsHidden: true` and no rate payload.
- `/apiStats/api/user-model-stats` and batch model stats omit `real`, `rated`, and `pricing` details while keeping the displayed total cost.

## Test Plan
- [x] `npm run lint:check`
- [x] `npm test -- --runInBand`
- [x] `cd web/admin-spa && npm run build`

Closes #1171
