### PR TITLE
fix(request-details): correct cache hit rate and fallback costs

### DIFF
--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -1866,56 +1866,50 @@ class ApiKeyService {
 
       const totalTokens = inputTokens + outputTokens + cacheCreateTokens + cacheReadTokens
 
-      // 计算费用（支持详细的缓存类型）- 添加错误处理
-      let costInfo = { totalCost: 0, ephemeral5mCost: 0, ephemeral1hCost: 0 }
+      // 计算费用统一走 CostCalculator，缺少动态价格时使用内置 unknown fallback。
+      let costInfo = {
+        totalCost: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheCreateCost: 0,
+        cacheReadCost: 0,
+        ephemeral5mCost: 0,
+        ephemeral1hCost: 0,
+        isLongContextRequest: false,
+        usedFallbackPricing: false,
+        pricingSource: null
+      }
       try {
-        const pricingService = require('./pricingService')
-        // 确保 pricingService 已初始化
-        if (!pricingService.pricingData) {
-          logger.warn('⚠️ PricingService not initialized, initializing now...')
-          await pricingService.initialize()
-        }
-        costInfo = pricingService.calculateCost(usageObject, model)
+        const CostCalculator = require('../utils/costCalculator')
+        const calculatedCost = CostCalculator.calculateCost(usageObject, model)
+        const costs = calculatedCost?.costs || {}
+        const totalCost = Number(costs.total ?? calculatedCost?.totalCost ?? 0)
 
-        // 验证计算结果
-        if (!costInfo || typeof costInfo.totalCost !== 'number') {
-          logger.error(`❌ Invalid cost calculation result for model ${model}:`, costInfo)
-          // 使用 CostCalculator 作为后备
-          const CostCalculator = require('../utils/costCalculator')
-          const fallbackCost = CostCalculator.calculateCost(usageObject, model)
-          if (fallbackCost && fallbackCost.costs && fallbackCost.costs.total > 0) {
-            logger.warn(
-              `⚠️ Using fallback cost calculation for ${model}: $${fallbackCost.costs.total}`
-            )
-            costInfo = {
-              totalCost: fallbackCost.costs.total,
-              ephemeral5mCost: 0,
-              ephemeral1hCost: 0
-            }
-          } else {
-            costInfo = { totalCost: 0, ephemeral5mCost: 0, ephemeral1hCost: 0 }
-          }
+        if (!Number.isFinite(totalCost)) {
+          throw new Error(`Invalid cost calculation result for model ${model}`)
+        }
+
+        costInfo = {
+          totalCost,
+          inputCost: Number(costs.input ?? calculatedCost?.inputCost ?? 0) || 0,
+          outputCost: Number(costs.output ?? calculatedCost?.outputCost ?? 0) || 0,
+          cacheCreateCost:
+            Number(costs.cacheCreate ?? costs.cacheWrite ?? calculatedCost?.cacheCreateCost ?? 0) ||
+            0,
+          cacheReadCost: Number(costs.cacheRead ?? calculatedCost?.cacheReadCost ?? 0) || 0,
+          ephemeral5mCost: Number(costs.ephemeral5m ?? calculatedCost?.ephemeral5mCost ?? 0) || 0,
+          ephemeral1hCost: Number(costs.ephemeral1h ?? calculatedCost?.ephemeral1hCost ?? 0) || 0,
+          isLongContextRequest:
+            calculatedCost?.isLongContextRequest === true ||
+            calculatedCost?.debug?.isLongContextRequest === true,
+          usedFallbackPricing: calculatedCost?.debug?.usedFallbackPricing === true,
+          pricingSource:
+            calculatedCost?.debug?.pricingSource ||
+            (calculatedCost?.usingDynamicPricing ? 'dynamic' : 'unknown-fallback')
         }
       } catch (pricingError) {
         logger.error(`❌ Failed to calculate cost for model ${model}:`, pricingError)
         logger.error(`   Usage object:`, JSON.stringify(usageObject))
-        // 使用 CostCalculator 作为后备
-        try {
-          const CostCalculator = require('../utils/costCalculator')
-          const fallbackCost = CostCalculator.calculateCost(usageObject, model)
-          if (fallbackCost && fallbackCost.costs && fallbackCost.costs.total > 0) {
-            logger.warn(
-              `⚠️ Using fallback cost calculation for ${model}: $${fallbackCost.costs.total}`
-            )
-            costInfo = {
-              totalCost: fallbackCost.costs.total,
-              ephemeral5mCost: 0,
-              ephemeral1hCost: 0
-            }
-          }
-        } catch (fallbackError) {
-          logger.error(`❌ Fallback cost calculation also failed:`, fallbackError)
-        }
       }
 
       // 提取详细的缓存创建数据
@@ -2048,14 +2042,26 @@ class ApiKeyService {
         totalTokens,
         cost: Number(ratedCostWithDetails.toFixed(6)),
         realCost: Number(realCostWithDetails.toFixed(6)),
+        costBreakdown: {
+          input: costInfo.inputCost || 0,
+          output: costInfo.outputCost || 0,
+          cacheCreate: costInfo.cacheCreateCost || 0,
+          cacheRead: costInfo.cacheReadCost || 0,
+          ephemeral5m: costInfo.ephemeral5mCost || 0,
+          ephemeral1h: costInfo.ephemeral1hCost || 0,
+          total: realCostWithDetails
+        },
         realCostBreakdown: {
           input: costInfo.inputCost || 0,
           output: costInfo.outputCost || 0,
           cacheCreate: costInfo.cacheCreateCost || 0,
           cacheRead: costInfo.cacheReadCost || 0,
           ephemeral5m: costInfo.ephemeral5mCost || 0,
-          ephemeral1h: costInfo.ephemeral1hCost || 0
+          ephemeral1h: costInfo.ephemeral1hCost || 0,
+          total: realCostWithDetails
         },
+        pricingSource: costInfo.pricingSource || null,
+        usedFallbackPricing: costInfo.usedFallbackPricing === true,
         isLongContext: costInfo.isLongContextRequest || false
       }
 
@@ -2153,6 +2159,8 @@ class ApiKeyService {
       realCost: usageRecord.realCost || usageRecord.cost || 0,
       costBreakdown: usageRecord.costBreakdown || null,
       realCostBreakdown: usageRecord.realCostBreakdown || usageRecord.costBreakdown || null,
+      pricingSource: usageRecord.pricingSource || null,
+      usedFallbackPricing: usageRecord.usedFallbackPricing === true,
       isLongContextRequest:
         usageRecord.isLongContext === true || usageRecord.isLongContextRequest === true
     })

--- a/src/services/requestDetailService.js
+++ b/src/services/requestDetailService.js
@@ -11,11 +11,13 @@ const openaiResponsesAccountService = require('./account/openaiResponsesAccountS
 const azureOpenaiAccountService = require('./account/azureOpenaiAccountService')
 const droidAccountService = require('./account/droidAccountService')
 const bedrockAccountService = require('./account/bedrockAccountService')
+const CostCalculator = require('../utils/costCalculator')
 const {
   sanitizeRequestBodySnapshot,
   getRequestDetailCacheMetrics,
   extractRequestReasoningInfo,
-  resolveRequestDetailReasoning
+  resolveRequestDetailReasoning,
+  CACHE_HIT_FORMULA
 } = require('../utils/requestDetailHelper')
 
 const REQUEST_DETAIL_ITEM_PREFIX = 'request_detail:item:'
@@ -76,6 +78,122 @@ function normalizeNumber(value, digits = null) {
   }
 
   return Number(num.toFixed(digits))
+}
+
+function normalizeTokenValue(value) {
+  return Math.max(0, Math.trunc(normalizeNumber(value)))
+}
+
+function buildCostUsageFromRequestDetail(record = {}) {
+  const inputTokens = normalizeTokenValue(record.inputTokens)
+  const outputTokens = normalizeTokenValue(record.outputTokens)
+  const cacheCreateTokens = normalizeTokenValue(record.cacheCreateTokens)
+  const cacheReadTokens = normalizeTokenValue(record.cacheReadTokens)
+  const usage = {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_creation_input_tokens: cacheCreateTokens,
+    cache_read_input_tokens: cacheReadTokens
+  }
+
+  const ephemeral5mTokens = normalizeTokenValue(
+    record.ephemeral5mTokens ?? record.cache_creation?.ephemeral_5m_input_tokens
+  )
+  const ephemeral1hTokens = normalizeTokenValue(
+    record.ephemeral1hTokens ?? record.cache_creation?.ephemeral_1h_input_tokens
+  )
+
+  if (ephemeral5mTokens > 0 || ephemeral1hTokens > 0) {
+    usage.cache_creation = {
+      ephemeral_5m_input_tokens: ephemeral5mTokens,
+      ephemeral_1h_input_tokens: ephemeral1hTokens
+    }
+  }
+
+  return usage
+}
+
+function getCostResultNumber(costResult, key, fallbackKey = null) {
+  return normalizeNumber(costResult?.costs?.[key] ?? costResult?.[fallbackKey] ?? 0, 12)
+}
+
+function buildCostBreakdownFromResult(costResult) {
+  const input = getCostResultNumber(costResult, 'input', 'inputCost')
+  const output = getCostResultNumber(costResult, 'output', 'outputCost')
+  const cacheCreate =
+    getCostResultNumber(costResult, 'cacheCreate', 'cacheCreateCost') ||
+    getCostResultNumber(costResult, 'cacheWrite', 'cacheCreateCost')
+  const cacheRead = getCostResultNumber(costResult, 'cacheRead', 'cacheReadCost')
+  const ephemeral5m = getCostResultNumber(costResult, 'ephemeral5m', 'ephemeral5mCost')
+  const ephemeral1h = getCostResultNumber(costResult, 'ephemeral1h', 'ephemeral1hCost')
+  const total = getCostResultNumber(costResult, 'total', 'totalCost')
+
+  return {
+    input,
+    output,
+    cacheCreate,
+    cacheWrite: cacheCreate,
+    cacheRead,
+    ephemeral5m,
+    ephemeral1h,
+    total
+  }
+}
+
+function createCostRecomputePatch(record = {}) {
+  const storedCost = normalizeNumber(record.cost, 6)
+  const storedRealCost = normalizeNumber(record.realCost, 6)
+  if (storedCost > 0 || storedRealCost > 0) {
+    return null
+  }
+
+  const usage = buildCostUsageFromRequestDetail(record)
+  const totalTokens =
+    usage.input_tokens +
+    usage.output_tokens +
+    usage.cache_creation_input_tokens +
+    usage.cache_read_input_tokens
+  if (totalTokens <= 0) {
+    return null
+  }
+
+  try {
+    const costResult = CostCalculator.calculateCost(usage, record.model || 'unknown')
+    const totalCost = normalizeNumber(costResult?.costs?.total ?? costResult?.totalCost ?? 0, 6)
+    if (totalCost <= 0) {
+      return null
+    }
+
+    const breakdown = buildCostBreakdownFromResult(costResult)
+    const pricingSource =
+      costResult?.debug?.pricingSource ||
+      (costResult?.usingDynamicPricing ? 'dynamic' : 'unknown-fallback')
+
+    return {
+      cost: totalCost,
+      realCost: totalCost,
+      costBreakdown: breakdown,
+      realCostBreakdown: breakdown,
+      costRecomputed: true,
+      usedFallbackPricing: costResult?.debug?.usedFallbackPricing === true,
+      pricingSource
+    }
+  } catch (error) {
+    logger.debug(`⚠️ Failed to recompute request detail cost: ${error.message}`)
+    return null
+  }
+}
+
+function prepareRecordForDisplay(record = {}) {
+  const costPatch = createCostRecomputePatch(record)
+  if (!costPatch) {
+    return record
+  }
+
+  return {
+    ...record,
+    ...costPatch
+  }
 }
 
 function formatDayKey(date) {
@@ -504,6 +622,9 @@ function finalizeSummary(accumulator) {
             ((accumulator.cacheHitNumerator / accumulator.cacheHitDenominator) * 100).toFixed(2)
           )
         : 0,
+    cacheHitNumerator: accumulator.cacheHitNumerator,
+    cacheHitDenominator: accumulator.cacheHitDenominator,
+    cacheHitFormula: CACHE_HIT_FORMULA,
     cacheCreateNotApplicable:
       accumulator.totalRequests > 0 &&
       accumulator.openAIRelatedRequests === accumulator.totalRequests
@@ -565,6 +686,9 @@ class RequestDetailService {
         totalCost: 0,
         avgDurationMs: 0,
         cacheHitRate: 0,
+        cacheHitNumerator: 0,
+        cacheHitDenominator: 0,
+        cacheHitFormula: CACHE_HIT_FORMULA,
         cacheCreateNotApplicable: false
       }
     }
@@ -606,6 +730,9 @@ class RequestDetailService {
       realCost,
       costBreakdown: detail.costBreakdown || null,
       realCostBreakdown: detail.realCostBreakdown || null,
+      pricingSource: detail.pricingSource || null,
+      usedFallbackPricing: detail.usedFallbackPricing === true,
+      costRecomputed: detail.costRecomputed === true,
       durationMs,
       isLongContextRequest: detail.isLongContextRequest === true,
       reasoningDisplay: detail.reasoningDisplay || reasoningInfo.reasoningDisplay || null,
@@ -933,28 +1060,32 @@ class RequestDetailService {
     const enriched = []
 
     for (const record of records) {
-      const cacheMetrics = getRequestDetailCacheMetrics(record)
-      const reasoningInfo = resolveRequestDetailReasoning(record)
-      const apiKeyName = await this._getApiKeyName(record.apiKeyId, apiKeyCache)
+      const displayRecord = prepareRecordForDisplay(record)
+      const cacheMetrics = getRequestDetailCacheMetrics(displayRecord)
+      const reasoningInfo = resolveRequestDetailReasoning(displayRecord)
+      const apiKeyName = await this._getApiKeyName(displayRecord.apiKeyId, apiKeyCache)
       const accountInfo = await this._resolveAccountInfo(
-        record.accountId,
-        record.accountType,
+        displayRecord.accountId,
+        displayRecord.accountType,
         accountCache
       )
 
       enriched.push({
-        ...record,
-        apiKeyName: apiKeyName || record.apiKeyId || '未知 Key',
-        accountName: accountInfo?.accountName || record.accountId || '未知账户',
-        accountType: accountInfo?.accountType || record.accountType || 'unknown',
+        ...displayRecord,
+        apiKeyName: apiKeyName || displayRecord.apiKeyId || '未知 Key',
+        accountName: accountInfo?.accountName || displayRecord.accountId || '未知账户',
+        accountType: accountInfo?.accountType || displayRecord.accountType || 'unknown',
         accountTypeName:
           accountInfo?.accountTypeName ||
-          accountTypeNames[record.accountType] ||
+          accountTypeNames[displayRecord.accountType] ||
           accountTypeNames.unknown,
         isOpenAIRelated: cacheMetrics.isOpenAIRelated,
         cacheCreateNotApplicable: cacheMetrics.cacheCreateNotApplicable,
         cacheHitRate: cacheMetrics.rate,
-        hasRequestBodySnapshot: Boolean(record.requestBodySnapshot),
+        cacheHitNumerator: cacheMetrics.numerator,
+        cacheHitDenominator: cacheMetrics.denominator,
+        cacheHitFormula: cacheMetrics.cacheHitFormula,
+        hasRequestBodySnapshot: Boolean(displayRecord.requestBodySnapshot),
         reasoningDisplay: reasoningInfo.reasoningDisplay,
         reasoningSource: reasoningInfo.reasoningSource
       })
@@ -1183,11 +1314,12 @@ class RequestDetailService {
             continue
           }
 
-          updateSummaryAccumulator(summaryAccumulator, record)
+          const displayRecord = prepareRecordForDisplay(record)
+          updateSummaryAccumulator(summaryAccumulator, displayRecord)
 
           matchedPointers.push({
-            requestId: record.requestId,
-            timestampMs: toMillis(record.timestamp) ?? pointer.timestampMs
+            requestId: displayRecord.requestId,
+            timestampMs: toMillis(displayRecord.timestamp) ?? pointer.timestampMs
           })
         }
       }

--- a/src/utils/costCalculator.js
+++ b/src/utils/costCalculator.js
@@ -166,15 +166,21 @@ class CostCalculator {
       costs: {
         input: result.inputCost,
         output: result.outputCost,
+        cacheCreate: result.cacheCreateCost,
         cacheWrite: result.cacheCreateCost,
         cacheRead: result.cacheReadCost,
+        ephemeral5m: result.ephemeral5mCost || 0,
+        ephemeral1h: result.ephemeral1hCost || 0,
         total: result.totalCost
       },
       formatted: {
         input: this.formatCost(result.inputCost),
         output: this.formatCost(result.outputCost),
+        cacheCreate: this.formatCost(result.cacheCreateCost),
         cacheWrite: this.formatCost(result.cacheCreateCost),
         cacheRead: this.formatCost(result.cacheReadCost),
+        ephemeral5m: this.formatCost(result.ephemeral5mCost || 0),
+        ephemeral1h: this.formatCost(result.ephemeral1hCost || 0),
         total: this.formatCost(result.totalCost)
       },
       debug: {
@@ -261,15 +267,21 @@ class CostCalculator {
       costs: {
         input: inputCost,
         output: outputCost,
+        cacheCreate: cacheWriteCost,
         cacheWrite: cacheWriteCost,
         cacheRead: cacheReadCost,
+        ephemeral5m: 0,
+        ephemeral1h: 0,
         total: totalCost
       },
       formatted: {
         input: this.formatCost(inputCost),
         output: this.formatCost(outputCost),
+        cacheCreate: this.formatCost(cacheWriteCost),
         cacheWrite: this.formatCost(cacheWriteCost),
         cacheRead: this.formatCost(cacheReadCost),
+        ephemeral5m: this.formatCost(0),
+        ephemeral1h: this.formatCost(0),
         total: this.formatCost(totalCost)
       },
       debug: {

--- a/src/utils/requestDetailHelper.js
+++ b/src/utils/requestDetailHelper.js
@@ -8,6 +8,7 @@ const ENCRYPTED_CONTENT_KEY = 'encrypted_content'
 const TOOLS_KEY = 'tools'
 const PREVIEW_TRUNCATION_SUFFIX_PATTERN = /\.\.\.\[(?:truncated )?(\d+) chars\]$/
 const OPENAI_RELATED_ACCOUNT_TYPES = new Set(['openai', 'openai-responses', 'azure-openai'])
+const CACHE_HIT_FORMULA = 'cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreateTokens)'
 
 function toFiniteNumber(value) {
   if (value === undefined || value === null || value === '') {
@@ -656,7 +657,7 @@ function getRequestDetailCacheMetrics(detail = {}) {
   const input = Math.max(0, Number(detail.inputTokens) || 0)
   const isOpenAIRelated =
     OPENAI_RELATED_ACCOUNT_TYPES.has(detail.accountType) || isOpenAIRelatedEndpoint(detail.endpoint)
-  const denominator = isOpenAIRelated ? input + read : read + create
+  const denominator = input + read + create
 
   if (denominator <= 0) {
     return {
@@ -664,6 +665,8 @@ function getRequestDetailCacheMetrics(detail = {}) {
       cacheCreateNotApplicable: isOpenAIRelated,
       numerator: read,
       denominator: 0,
+      formula: CACHE_HIT_FORMULA,
+      cacheHitFormula: CACHE_HIT_FORMULA,
       rate: 0
     }
   }
@@ -673,18 +676,25 @@ function getRequestDetailCacheMetrics(detail = {}) {
     cacheCreateNotApplicable: isOpenAIRelated,
     numerator: read,
     denominator,
+    formula: CACHE_HIT_FORMULA,
+    cacheHitFormula: CACHE_HIT_FORMULA,
     rate: Number(((read / denominator) * 100).toFixed(2))
   }
 }
 
-function calculateCacheHitRate(cacheReadTokensOrDetail = 0, cacheCreateTokens = 0) {
+function calculateCacheHitRate(
+  cacheReadTokensOrDetail = 0,
+  cacheCreateTokens = 0,
+  inputTokens = 0
+) {
   if (typeof cacheReadTokensOrDetail === 'object' && cacheReadTokensOrDetail !== null) {
     return getRequestDetailCacheMetrics(cacheReadTokensOrDetail).rate
   }
 
   const read = Math.max(0, Number(cacheReadTokensOrDetail) || 0)
   const create = Math.max(0, Number(cacheCreateTokens) || 0)
-  const denominator = read + create
+  const input = Math.max(0, Number(inputTokens) || 0)
+  const denominator = input + read + create
 
   if (denominator <= 0) {
     return 0
@@ -701,6 +711,7 @@ module.exports = {
   finalizeRequestDetailMeta,
   extractOpenAICacheReadTokens,
   isOpenAIRelatedEndpoint,
+  CACHE_HIT_FORMULA,
   getRequestDetailCacheMetrics,
   calculateCacheHitRate
 }

--- a/tests/apiKeyServiceOpenAIResponsesConfig.test.js
+++ b/tests/apiKeyServiceOpenAIResponsesConfig.test.js
@@ -10,7 +10,11 @@ jest.mock(
 
 jest.mock('../src/models/redis', () => ({
   setApiKey: jest.fn(),
-  getApiKey: jest.fn()
+  getApiKey: jest.fn(),
+  incrementTokenUsage: jest.fn(),
+  incrementDailyCost: jest.fn(),
+  incrementAccountUsage: jest.fn(),
+  addUsageRecord: jest.fn()
 }))
 
 jest.mock('../src/services/costRankService', () => ({
@@ -25,11 +29,24 @@ jest.mock('../src/services/apiKeyIndexService', () => ({
 jest.mock('../src/utils/logger', () => ({
   success: jest.fn(),
   warn: jest.fn(),
-  error: jest.fn()
+  error: jest.fn(),
+  database: jest.fn(),
+  debug: jest.fn()
 }))
 
-jest.mock('../src/services/serviceRatesService', () => ({}))
-jest.mock('../src/services/requestDetailService', () => ({}))
+jest.mock('../src/services/serviceRatesService', () => ({
+  getService: jest.fn(),
+  getServiceRate: jest.fn()
+}))
+jest.mock('../src/services/requestDetailService', () => ({
+  captureRequestDetail: jest.fn()
+}))
+jest.mock('../src/services/billingEventPublisher', () => ({
+  publishBillingEvent: jest.fn()
+}))
+jest.mock('../src/utils/costCalculator', () => ({
+  calculateCost: jest.fn()
+}))
 jest.mock('../src/utils/modelHelper', () => ({
   isClaudeFamilyModel: jest.fn(() => false)
 }))
@@ -38,11 +55,29 @@ jest.mock('../src/utils/requestDetailHelper', () => ({
 }))
 
 const redis = require('../src/models/redis')
+const serviceRatesService = require('../src/services/serviceRatesService')
+const requestDetailService = require('../src/services/requestDetailService')
+const billingEventPublisher = require('../src/services/billingEventPublisher')
+const CostCalculator = require('../src/utils/costCalculator')
 const apiKeyService = require('../src/services/apiKeyService')
 
 describe('apiKeyService openai responses config', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    redis.getApiKey.mockResolvedValue({
+      id: 'key-1',
+      name: 'Key',
+      serviceRates: '{}'
+    })
+    redis.setApiKey.mockResolvedValue()
+    redis.incrementTokenUsage.mockResolvedValue()
+    redis.incrementDailyCost.mockResolvedValue()
+    redis.incrementAccountUsage.mockResolvedValue()
+    redis.addUsageRecord.mockResolvedValue()
+    serviceRatesService.getService.mockReturnValue('claude')
+    serviceRatesService.getServiceRate.mockResolvedValue(1)
+    requestDetailService.captureRequestDetail.mockResolvedValue({ captured: true })
+    billingEventPublisher.publishBillingEvent.mockResolvedValue()
   })
 
   test('generateApiKey stores default toggle values', async () => {
@@ -122,5 +157,84 @@ describe('apiKeyService openai responses config', () => {
     expect(result.openaiResponsesPayloadRules).toEqual([
       { path: 'model', valueType: 'string', value: 'gpt-5' }
     ])
+  })
+
+  test('recordUsageWithDetails uses CostCalculator unknown fallback for missing model pricing', async () => {
+    CostCalculator.calculateCost.mockReturnValue({
+      costs: {
+        input: 0.051618,
+        output: 0.000765,
+        cacheCreate: 0,
+        cacheWrite: 0,
+        cacheRead: 0.0006144,
+        total: 0.0529974
+      },
+      debug: {
+        usedFallbackPricing: true,
+        pricingSource: 'unknown-fallback',
+        isLongContextRequest: false
+      },
+      usingDynamicPricing: false
+    })
+
+    const result = await apiKeyService.recordUsageWithDetails(
+      'key-1',
+      {
+        input_tokens: 17206,
+        output_tokens: 51,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 2048
+      },
+      'mimo-v2.5-pro',
+      'acct-1',
+      'claude-console',
+      {
+        requestId: 'req-1',
+        endpoint: '/api/v1/messages',
+        method: 'POST',
+        statusCode: 200
+      }
+    )
+
+    expect(CostCalculator.calculateCost).toHaveBeenCalledWith(
+      {
+        input_tokens: 17206,
+        output_tokens: 51,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 2048
+      },
+      'mimo-v2.5-pro'
+    )
+    expect(result.realCost).toBeCloseTo(0.0529974, 10)
+    expect(result.ratedCost).toBeCloseTo(0.0529974, 10)
+    expect(redis.incrementDailyCost.mock.calls[0][0]).toBe('key-1')
+    expect(redis.incrementDailyCost.mock.calls[0][1]).toBeCloseTo(0.0529974, 10)
+    expect(redis.incrementDailyCost.mock.calls[0][2]).toBeCloseTo(0.0529974, 10)
+    expect(redis.addUsageRecord).toHaveBeenCalledWith(
+      'key-1',
+      expect.objectContaining({
+        model: 'mimo-v2.5-pro',
+        cost: 0.052997,
+        realCost: 0.052997,
+        usedFallbackPricing: true,
+        pricingSource: 'unknown-fallback',
+        costBreakdown: expect.objectContaining({
+          input: 0.051618,
+          output: 0.000765,
+          cacheRead: 0.0006144,
+          total: 0.0529974
+        })
+      })
+    )
+    expect(requestDetailService.captureRequestDetail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'req-1',
+        model: 'mimo-v2.5-pro',
+        cost: 0.052997,
+        realCost: 0.052997,
+        usedFallbackPricing: true,
+        pricingSource: 'unknown-fallback'
+      })
+    )
   })
 })

--- a/tests/requestDetailHelper.test.js
+++ b/tests/requestDetailHelper.test.js
@@ -6,6 +6,7 @@ const {
   finalizeRequestDetailMeta,
   extractOpenAICacheReadTokens,
   isOpenAIRelatedEndpoint,
+  getRequestDetailCacheMetrics,
   calculateCacheHitRate
 } = require('../src/utils/requestDetailHelper')
 
@@ -253,18 +254,37 @@ describe('requestDetailHelper', () => {
     ).toBe(0)
   })
 
-  test('calculateCacheHitRate uses cacheRead / (cacheRead + cacheCreate) for non-openai requests', () => {
-    expect(calculateCacheHitRate(120, 80)).toBe(60)
+  test('calculateCacheHitRate uses cacheRead / (input + cacheRead + cacheCreate)', () => {
+    expect(calculateCacheHitRate(2048, 0, 17206)).toBe(10.64)
+    expect(calculateCacheHitRate(120, 80, 100)).toBe(40)
     expect(calculateCacheHitRate(0, 0)).toBe(0)
   })
 
-  test('calculateCacheHitRate uses cached_tokens / prompt_tokens for /openai/ requests', () => {
+  test('getRequestDetailCacheMetrics exposes formula details for the request detail page', () => {
+    const metrics = getRequestDetailCacheMetrics({
+      endpoint: '/api/v1/messages',
+      accountType: 'claude-console',
+      inputTokens: 17206,
+      outputTokens: 51,
+      cacheReadTokens: 2048,
+      cacheCreateTokens: 0
+    })
+
+    expect(metrics.numerator).toBe(2048)
+    expect(metrics.denominator).toBe(19254)
+    expect(metrics.rate).toBe(10.64)
+    expect(metrics.cacheHitFormula).toBe(
+      'cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreateTokens)'
+    )
+  })
+
+  test('calculateCacheHitRate uses the same input-side denominator for /openai/ requests', () => {
     expect(
       calculateCacheHitRate({
         endpoint: '/openai/v1/responses',
         inputTokens: 100,
         cacheReadTokens: 60,
-        cacheCreateTokens: 999
+        cacheCreateTokens: 0
       })
     ).toBe(37.5)
     expect(
@@ -276,7 +296,7 @@ describe('requestDetailHelper', () => {
     ).toBe(0)
   })
 
-  test('calculateCacheHitRate uses openai formula for azure records and non-openai formula for claude compatibility routes', () => {
+  test('calculateCacheHitRate uses one denominator for azure records and claude compatibility routes', () => {
     expect(
       calculateCacheHitRate({
         endpoint: '/azure/chat/completions',
@@ -295,6 +315,6 @@ describe('requestDetailHelper', () => {
         cacheReadTokens: 30,
         cacheCreateTokens: 20
       })
-    ).toBe(60)
+    ).toBe(20)
   })
 })

--- a/tests/requestDetailService.test.js
+++ b/tests/requestDetailService.test.js
@@ -27,17 +27,22 @@ jest.mock('../src/services/account/openaiResponsesAccountService', () => ({
 jest.mock('../src/services/account/azureOpenaiAccountService', () => ({ getAccount: jest.fn() }))
 jest.mock('../src/services/account/droidAccountService', () => ({ getAccount: jest.fn() }))
 jest.mock('../src/services/account/bedrockAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/utils/costCalculator', () => ({
+  calculateCost: jest.fn()
+}))
 
 const redis = require('../src/models/redis')
 const claudeRelayConfigService = require('../src/services/claudeRelayConfigService')
 const claudeAccountService = require('../src/services/account/claudeAccountService')
+const claudeConsoleAccountService = require('../src/services/account/claudeConsoleAccountService')
 const openaiAccountService = require('../src/services/account/openaiAccountService')
 const bedrockAccountService = require('../src/services/account/bedrockAccountService')
+const CostCalculator = require('../src/utils/costCalculator')
 const requestDetailService = require('../src/services/requestDetailService')
 
 describe('requestDetailService', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
     jest.useFakeTimers().setSystemTime(Date.parse('2026-04-07T18:00:00.000Z'))
   })
 
@@ -128,8 +133,8 @@ describe('requestDetailService', () => {
           inputTokens: 100,
           outputTokens: 50,
           cacheReadTokens: 60,
-          cacheCreateTokens: 40,
-          totalTokens: 250,
+          cacheCreateTokens: 0,
+          totalTokens: 210,
           cost: 0.5,
           durationMs: 1200,
           requestBodySnapshot: { model: 'gpt-5.4' }
@@ -157,6 +162,8 @@ describe('requestDetailService', () => {
     expect(result.summary.totalRequests).toBe(1)
     expect(result.summary.cacheCreateTokens).toBe(0)
     expect(result.summary.cacheCreateNotApplicable).toBe(true)
+    expect(result.summary.cacheHitNumerator).toBe(60)
+    expect(result.summary.cacheHitDenominator).toBe(160)
     expect(result.summary.cacheHitRate).toBe(37.5)
     expect(result.availableFilters.models).toEqual(['gpt-5.4'])
     expect(result.filters.hasCustomDateRange).toBe(true)
@@ -194,7 +201,7 @@ describe('requestDetailService', () => {
           inputTokens: 100,
           outputTokens: 20,
           cacheReadTokens: 60,
-          cacheCreateTokens: 40,
+          cacheCreateTokens: 0,
           totalTokens: 180,
           cost: 0.3,
           durationMs: 500
@@ -228,7 +235,12 @@ describe('requestDetailService', () => {
     expect(result.summary.totalRequests).toBe(2)
     expect(result.summary.cacheCreateNotApplicable).toBe(false)
     expect(result.summary.cacheCreateTokens).toBe(30)
-    expect(result.summary.cacheHitRate).toBe(40.91)
+    expect(result.summary.cacheHitNumerator).toBe(90)
+    expect(result.summary.cacheHitDenominator).toBe(310)
+    expect(result.summary.cacheHitFormula).toBe(
+      'cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreateTokens)'
+    )
+    expect(result.summary.cacheHitRate).toBe(29.03)
   })
 
   test('listRequestDetails treats azure-openai cache hits as openai-style metrics', async () => {
@@ -274,6 +286,97 @@ describe('requestDetailService', () => {
     expect(result.records[0].cacheHitRate).toBe(37.5)
     expect(result.summary.cacheCreateTokens).toBe(0)
     expect(result.summary.cacheHitRate).toBe(37.5)
+  })
+
+  test('reads retained zero-cost unknown model records with recomputed display cost', async () => {
+    claudeRelayConfigService.getConfig.mockResolvedValue({
+      requestDetailCaptureEnabled: true,
+      requestDetailRetentionHours: 6,
+      requestDetailBodyPreviewEnabled: true
+    })
+
+    redis.getApiKey.mockResolvedValue({ name: 'Mimo Key' })
+    claudeConsoleAccountService.getAccount.mockResolvedValue({ name: 'Claude Console' })
+    CostCalculator.calculateCost.mockReturnValue({
+      costs: {
+        input: 0.051618,
+        output: 0.000765,
+        cacheCreate: 0,
+        cacheWrite: 0,
+        cacheRead: 0.0006144,
+        total: 0.0529974
+      },
+      debug: {
+        usedFallbackPricing: true,
+        pricingSource: 'unknown-fallback'
+      },
+      usingDynamicPricing: false
+    })
+
+    const storedRecord = JSON.stringify({
+      requestId: 'req_mimo',
+      timestamp: '2026-04-07T12:00:00.000Z',
+      endpoint: '/api/v1/messages',
+      method: 'POST',
+      apiKeyId: 'key_mimo',
+      accountId: 'acct_mimo',
+      accountType: 'claude-console',
+      model: 'mimo-v2.5-pro',
+      inputTokens: 17206,
+      outputTokens: 51,
+      cacheReadTokens: 2048,
+      cacheCreateTokens: 0,
+      totalTokens: 19305,
+      cost: 0,
+      realCost: 0,
+      realCostBreakdown: {
+        input: 0,
+        output: 0,
+        cacheCreate: 0,
+        cacheRead: 0
+      },
+      durationMs: 5662
+    })
+    const client = {
+      zrangebyscore: jest.fn().mockResolvedValue(['req_mimo', '1775563200000']),
+      mget: jest.fn().mockResolvedValue([storedRecord]),
+      get: jest.fn().mockResolvedValue(storedRecord),
+      set: jest.fn().mockResolvedValue('OK')
+    }
+    redis.getClient.mockReturnValue(client)
+
+    const result = await requestDetailService.listRequestDetails({
+      startDate: '2026-04-07T00:00:00.000Z',
+      endDate: '2026-04-07T23:59:59.000Z'
+    })
+    const detail = await requestDetailService.getRequestDetail('req_mimo')
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].cacheHitRate).toBe(10.64)
+    expect(result.records[0].cacheHitNumerator).toBe(2048)
+    expect(result.records[0].cacheHitDenominator).toBe(19254)
+    expect(result.records[0].cost).toBe(0.052997)
+    expect(result.records[0].realCost).toBe(0.052997)
+    expect(result.records[0].costRecomputed).toBe(true)
+    expect(result.records[0].usedFallbackPricing).toBe(true)
+    expect(result.records[0].pricingSource).toBe('unknown-fallback')
+    expect(result.records[0].realCostBreakdown).toEqual(
+      expect.objectContaining({
+        input: 0.051618,
+        output: 0.000765,
+        cacheRead: 0.0006144,
+        total: 0.0529974
+      })
+    )
+    expect(result.summary.cacheHitRate).toBe(10.64)
+    expect(result.summary.totalCost).toBe(0.052997)
+    expect(detail.record.cost).toBe(0.052997)
+    expect(detail.record.costRecomputed).toBe(true)
+    expect(client.set).not.toHaveBeenCalledWith(
+      'request_detail:item:req_mimo',
+      expect.any(String),
+      expect.anything()
+    )
   })
 
   test('listRequestDetails still exposes retained data when capture is disabled', async () => {

--- a/web/admin-spa/src/components/admin/RequestDetailModal.vue
+++ b/web/admin-spa/src/components/admin/RequestDetailModal.vue
@@ -57,7 +57,11 @@
             <p class="info-value text-amber-600 dark:text-amber-400">
               {{ formatCost(detail.cost) }}
             </p>
-            <p class="info-sub">真实成本 {{ formatCost(detail.realCost) }}</p>
+            <p class="info-sub">
+              {{ detail.costRecomputed ? '估算成本' : '真实成本' }}
+              {{ formatCost(detail.realCost) }}
+              <span v-if="detail.usedFallbackPricing">unknown fallback</span>
+            </p>
           </div>
           <div class="info-card">
             <p class="info-label">缓存命中率</p>
@@ -365,9 +369,7 @@ const formattedSnapshot = computed(() => {
   return JSON.stringify(snapshotSource, null, 2)
 })
 
-const cacheHitRateLabel = computed(() =>
-  detail.value?.isOpenAIRelated ? 'cached_tokens / prompt_tokens' : '读 / (读 + 建)'
-)
+const cacheHitRateLabel = computed(() => '读 / (输入 + 读 + 建)')
 
 const emitClose = () => emit('close')
 

--- a/web/admin-spa/src/views/RequestDetailsView.vue
+++ b/web/admin-spa/src/views/RequestDetailsView.vue
@@ -112,8 +112,8 @@
                 {{ formatPercent(summary.cacheHitRate) }}
               </p>
               <p class="summary-sub">
-                读 {{ formatNumber(summary.cacheReadTokens) }} / 建
-                {{ formatCacheCreate(summary.cacheCreateTokens, summary.cacheCreateNotApplicable) }}
+                读 / (输入 + 读 + 建)：{{ formatNumber(summary.cacheHitNumerator) }} /
+                {{ formatNumber(summary.cacheHitDenominator) }}
               </p>
             </div>
             <div class="summary-card">
@@ -650,6 +650,9 @@ const summary = reactive({
   totalCost: 0,
   avgDurationMs: 0,
   cacheHitRate: 0,
+  cacheHitNumerator: 0,
+  cacheHitDenominator: 0,
+  cacheHitFormula: 'cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreateTokens)',
   cacheCreateNotApplicable: false
 })
 
@@ -769,6 +772,11 @@ const syncResponseState = (data) => {
   summary.totalCost = summaryData.totalCost || 0
   summary.avgDurationMs = summaryData.avgDurationMs || 0
   summary.cacheHitRate = summaryData.cacheHitRate || 0
+  summary.cacheHitNumerator = summaryData.cacheHitNumerator || 0
+  summary.cacheHitDenominator = summaryData.cacheHitDenominator || 0
+  summary.cacheHitFormula =
+    summaryData.cacheHitFormula ||
+    'cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreateTokens)'
   summary.cacheCreateNotApplicable = summaryData.cacheCreateNotApplicable === true
 }
 


### PR DESCRIPTION
## Summary
- Use the official input-side denominator for request-detail cache hit rate: `cacheReadTokens / (inputTokens + cacheReadTokens + cacheCreateTokens)`.
- Route `recordUsageWithDetails` cost calculation through `CostCalculator.calculateCost` so unknown models use the existing `MODEL_PRICING.unknown` fallback.
- Recompute display-only estimated cost and cost breakdown for retained zero-cost request-detail records without writing back to Redis.
- Show the cache hit formula and fallback pricing metadata in the admin request-detail UI.

## Testing
- `npm test -- tests/requestDetailHelper.test.js tests/requestDetailService.test.js tests/costCalculator.test.js tests/apiKeyServiceOpenAIResponsesConfig.test.js`
- `npm test -- tests/requestDetailService.test.js tests/requestDetailHelper.test.js`
- `npm run lint:check`
- `cd web/admin-spa && npm run build`
- Local runtime verification with `docker compose -f /Users/user/Services/crs/docker-compose.yml up -d --build claude-relay` and `curl -fsS http://127.0.0.1:33033/health`

## Notes
- Existing non-zero cost records keep their stored values.
- Historical zero-cost request details are adjusted only in read responses; Redis records are not backfilled.
- Unknown model costs remain estimates based on the existing unknown fallback pricing.
