### PR TITLE
fix(openai): surface OAuth exchange errors clearly

### DIFF
--- a/src/routes/admin/openaiAccounts.js
+++ b/src/routes/admin/openaiAccounts.js
@@ -217,11 +217,27 @@ router.post('/exchange-code', authenticateAdmin, async (req, res) => {
       }
     })
   } catch (error) {
+    const openaiError = error.response?.data?.error || null
+    const openaiErrorCode = openaiError?.code || ''
+    const openaiErrorMessage = openaiError?.message || ''
+
+    if (openaiErrorCode === 'unsupported_country_region_territory') {
+      logger.error('OpenAI OAuth token exchange rejected by region policy:', error)
+      return res.status(403).json({
+        success: false,
+        message:
+          'OpenAI 拒绝了这次授权码交换：当前服务端出口 IP 所在国家或地区不受支持。请更换服务端代理出口后重试。',
+        error: openaiErrorCode,
+        details: openaiErrorMessage
+      })
+    }
+
     logger.error('OpenAI OAuth token exchange failed:', error)
     return res.status(500).json({
       success: false,
       message: '交换授权码失败',
-      error: error.message
+      error: error.message,
+      details: openaiErrorMessage || null
     })
   }
 })

--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -5104,8 +5104,17 @@ const handleOAuthSuccess = async (tokenInfoOrList) => {
       // 添加 Gemini 优先级
       data.priority = form.value.priority || 50
     } else if (currentPlatform === 'openai') {
-      data.openaiOauth = tokenInfo.tokens || tokenInfo
-      data.accountInfo = tokenInfo.accountInfo
+      const rawTokenInfo = tokenInfo || {}
+      const openaiOauth = rawTokenInfo.tokens || rawTokenInfo
+
+      if (!openaiOauth || Object.keys(openaiOauth).length === 0) {
+        loading.value = false
+        showToast('OpenAI 授权成功，但未返回有效的 Token 数据，请重试。', 'error')
+        return
+      }
+
+      data.openaiOauth = openaiOauth
+      data.accountInfo = rawTokenInfo.accountInfo || {}
       data.priority = form.value.priority || 50
     } else if (currentPlatform === 'droid') {
       const rawTokens = tokenInfo.tokens || tokenInfo || {}

--- a/web/admin-spa/src/stores/accounts.js
+++ b/web/admin-spa/src/stores/accounts.js
@@ -241,8 +241,12 @@ export const useAccountsStore = defineStore('accounts', () => {
 
   const exchangeOpenAICode = async (data) => {
     const res = await httpApis.exchangeOpenAICodeApi(data)
-    if (!res.success) error.value = res.message
-    return res.success ? res.data : null
+    if (!res.success) {
+      error.value = res.message
+      const detailMessage = res.details ? `${res.message}\n${res.details}` : res.message
+      throw new Error(detailMessage || 'OpenAI 授权码交换失败')
+    }
+    return res.data
   }
 
   const generateDroidAuthUrl = async (proxyConfig) => {

--- a/web/admin-spa/src/utils/request.js
+++ b/web/admin-spa/src/utils/request.js
@@ -41,7 +41,13 @@ const request = async (config) => {
     if (data) {
       if (typeof data.success !== 'undefined') return data
       // 处理 { error, message } 格式的响应
-      if (data.error || data.message) return { success: false, message: data.message || data.error }
+      if (data.error || data.message)
+        return {
+          success: false,
+          message: data.message || data.error,
+          details: data.details || null,
+          error: data.error || null
+        }
     }
     const status = error.response?.status
     const messages = {


### PR DESCRIPTION
## Summary

This PR improves the OpenAI OAuth exchange flow in the admin account form.

Before this change:
- the frontend could crash with `Cannot read properties of null (reading 'tokens')`
- backend OAuth exchange failures were collapsed into a generic `交换授权码失败`
- the UI did not surface the actual OpenAI error returned by `/oauth/token`

After this change:
- the form guards against empty/null OAuth payloads
- backend detects `unsupported_country_region_territory` explicitly
- frontend surfaces backend `details` so the operator can see the real failure reason

## Changes

- handle empty OpenAI OAuth payload safely in `AccountForm.vue`
- throw explicit errors in `accounts.js` when OpenAI code exchange fails
- preserve `details` from backend errors in `request.js`
- detect and return a clearer 403 response for OpenAI region-policy rejection in `openaiAccounts.js`

## User-facing behavior

Instead of:
- `Cannot read properties of null (reading 'tokens')`
- or a generic `交换授权码失败`

the UI now shows a clearer message when OpenAI rejects the token exchange because of region policy.

## Screenshot

Previous error screenshot available locally from the reporter and should be attached in the GitHub PR editor if needed.

## Notes

Observed backend response from OpenAI:
- HTTP 403
- `unsupported_country_region_territory`
- `Country, region, or territory not supported`
