### PR TITLE
feat(observability): add Langfuse tracing for relay services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,3 +209,16 @@ DEFAULT_USER_ROLE=user
 USER_SESSION_TIMEOUT=86400000
 MAX_API_KEYS_PER_USER=1
 ALLOW_USER_DELETE_API_KEYS=false
+
+# 📡 Langfuse 调用追踪 (https://langfuse.com)
+# 启用后，每次 LLM 调用都会上报到 Langfuse，包含完整请求体、响应文本、用量、成本等
+LANGFUSE_ENABLED=false
+LANGFUSE_HOST=https://cloud.langfuse.com
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+# 设为 false 仅上报元数据/用量，不上报 input/output（隐私敏感场景）
+LANGFUSE_CAPTURE_BODY=true
+# 缓冲区达到该数量条数后批量上报
+LANGFUSE_FLUSH_AT=15
+# 周期性 flush 间隔（毫秒）
+LANGFUSE_FLUSH_INTERVAL=10000

--- a/config/config.example.js
+++ b/config/config.example.js
@@ -230,6 +230,20 @@ const config = {
     maxTotalCostLimit: parseFloat(process.env.QUOTA_CARD_MAX_TOTAL_COST_LIMIT) || 1000 // 最大总额度（美元）
   },
 
+  // 📡 Langfuse 调用追踪配置
+  // 当 enabled=true 时，每一次 LLM 调用都会被上报到 Langfuse 平台，
+  // 包含完整的请求体、响应文本、token 用量、成本、耗时、模型、账户类型等。
+  // captureBody=false 时仅上报元数据与用量，不上报 input/output。
+  langfuse: {
+    enabled: process.env.LANGFUSE_ENABLED === 'true',
+    host: process.env.LANGFUSE_HOST || 'https://cloud.langfuse.com',
+    publicKey: process.env.LANGFUSE_PUBLIC_KEY || '',
+    secretKey: process.env.LANGFUSE_SECRET_KEY || '',
+    captureBody: process.env.LANGFUSE_CAPTURE_BODY !== 'false',
+    flushAt: parseInt(process.env.LANGFUSE_FLUSH_AT) || 15,
+    flushInterval: parseInt(process.env.LANGFUSE_FLUSH_INTERVAL) || 10000
+  },
+
   // ⏱️ 上游错误自动暂停配置
   // 说明：此处是全局默认值。Claude 官方 OAuth 账号可在后台做账号级 503/5xx 覆盖，
   // 且可通过账号设置禁用 temp_unavailable（账号级策略优先于全局默认值）。

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "https-proxy-agent": "^7.0.2",
     "inquirer": "^8.2.6",
     "ioredis": "^5.3.2",
+    "langfuse": "^3.38.0",
     "ldapjs": "^3.0.7",
     "morgan": "^1.10.0",
     "node-cron": "^4.2.1",

--- a/src/app.js
+++ b/src/app.js
@@ -905,6 +905,15 @@ class Application {
             // 不阻止退出流程
           }
 
+          // 📡 Flush Langfuse 队列，确保关闭前未发送的事件被上报
+          try {
+            const langfuseTracker = require('./utils/langfuseTracker')
+            await langfuseTracker.flush()
+            logger.info('📡 Langfuse tracker flushed')
+          } catch (error) {
+            logger.warn('⚠️ Error flushing Langfuse tracker:', error.message)
+          }
+
           try {
             await redis.disconnect()
             logger.info('👋 Redis disconnected')

--- a/src/handlers/geminiHandlers.js
+++ b/src/handlers/geminiHandlers.js
@@ -1733,6 +1733,31 @@ async function handleGenerateContent(req, res) {
     if (response?.response?.usageMetadata) {
       try {
         const usage = response.response.usageMetadata
+        // 📡 Langfuse 输出文本提取
+        let _geminiNonStreamText = ''
+        try {
+          const candidates = response?.response?.candidates
+          if (Array.isArray(candidates)) {
+            for (const candidate of candidates) {
+              const parts = candidate?.content?.parts
+              if (Array.isArray(parts)) {
+                for (const part of parts) {
+                  if (part && typeof part.text === 'string') {
+                    _geminiNonStreamText += part.text
+                  }
+                }
+              }
+            }
+          }
+        } catch (_textErr) {
+          _geminiNonStreamText = ''
+        }
+        const _geminiMeta = createRequestDetailMeta(req, {
+          requestBody: req.body,
+          stream: false,
+          statusCode: res.statusCode || 200
+        })
+        _geminiMeta.responseText = _geminiNonStreamText
         const geminiNonStreamCosts = await apiKeyService.recordUsage(
           req.apiKey.id,
           usage.promptTokenCount || 0,
@@ -1743,11 +1768,7 @@ async function handleGenerateContent(req, res) {
           account.id,
           'gemini',
           null,
-          createRequestDetailMeta(req, {
-            requestBody: req.body,
-            stream: false,
-            statusCode: res.statusCode || 200
-          })
+          _geminiMeta
         )
         logger.info(
           `📊 Recorded Gemini usage - Input: ${usage.promptTokenCount}, Output: ${usage.candidatesTokenCount}, Total: ${usage.totalTokenCount}`

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -22,6 +22,7 @@ const {
 const { sanitizeUpstreamError } = require('../utils/errorSanitizer')
 const { dumpAnthropicMessagesRequest } = require('../utils/anthropicRequestDump')
 const { createRequestDetailMeta } = require('../utils/requestDetailHelper')
+const StreamTextCollector = require('../utils/streamTextCollector')
 const {
   handleAnthropicMessagesToGemini,
   handleAnthropicCountTokensToGemini
@@ -432,6 +433,8 @@ async function handleMessagesRequest(req, res) {
         const _requestBody = req.body // 传递后清除引用
         const _apiKey = req.apiKey
         const _headers = req.headers
+        // 📡 Langfuse 输出文本捕获器（按 Anthropic SSE 解析）
+        const _langfuseCollector = new StreamTextCollector({ format: 'anthropic' })
 
         await claudeRelayService.relayStreamRequestWithUsageCapture(
           _requestBody,
@@ -499,6 +502,15 @@ async function handleMessagesRequest(req, res) {
                 }
               }
 
+              const _streamMetaOfficial = createRequestDetailMeta(req, {
+                requestBody: _requestBody,
+                stream: true,
+                statusCode: res.statusCode
+              })
+              _streamMetaOfficial.responseText = _langfuseCollector.getText()
+              if (_langfuseCollector.isTruncated()) {
+                _streamMetaOfficial.outputTruncated = true
+              }
               apiKeyService
                 .recordUsageWithDetails(
                   _apiKeyId,
@@ -506,11 +518,7 @@ async function handleMessagesRequest(req, res) {
                   model,
                   usageAccountId,
                   accountType,
-                  createRequestDetailMeta(req, {
-                    requestBody: _requestBody,
-                    stream: true,
-                    statusCode: res.statusCode
-                  })
+                  _streamMetaOfficial
                 )
                 .then((costs) => {
                   queueRateLimitUpdate(
@@ -556,7 +564,9 @@ async function handleMessagesRequest(req, res) {
                 JSON.stringify(usageData)
               )
             }
-          }
+          },
+          null,
+          { langfuseCollector: _langfuseCollector }
         )
       } else if (accountType === 'claude-console') {
         // Claude Console账号使用Console转发服务（需要传递accountId）
@@ -566,6 +576,8 @@ async function handleMessagesRequest(req, res) {
         const _requestBodyConsole = req.body
         const _apiKeyConsole = req.apiKey
         const _headersConsole = req.headers
+        // 📡 Langfuse 输出文本捕获器
+        const _langfuseCollectorConsole = new StreamTextCollector({ format: 'anthropic' })
 
         await claudeConsoleRelayService.relayStreamRequestWithUsageCapture(
           _requestBodyConsole,
@@ -643,11 +655,18 @@ async function handleMessagesRequest(req, res) {
                   model,
                   usageAccountId,
                   'claude-console',
-                  createRequestDetailMeta(req, {
-                    requestBody: _requestBodyConsole,
-                    stream: true,
-                    statusCode: res.statusCode
-                  })
+                  (() => {
+                    const _meta = createRequestDetailMeta(req, {
+                      requestBody: _requestBodyConsole,
+                      stream: true,
+                      statusCode: res.statusCode
+                    })
+                    _meta.responseText = _langfuseCollectorConsole.getText()
+                    if (_langfuseCollectorConsole.isTruncated()) {
+                      _meta.outputTruncated = true
+                    }
+                    return _meta
+                  })()
                 )
                 .then((costs) => {
                   queueRateLimitUpdate(
@@ -693,7 +712,9 @@ async function handleMessagesRequest(req, res) {
               )
             }
           },
-          accountId
+          accountId,
+          null,
+          { langfuseCollector: _langfuseCollectorConsole }
         )
       } else if (accountType === 'bedrock') {
         // Bedrock账号使用Bedrock转发服务
@@ -720,6 +741,17 @@ async function handleMessagesRequest(req, res) {
             const inputTokens = result.usage.input_tokens || 0
             const outputTokens = result.usage.output_tokens || 0
 
+            const _bedrockMeta = createRequestDetailMeta(req, {
+              requestBody: _requestBodyBedrock,
+              stream: true,
+              statusCode: res.statusCode
+            })
+            if (typeof result.responseText === 'string') {
+              _bedrockMeta.responseText = result.responseText
+              if (result.responseTextTruncated) {
+                _bedrockMeta.outputTruncated = true
+              }
+            }
             apiKeyService
               .recordUsage(
                 _apiKeyIdBedrock,
@@ -731,11 +763,7 @@ async function handleMessagesRequest(req, res) {
                 accountId,
                 'bedrock',
                 null,
-                createRequestDetailMeta(req, {
-                  requestBody: _requestBodyBedrock,
-                  stream: true,
-                  statusCode: res.statusCode
-                })
+                _bedrockMeta
               )
               .then((costs) => {
                 queueRateLimitUpdate(
@@ -797,6 +825,8 @@ async function handleMessagesRequest(req, res) {
         const _requestBodyCcr = req.body
         const _apiKeyCcr = req.apiKey
         const _headersCcr = req.headers
+        // 📡 Langfuse 输出文本捕获器
+        const _langfuseCollectorCcr = new StreamTextCollector({ format: 'anthropic' })
 
         await ccrRelayService.relayStreamRequestWithUsageCapture(
           _requestBodyCcr,
@@ -871,11 +901,18 @@ async function handleMessagesRequest(req, res) {
                   model,
                   usageAccountId,
                   'ccr',
-                  createRequestDetailMeta(req, {
-                    requestBody: _requestBodyCcr,
-                    stream: true,
-                    statusCode: res.statusCode
-                  })
+                  (() => {
+                    const _meta = createRequestDetailMeta(req, {
+                      requestBody: _requestBodyCcr,
+                      stream: true,
+                      statusCode: res.statusCode
+                    })
+                    _meta.responseText = _langfuseCollectorCcr.getText()
+                    if (_langfuseCollectorCcr.isTruncated()) {
+                      _meta.outputTruncated = true
+                    }
+                    return _meta
+                  })()
                 )
                 .then((costs) => {
                   queueRateLimitUpdate(
@@ -921,7 +958,9 @@ async function handleMessagesRequest(req, res) {
               )
             }
           },
-          accountId
+          accountId,
+          null,
+          { langfuseCollector: _langfuseCollectorCcr }
         )
       }
 
@@ -1298,17 +1337,33 @@ async function handleMessagesRequest(req, res) {
 
           // 记录真实的token使用量（包含模型信息和所有4种token以及账户ID）
           const { accountId: responseAccountId } = response
+          // 提取助手响应文本用于 Langfuse 输出捕获
+          let nonStreamResponseText = ''
+          try {
+            if (Array.isArray(jsonData?.content)) {
+              nonStreamResponseText = jsonData.content
+                .filter((part) => part && (part.type === 'text' || typeof part.text === 'string'))
+                .map((part) => part.text || '')
+                .join('')
+            } else if (typeof jsonData?.content === 'string') {
+              nonStreamResponseText = jsonData.content
+            }
+          } catch (_textError) {
+            nonStreamResponseText = ''
+          }
+          const nonStreamMeta = createRequestDetailMeta(req, {
+            requestBody: _requestBodyNonStream,
+            stream: false,
+            statusCode: response.statusCode
+          })
+          nonStreamMeta.responseText = nonStreamResponseText
           const nonStreamCosts = await apiKeyService.recordUsageWithDetails(
             _apiKeyIdNonStream,
             usageObject,
             model,
             responseAccountId,
             accountType,
-            createRequestDetailMeta(req, {
-              requestBody: _requestBodyNonStream,
-              stream: false,
-              statusCode: response.statusCode
-            })
+            nonStreamMeta
           )
 
           await queueRateLimitUpdate(

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -20,6 +20,7 @@ const {
   extractOpenAICacheReadTokens
 } = require('../utils/requestDetailHelper')
 const requestBodyRuleService = require('../services/requestBodyRuleService')
+const StreamTextCollector = require('../utils/streamTextCollector')
 
 // Codex CLI 系统提示词（非 Codex CLI 客户端请求时注入，统一端点也使用）
 const CODEX_CLI_INSTRUCTIONS =
@@ -702,6 +703,34 @@ const handleResponses = async (req, res) => {
           // 计算实际输入token（总输入减去缓存部分）
           const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
 
+          // 📡 Langfuse 输出文本提取
+          let _openaiNonStreamText = ''
+          try {
+            const choices = responseData?.choices
+            if (Array.isArray(choices)) {
+              for (const choice of choices) {
+                const msg = choice?.message
+                if (typeof msg?.content === 'string') {
+                  _openaiNonStreamText += msg.content
+                } else if (Array.isArray(msg?.content)) {
+                  for (const part of msg.content) {
+                    if (part && typeof part.text === 'string') {
+                      _openaiNonStreamText += part.text
+                    }
+                  }
+                }
+              }
+            }
+          } catch (_textErr) {
+            _openaiNonStreamText = ''
+          }
+          const _openaiNonStreamMeta =
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: false,
+              statusCode: upstream.status
+            }) || {}
+          _openaiNonStreamMeta.responseText = _openaiNonStreamText
           const nonStreamCosts = await apiKeyService.recordUsage(
             apiKeyData.id,
             actualInputTokens, // 传递实际输入（不含缓存）
@@ -712,11 +741,7 @@ const handleResponses = async (req, res) => {
             accountId,
             'openai',
             req._serviceTier,
-            createRequestDetailMeta(req, {
-              requestBody: req.body,
-              stream: false,
-              statusCode: upstream.status
-            })
+            _openaiNonStreamMeta
           )
 
           logger.info(
@@ -752,6 +777,8 @@ const handleResponses = async (req, res) => {
 
     // 使用增量 SSE 解析器
     const sseParser = new IncrementalSSEParser()
+    // 📡 Langfuse 输出文本捕获器
+    const _langfuseStreamCollector = new StreamTextCollector({ format: 'openai' })
 
     // 处理解析出的事件
     const processSSEEvent = (eventData) => {
@@ -787,6 +814,13 @@ const handleResponses = async (req, res) => {
         // 转发数据给客户端
         if (!res.destroyed) {
           res.write(chunk)
+        }
+
+        // 📡 Langfuse 输出文本累积
+        try {
+          _langfuseStreamCollector.onChunk(chunk)
+        } catch (_collectErr) {
+          // ignore
         }
 
         // 使用增量解析器处理数据
@@ -825,6 +859,16 @@ const handleResponses = async (req, res) => {
           // 使用响应中的真实 model，如果没有则使用请求中的 model，最后回退到默认值
           const modelToRecord = actualModel || upstreamRequestedModel || 'gpt-4'
 
+          const _openaiStreamMeta =
+            createRequestDetailMeta(req, {
+              requestBody: req.body,
+              stream: true,
+              statusCode: res.statusCode
+            }) || {}
+          _openaiStreamMeta.responseText = _langfuseStreamCollector.getText()
+          if (_langfuseStreamCollector.isTruncated()) {
+            _openaiStreamMeta.outputTruncated = true
+          }
           const streamCosts = await apiKeyService.recordUsage(
             apiKeyData.id,
             actualInputTokens, // 传递实际输入（不含缓存）
@@ -835,11 +879,7 @@ const handleResponses = async (req, res) => {
             accountId,
             'openai',
             req._serviceTier,
-            createRequestDetailMeta(req, {
-              requestBody: req.body,
-              stream: true,
-              statusCode: res.statusCode
-            })
+            _openaiStreamMeta
           )
 
           logger.info(

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -8,6 +8,7 @@ const requestDetailService = require('./requestDetailService')
 const { isClaudeFamilyModel } = require('../utils/modelHelper')
 const { finalizeRequestDetailMeta } = require('../utils/requestDetailHelper')
 const requestBodyRuleService = require('./requestBodyRuleService')
+const langfuseTracker = require('../utils/langfuseTracker')
 
 const ACCOUNT_TYPE_CONFIG = {
   claude: { prefix: 'claude:account:' },
@@ -162,6 +163,100 @@ function parseOpenAIResponsesPayloadRules(rawRules) {
   }
 
   return parsedRules.map((rule) => requestBodyRuleService.normalizeRule(rule)).filter(Boolean)
+}
+
+// 🔭 将一次 LLM 调用记录上报到 Langfuse（统一入口，所有 recordUsage* 都会调用）
+// 任何异常都被吞掉以保证不会影响主流程
+function emitLangfuseGeneration({
+  keyId,
+  keyData,
+  model,
+  accountId,
+  accountType,
+  inputTokens,
+  outputTokens,
+  cacheCreateTokens,
+  cacheReadTokens,
+  totalTokens,
+  realCost,
+  ratedCost,
+  finalizedRequestMeta
+}) {
+  try {
+    if (!langfuseTracker || typeof langfuseTracker.captureGeneration !== 'function') {
+      return
+    }
+    if (!langfuseTracker.isEnabled || !langfuseTracker.isEnabled()) {
+      return
+    }
+
+    const meta = finalizedRequestMeta || {}
+    const startedAtMs = (() => {
+      const raw = meta.requestStartedAt
+      if (!raw) {
+        return null
+      }
+      const parsed = typeof raw === 'number' ? raw : Date.parse(raw)
+      return Number.isFinite(parsed) ? parsed : null
+    })()
+    const durationMs = typeof meta.durationMs === 'number' ? meta.durationMs : null
+    const startTime = startedAtMs ? new Date(startedAtMs) : new Date()
+    const endTime =
+      startedAtMs !== null && durationMs !== null
+        ? new Date(startedAtMs + Math.max(0, durationMs))
+        : new Date()
+
+    const sessionId = meta.sessionId || meta.sessionHash || null
+    const requestBody = meta.requestBody === undefined ? null : meta.requestBody
+    const { responseText } = meta
+    const traceName = `${accountType || 'llm'}-${meta.stream === true ? 'stream' : 'request'}`
+
+    const langfuseMetadata = {}
+    if (keyData?.name) {
+      langfuseMetadata.apiKeyName = keyData.name
+    }
+    if (meta.outputCapture) {
+      langfuseMetadata.outputCapture = meta.outputCapture
+    }
+    if (meta.outputTruncated) {
+      langfuseMetadata.outputTruncated = true
+    }
+
+    langfuseTracker.captureGeneration({
+      apiKeyId: keyId,
+      apiKeyName: keyData?.name || null,
+      accountId: accountId || null,
+      accountType: accountType || null,
+      model: model || null,
+      input: requestBody,
+      output: responseText !== undefined ? responseText : null,
+      usage: {
+        inputTokens,
+        outputTokens,
+        cacheCreateTokens,
+        cacheReadTokens,
+        totalTokens
+      },
+      costs: { realCost, ratedCost },
+      startTime,
+      endTime,
+      sessionId,
+      requestId: meta.requestId || null,
+      endpoint: meta.endpoint || null,
+      method: meta.method || null,
+      statusCode: meta.statusCode ?? null,
+      stream: meta.stream === true,
+      error: meta.error || null,
+      traceName,
+      metadata: langfuseMetadata
+    })
+  } catch (error) {
+    try {
+      logger.warn(`⚠️ Failed to emit Langfuse generation: ${error.message}`)
+    } catch (_logError) {
+      // ignore
+    }
+  }
 }
 
 class ApiKeyService {
@@ -1797,6 +1892,23 @@ class ApiKeyService {
         logger.warn(`⚠️ Failed to schedule request detail capture: ${captureError.message}`)
       })
 
+      // 📡 Langfuse 上报（启用时）
+      emitLangfuseGeneration({
+        keyId,
+        keyData,
+        model,
+        accountId,
+        accountType,
+        inputTokens,
+        outputTokens,
+        cacheCreateTokens,
+        cacheReadTokens,
+        totalTokens,
+        realCost,
+        ratedCost,
+        finalizedRequestMeta
+      })
+
       const logParts = [`Model: ${model}`, `Input: ${inputTokens}`, `Output: ${outputTokens}`]
       if (cacheCreateTokens > 0) {
         logParts.push(`Cache Create: ${cacheCreateTokens}`)
@@ -2062,6 +2174,23 @@ class ApiKeyService {
       await redis.addUsageRecord(keyId, usageRecord)
       this._captureRequestDetail(keyId, usageRecord, finalizedRequestMeta).catch((captureError) => {
         logger.warn(`⚠️ Failed to schedule request detail capture: ${captureError.message}`)
+      })
+
+      // 📡 Langfuse 上报（启用时）
+      emitLangfuseGeneration({
+        keyId,
+        keyData,
+        model,
+        accountId,
+        accountType,
+        inputTokens,
+        outputTokens,
+        cacheCreateTokens,
+        cacheReadTokens,
+        totalTokens,
+        realCost: realCostWithDetails,
+        ratedCost: ratedCostWithDetails,
+        finalizedRequestMeta
       })
 
       const logParts = [`Model: ${model}`, `Input: ${inputTokens}`, `Output: ${outputTokens}`]

--- a/src/services/relay/antigravityRelayService.js
+++ b/src/services/relay/antigravityRelayService.js
@@ -2,6 +2,7 @@ const apiKeyService = require('../apiKeyService')
 const { convertMessagesToGemini, convertGeminiResponse } = require('./geminiRelayService')
 const { normalizeAntigravityModelInput } = require('../../utils/antigravityModel')
 const antigravityClient = require('../antigravityClient')
+const StreamTextCollector = require('../../utils/streamTextCollector')
 
 function buildRequestData({ messages, model, temperature, maxTokens, sessionId }) {
   const requestedModel = normalizeAntigravityModelInput(model)
@@ -37,10 +38,22 @@ async function* handleStreamResponse(response, model, apiKeyId, accountId, reque
     totalTokenCount: 0
   }
   let usageRecorded = false
+  const textCollector = new StreamTextCollector({ format: 'gemini' })
+
+  const buildMeta = () => {
+    const meta = requestMeta ? { ...requestMeta } : {}
+    meta.responseText = textCollector.getText()
+    if (textCollector.isTruncated()) {
+      meta.outputTruncated = true
+    }
+    return meta
+  }
 
   try {
     for await (const chunk of response.data) {
       buffer += chunk.toString()
+      // 同时投喂给文本累积器（Langfuse 输出捕获）
+      textCollector.onChunk(chunk)
 
       const lines = buffer.split('\n')
       buffer = lines.pop() || ''
@@ -85,7 +98,7 @@ async function* handleStreamResponse(response, model, apiKeyId, accountId, reque
                   accountId,
                   'gemini',
                   null,
-                  requestMeta
+                  buildMeta()
                 )
                 usageRecorded = true
               }
@@ -109,7 +122,7 @@ async function* handleStreamResponse(response, model, apiKeyId, accountId, reque
         accountId,
         'gemini',
         null,
-        requestMeta
+        buildMeta()
       )
     }
   }
@@ -158,6 +171,13 @@ async function sendAntigravityRequest({
   const openaiResponse = convertGeminiResponse(payload, requestedModel, false)
 
   if (apiKeyId && openaiResponse?.usage) {
+    let responseText = ''
+    try {
+      responseText = openaiResponse?.choices?.[0]?.message?.content || ''
+    } catch (_error) {
+      responseText = ''
+    }
+    const meta = requestMeta ? { ...requestMeta, responseText } : { responseText }
     await apiKeyService.recordUsage(
       apiKeyId,
       openaiResponse.usage.prompt_tokens || 0,
@@ -168,7 +188,7 @@ async function sendAntigravityRequest({
       accountId,
       'gemini',
       null,
-      requestMeta
+      meta
     )
   }
 

--- a/src/services/relay/bedrockRelayService.js
+++ b/src/services/relay/bedrockRelayService.js
@@ -374,6 +374,26 @@ class BedrockRelayService {
       })
 
       let totalUsage = null
+      // 📡 Langfuse 输出文本捕获（按 Anthropic SSE 文本累积）
+      let _langfuseResponseText = ''
+      const _LANGFUSE_RESPONSE_MAX = 1024 * 1024
+      let _langfuseTruncated = false
+      const _appendLangfuseText = (text) => {
+        if (!text || _langfuseTruncated) {
+          return
+        }
+        const remaining = _LANGFUSE_RESPONSE_MAX - _langfuseResponseText.length
+        if (remaining <= 0) {
+          _langfuseTruncated = true
+          return
+        }
+        if (text.length <= remaining) {
+          _langfuseResponseText += text
+        } else {
+          _langfuseResponseText += text.slice(0, remaining)
+          _langfuseTruncated = true
+        }
+      }
 
       // 处理流式响应
       // Bedrock InvokeModelWithResponseStream 返回的 JSON 事件结构与 Claude API 完全一致，
@@ -403,6 +423,18 @@ class BedrockRelayService {
           if (chunkData.type === 'message_delta' && chunkData.usage) {
             totalUsage = chunkData.usage
           }
+
+          // 📡 Langfuse 输出文本累积
+          if (chunkData.type === 'content_block_delta' && chunkData.delta) {
+            if (chunkData.delta.type === 'text_delta' && typeof chunkData.delta.text === 'string') {
+              _appendLangfuseText(chunkData.delta.text)
+            } else if (
+              chunkData.delta.type === 'thinking_delta' &&
+              typeof chunkData.delta.thinking === 'string'
+            ) {
+              _appendLangfuseText(chunkData.delta.thinking)
+            }
+          }
         }
       }
 
@@ -418,7 +450,9 @@ class BedrockRelayService {
         success: true,
         usage: totalUsage,
         model: modelId,
-        duration
+        duration,
+        responseText: _langfuseResponseText,
+        responseTextTruncated: _langfuseTruncated
       }
     } catch (error) {
       // 客户端主动断开，不算错误

--- a/src/services/relay/ccrRelayService.js
+++ b/src/services/relay/ccrRelayService.js
@@ -769,6 +769,14 @@ class CcrRelayService {
 
             try {
               const chunkStr = chunk.toString('utf8')
+              // 📡 Langfuse 输出文本捕获
+              if (options && options.langfuseCollector) {
+                try {
+                  options.langfuseCollector.onChunk(chunkStr)
+                } catch (_collectErr) {
+                  // ignore
+                }
+              }
               rawBuffer += chunkStr
 
               // 按行分割处理 SSE 数据

--- a/src/services/relay/claudeConsoleRelayService.js
+++ b/src/services/relay/claudeConsoleRelayService.js
@@ -1007,6 +1007,14 @@ class ClaudeConsoleRelayService {
               }
 
               const chunkStr = chunk.toString()
+              // 📡 Langfuse 输出文本捕获
+              if (options && options.langfuseCollector) {
+                try {
+                  options.langfuseCollector.onChunk(chunkStr)
+                } catch (_collectErr) {
+                  // ignore
+                }
+              }
               buffer += chunkStr
 
               // 处理完整的SSE行

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -2553,6 +2553,15 @@ class ClaudeRelayService {
           try {
             const chunkStr = chunk.toString()
 
+            // 📡 Langfuse 输出文本捕获（如果 caller 提供了 collector）
+            if (requestOptions && requestOptions.langfuseCollector) {
+              try {
+                requestOptions.langfuseCollector.onChunk(chunkStr)
+              } catch (_collectErr) {
+                // 收集失败不影响主流程
+              }
+            }
+
             buffer += chunkStr
 
             // 处理完整的SSE行

--- a/src/utils/langfuseTracker.js
+++ b/src/utils/langfuseTracker.js
@@ -1,0 +1,293 @@
+/**
+ * Langfuse 调用追踪封装
+ *
+ * 这个模块统一负责将一次 LLM 调用的输入、输出、用量、成本等信息上报到
+ * Langfuse 平台。所有内部调用都被 try/catch 包裹，任何 Langfuse 故障都
+ * 不会向上抛出到中转主流程。
+ *
+ * 启用方式：
+ *   - 在配置中设置 langfuse.enabled = true
+ *   - 在环境变量中提供 LANGFUSE_HOST / LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY
+ *
+ * 调用方式：
+ *   const langfuseTracker = require('./utils/langfuseTracker')
+ *   langfuseTracker.captureGeneration({...})
+ *   await langfuseTracker.flush()
+ */
+
+const config = require('../../config/config')
+const logger = require('./logger')
+
+const MAX_INPUT_OUTPUT_CHARS = 256 * 1024 // 256KB 上限，避免 Langfuse 单条事件过大
+
+class LangfuseTracker {
+  constructor() {
+    this.client = null
+    this.initAttempted = false
+    this.options = this._readOptions()
+  }
+
+  _readOptions() {
+    const langfuseConfig = (config && config.langfuse) || {}
+    return {
+      enabled: langfuseConfig.enabled === true,
+      host: langfuseConfig.host || 'https://cloud.langfuse.com',
+      publicKey: langfuseConfig.publicKey || '',
+      secretKey: langfuseConfig.secretKey || '',
+      captureBody: langfuseConfig.captureBody !== false,
+      flushAt: Number.isFinite(langfuseConfig.flushAt) ? langfuseConfig.flushAt : 15,
+      flushInterval: Number.isFinite(langfuseConfig.flushInterval)
+        ? langfuseConfig.flushInterval
+        : 10000
+    }
+  }
+
+  isEnabled() {
+    return Boolean(
+      this.options.enabled && this.options.publicKey && this.options.secretKey && this.options.host
+    )
+  }
+
+  _ensureClient() {
+    if (this.client || this.initAttempted) {
+      return this.client
+    }
+
+    this.initAttempted = true
+
+    if (!this.isEnabled()) {
+      return null
+    }
+
+    try {
+      // 延迟加载 SDK，未启用时不付出 require 成本
+      // eslint-disable-next-line global-require
+      const { Langfuse } = require('langfuse')
+      this.client = new Langfuse({
+        publicKey: this.options.publicKey,
+        secretKey: this.options.secretKey,
+        baseUrl: this.options.host,
+        flushAt: this.options.flushAt,
+        flushInterval: this.options.flushInterval
+      })
+      logger.info(`📡 Langfuse tracker initialized (host=${this.options.host})`)
+    } catch (error) {
+      logger.warn(`⚠️ Failed to initialize Langfuse client: ${error.message}`)
+      this.client = null
+    }
+
+    return this.client
+  }
+
+  _truncateForLangfuse(value) {
+    if (value === null || value === undefined) {
+      return value
+    }
+
+    try {
+      if (typeof value === 'string') {
+        if (value.length <= MAX_INPUT_OUTPUT_CHARS) {
+          return value
+        }
+        return `${value.slice(0, MAX_INPUT_OUTPUT_CHARS)}...[truncated ${
+          value.length - MAX_INPUT_OUTPUT_CHARS
+        } chars]`
+      }
+
+      const json = JSON.stringify(value)
+      if (typeof json !== 'string' || json.length <= MAX_INPUT_OUTPUT_CHARS) {
+        return value
+      }
+
+      return {
+        __langfuseTruncated: true,
+        originalChars: json.length,
+        preview: `${json.slice(0, MAX_INPUT_OUTPUT_CHARS)}...[truncated ${
+          json.length - MAX_INPUT_OUTPUT_CHARS
+        } chars]`
+      }
+    } catch (error) {
+      return String(value)
+    }
+  }
+
+  _normalizeTimestamp(value, fallback) {
+    if (value instanceof Date) {
+      return value
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return new Date(value)
+    }
+
+    if (typeof value === 'string' && value) {
+      const parsed = Date.parse(value)
+      if (Number.isFinite(parsed)) {
+        return new Date(parsed)
+      }
+    }
+
+    return fallback || new Date()
+  }
+
+  /**
+   * 捕获一次 LLM 调用记录
+   *
+   * @param {Object} payload
+   * @param {string} payload.apiKeyId
+   * @param {string} [payload.apiKeyName]
+   * @param {string} [payload.accountId]
+   * @param {string} [payload.accountType]
+   * @param {string} [payload.model]
+   * @param {*}      [payload.input] 完整请求体（messages / contents 等）
+   * @param {*}      [payload.output] 完整响应文本或对象
+   * @param {Object} [payload.usage] { inputTokens, outputTokens, totalTokens, cacheCreateTokens, cacheReadTokens }
+   * @param {Object} [payload.costs] { realCost, ratedCost }
+   * @param {Date|number|string} [payload.startTime]
+   * @param {Date|number|string} [payload.endTime]
+   * @param {string} [payload.sessionId]
+   * @param {string} [payload.traceId]
+   * @param {string} [payload.requestId]
+   * @param {string} [payload.endpoint]
+   * @param {boolean} [payload.stream]
+   * @param {number} [payload.statusCode]
+   * @param {*}      [payload.error]
+   * @param {Object} [payload.metadata] 额外的自定义元数据
+   */
+  captureGeneration(payload = {}) {
+    try {
+      if (!this.isEnabled()) {
+        return
+      }
+
+      const client = this._ensureClient()
+      if (!client) {
+        return
+      }
+
+      const now = new Date()
+      const startTime = this._normalizeTimestamp(payload.startTime, now)
+      const endTime = this._normalizeTimestamp(payload.endTime, now)
+
+      const usage = payload.usage || {}
+      const costs = payload.costs || {}
+
+      const sessionId = payload.sessionId || undefined
+      const userId = payload.apiKeyId || payload.apiKeyName || undefined
+
+      const baseMetadata = {
+        apiKeyId: payload.apiKeyId || null,
+        apiKeyName: payload.apiKeyName || null,
+        accountId: payload.accountId || null,
+        accountType: payload.accountType || null,
+        endpoint: payload.endpoint || null,
+        method: payload.method || null,
+        statusCode: payload.statusCode ?? null,
+        stream: payload.stream === true,
+        requestId: payload.requestId || null,
+        realCost: typeof costs.realCost === 'number' ? costs.realCost : null,
+        ratedCost: typeof costs.ratedCost === 'number' ? costs.ratedCost : null,
+        cacheCreateTokens: usage.cacheCreateTokens || 0,
+        cacheReadTokens: usage.cacheReadTokens || 0,
+        ...(payload.metadata && typeof payload.metadata === 'object' ? payload.metadata : {})
+      }
+
+      const traceName = payload.traceName || `${payload.accountType || 'llm'}-relay`
+      const traceId = payload.traceId || payload.requestId || undefined
+
+      const trace = client.trace({
+        id: traceId,
+        name: traceName,
+        sessionId,
+        userId,
+        metadata: baseMetadata,
+        tags: [payload.accountType, payload.stream === true ? 'stream' : 'non-stream'].filter(
+          Boolean
+        )
+      })
+
+      const generationParams = {
+        name: payload.model || payload.accountType || 'generation',
+        model: payload.model || null,
+        startTime,
+        endTime,
+        usage: {
+          input: usage.inputTokens || 0,
+          output: usage.outputTokens || 0,
+          total:
+            usage.totalTokens ||
+            (usage.inputTokens || 0) +
+              (usage.outputTokens || 0) +
+              (usage.cacheCreateTokens || 0) +
+              (usage.cacheReadTokens || 0),
+          unit: 'TOKENS'
+        },
+        metadata: baseMetadata
+      }
+
+      if (typeof costs.ratedCost === 'number' || typeof costs.realCost === 'number') {
+        generationParams.usage.totalCost =
+          typeof costs.ratedCost === 'number' ? costs.ratedCost : costs.realCost
+      }
+
+      if (this.options.captureBody) {
+        if (payload.input !== undefined && payload.input !== null) {
+          generationParams.input = this._truncateForLangfuse(payload.input)
+        }
+        if (payload.output !== undefined && payload.output !== null) {
+          generationParams.output = this._truncateForLangfuse(payload.output)
+        }
+      } else {
+        baseMetadata.bodyCaptured = false
+      }
+
+      if (payload.error) {
+        generationParams.level = 'ERROR'
+        const errorMessage =
+          typeof payload.error === 'string'
+            ? payload.error
+            : payload.error.message || String(payload.error)
+        generationParams.statusMessage = errorMessage.slice(0, 500)
+        baseMetadata.error = errorMessage
+      }
+
+      trace.generation(generationParams)
+    } catch (error) {
+      try {
+        logger.warn(`⚠️ Langfuse captureGeneration failed: ${error.message}`)
+      } catch (_logError) {
+        // 日志失败也不能影响主流程
+      }
+    }
+  }
+
+  async flush() {
+    try {
+      if (!this.client) {
+        return
+      }
+      if (typeof this.client.flushAsync === 'function') {
+        await this.client.flushAsync()
+      } else if (typeof this.client.flush === 'function') {
+        await this.client.flush()
+      } else if (typeof this.client.shutdownAsync === 'function') {
+        await this.client.shutdownAsync()
+      }
+    } catch (error) {
+      try {
+        logger.warn(`⚠️ Langfuse flush failed: ${error.message}`)
+      } catch (_logError) {
+        // ignore
+      }
+    }
+  }
+
+  // 测试辅助方法：重置内部状态，方便单元测试
+  _resetForTests() {
+    this.client = null
+    this.initAttempted = false
+    this.options = this._readOptions()
+  }
+}
+
+module.exports = new LangfuseTracker()

--- a/src/utils/streamTextCollector.js
+++ b/src/utils/streamTextCollector.js
@@ -1,0 +1,300 @@
+/**
+ * 流式响应文本累积器
+ *
+ * 各转发服务在流式转发过程中，会把每一段原始 buffer 投喂给本工具，
+ * 本工具会按 SSE/JSON 协议解析并提取出助手的文本输出，最终用于
+ * Langfuse 的 generation.output 字段。
+ *
+ * 支持三种格式：
+ *  - 'anthropic' : Anthropic Messages API SSE
+ *  - 'openai'    : OpenAI Chat Completions SSE
+ *  - 'gemini'    : Gemini streamGenerateContent SSE/JSON 流
+ *
+ * 容错原则：
+ *  - 任何解析异常都被吞掉（流式数据可能被截断）
+ *  - 累积长度封顶 1MB，超过后丢弃后续内容
+ */
+
+const DEFAULT_MAX_CHARS = 1024 * 1024 // 1MB
+
+class StreamTextCollector {
+  /**
+   * @param {Object} [options]
+   * @param {'anthropic'|'openai'|'gemini'} [options.format='anthropic']
+   * @param {number} [options.maxChars=1048576]
+   */
+  constructor(options = {}) {
+    this.format = options.format || 'anthropic'
+    this.maxChars = options.maxChars || DEFAULT_MAX_CHARS
+    this.buffer = ''
+    this.text = ''
+    this.truncated = false
+  }
+
+  /**
+   * 追加一段流式 chunk（可以是 Buffer / string）
+   * @param {*} chunk
+   */
+  onChunk(chunk) {
+    if (chunk === null || chunk === undefined) {
+      return
+    }
+
+    let str
+    try {
+      if (typeof chunk === 'string') {
+        str = chunk
+      } else if (Buffer.isBuffer(chunk)) {
+        str = chunk.toString('utf8')
+      } else if (typeof chunk.toString === 'function') {
+        str = chunk.toString()
+      } else {
+        return
+      }
+    } catch (_error) {
+      return
+    }
+
+    if (!str) {
+      return
+    }
+
+    if (this.truncated) {
+      return
+    }
+
+    this.buffer += str
+
+    try {
+      this._drain()
+    } catch (_error) {
+      // 任何解析错误都不能影响主流程
+    }
+  }
+
+  _drain() {
+    if (this.format === 'gemini') {
+      this._drainGemini()
+      return
+    }
+
+    // SSE 格式按 \n\n 切分事件
+    let separatorIndex
+    while ((separatorIndex = this.buffer.indexOf('\n\n')) !== -1) {
+      const eventBlock = this.buffer.slice(0, separatorIndex)
+      this.buffer = this.buffer.slice(separatorIndex + 2)
+      this._handleEventBlock(eventBlock)
+    }
+  }
+
+  _handleEventBlock(eventBlock) {
+    if (!eventBlock) {
+      return
+    }
+
+    const lines = eventBlock.split('\n')
+    for (const rawLine of lines) {
+      const line = rawLine.replace(/\r$/, '')
+      if (!line.startsWith('data:')) {
+        continue
+      }
+
+      const payload = line.slice(5).trimStart()
+      if (!payload || payload === '[DONE]') {
+        continue
+      }
+
+      let data
+      try {
+        data = JSON.parse(payload)
+      } catch (_error) {
+        continue
+      }
+
+      if (this.format === 'anthropic') {
+        this._handleAnthropicEvent(data)
+      } else if (this.format === 'openai') {
+        this._handleOpenAIEvent(data)
+      }
+    }
+  }
+
+  _handleAnthropicEvent(data) {
+    if (!data || typeof data !== 'object') {
+      return
+    }
+
+    // content_block_delta -> { delta: { type: 'text_delta', text: '...' } }
+    if (data.type === 'content_block_delta' && data.delta) {
+      const { delta } = data
+      if (delta.type === 'text_delta' && typeof delta.text === 'string') {
+        this._append(delta.text)
+        return
+      }
+
+      // 思考模式输出（thinking_delta）
+      if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+        this._append(delta.thinking)
+        return
+      }
+    }
+
+    // content_block_start 中可能直接带有 text
+    if (data.type === 'content_block_start' && data.content_block) {
+      const block = data.content_block
+      if (block.type === 'text' && typeof block.text === 'string') {
+        this._append(block.text)
+      }
+    }
+  }
+
+  _handleOpenAIEvent(data) {
+    if (!data || typeof data !== 'object') {
+      return
+    }
+
+    const choices = Array.isArray(data.choices) ? data.choices : null
+    if (!choices) {
+      return
+    }
+
+    for (const choice of choices) {
+      if (!choice) {
+        continue
+      }
+      const delta = choice.delta || choice.message
+      if (!delta) {
+        continue
+      }
+      if (typeof delta.content === 'string') {
+        this._append(delta.content)
+      } else if (Array.isArray(delta.content)) {
+        for (const part of delta.content) {
+          if (part && typeof part.text === 'string') {
+            this._append(part.text)
+          }
+        }
+      }
+      if (typeof delta.reasoning_content === 'string') {
+        this._append(delta.reasoning_content)
+      }
+    }
+  }
+
+  _drainGemini() {
+    // Gemini 流既可能是 SSE（"data: {json}\n\n"）也可能是裸 JSON 数组流。
+    // 我们尝试两种解析。先按 \n\n 切，如果切到事件块再判断。
+    let separatorIndex
+    while ((separatorIndex = this.buffer.indexOf('\n\n')) !== -1) {
+      const eventBlock = this.buffer.slice(0, separatorIndex)
+      this.buffer = this.buffer.slice(separatorIndex + 2)
+      this._handleGeminiBlock(eventBlock)
+    }
+
+    // 同时尝试按行解析（部分实现仅以 \n 分隔）
+    let nlIndex
+    // 复制一份 buffer 用于行级试探，避免吃掉未完成行
+    while ((nlIndex = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, nlIndex)
+      // 只在该行明显是完整 SSE data 行时才 consume
+      if (line.startsWith('data:')) {
+        this.buffer = this.buffer.slice(nlIndex + 1)
+        this._handleGeminiLine(line)
+      } else {
+        // 不是 SSE 行，停止行级解析（可能是 JSON 数组流）
+        break
+      }
+    }
+  }
+
+  _handleGeminiBlock(block) {
+    if (!block) {
+      return
+    }
+    const lines = block.split('\n')
+    for (const rawLine of lines) {
+      const line = rawLine.replace(/\r$/, '')
+      this._handleGeminiLine(line)
+    }
+  }
+
+  _handleGeminiLine(line) {
+    if (!line) {
+      return
+    }
+    let payload = line
+    if (line.startsWith('data:')) {
+      payload = line.slice(5).trimStart()
+    }
+    if (!payload || payload === '[DONE]') {
+      return
+    }
+
+    let data
+    try {
+      data = JSON.parse(payload)
+    } catch (_error) {
+      return
+    }
+
+    this._extractGeminiText(data)
+  }
+
+  _extractGeminiText(data) {
+    if (!data || typeof data !== 'object') {
+      return
+    }
+
+    // Gemini 响应可能再嵌一层 response
+    const target = data.response || data
+    const candidates = Array.isArray(target.candidates) ? target.candidates : null
+    if (!candidates) {
+      return
+    }
+
+    for (const candidate of candidates) {
+      const parts = candidate?.content?.parts
+      if (!Array.isArray(parts)) {
+        continue
+      }
+      for (const part of parts) {
+        if (part && typeof part.text === 'string') {
+          this._append(part.text)
+        }
+      }
+    }
+  }
+
+  _append(text) {
+    if (!text || this.truncated) {
+      return
+    }
+
+    const remaining = this.maxChars - this.text.length
+    if (remaining <= 0) {
+      this.truncated = true
+      return
+    }
+
+    if (text.length <= remaining) {
+      this.text += text
+    } else {
+      this.text += text.slice(0, remaining)
+      this.truncated = true
+    }
+  }
+
+  /**
+   * 获取累积的文本输出
+   * @returns {string}
+   */
+  getText() {
+    return this.text
+  }
+
+  isTruncated() {
+    return this.truncated
+  }
+}
+
+module.exports = StreamTextCollector

--- a/tests/langfuseTracker.test.js
+++ b/tests/langfuseTracker.test.js
@@ -1,0 +1,186 @@
+const path = require('path')
+
+const TRACKER_PATH = path.resolve(__dirname, '../src/utils/langfuseTracker')
+const CONFIG_PATH = path.resolve(__dirname, '../config/config')
+const LOGGER_PATH = path.resolve(__dirname, '../src/utils/logger')
+
+const generationMock = jest.fn()
+const traceMock = jest.fn(() => ({ generation: generationMock }))
+const flushAsyncMock = jest.fn().mockResolvedValue(undefined)
+
+class FakeLangfuse {
+  constructor(opts) {
+    FakeLangfuse.lastOptions = opts
+  }
+
+  trace(...args) {
+    return traceMock(...args)
+  }
+
+  async flushAsync() {
+    return flushAsyncMock()
+  }
+}
+
+function loadTracker(overrides = {}) {
+  jest.resetModules()
+  generationMock.mockReset()
+  traceMock.mockClear()
+  flushAsyncMock.mockClear()
+
+  jest.doMock(LOGGER_PATH, () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    success: jest.fn(),
+    api: jest.fn(),
+    database: jest.fn(),
+    performance: jest.fn()
+  }))
+
+  jest.doMock(CONFIG_PATH, () => ({
+    langfuse: {
+      enabled: true,
+      host: 'https://example.langfuse.test',
+      publicKey: 'pk_test',
+      secretKey: 'sk_test',
+      captureBody: true,
+      flushAt: 1,
+      flushInterval: 1000,
+      ...overrides
+    },
+    proxy: {}
+  }))
+
+  jest.doMock('langfuse', () => ({ Langfuse: FakeLangfuse }), { virtual: true })
+
+  // eslint-disable-next-line global-require
+  return require(TRACKER_PATH)
+}
+
+describe('langfuseTracker', () => {
+  afterEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+  })
+
+  test('does nothing when disabled', () => {
+    const tracker = loadTracker({ enabled: false })
+    tracker.captureGeneration({
+      apiKeyId: 'k1',
+      model: 'gpt-4',
+      input: { messages: [] },
+      output: 'hi'
+    })
+    expect(traceMock).not.toHaveBeenCalled()
+    expect(generationMock).not.toHaveBeenCalled()
+  })
+
+  test('does nothing when keys missing', () => {
+    const tracker = loadTracker({ publicKey: '', secretKey: '' })
+    tracker.captureGeneration({
+      apiKeyId: 'k1',
+      model: 'gpt-4',
+      input: { messages: [] },
+      output: 'hi'
+    })
+    expect(traceMock).not.toHaveBeenCalled()
+  })
+
+  test('creates trace + generation with full input/output when enabled', () => {
+    const tracker = loadTracker()
+    tracker.captureGeneration({
+      apiKeyId: 'apikey-1',
+      apiKeyName: 'my-key',
+      accountId: 'acc-1',
+      accountType: 'claude-official',
+      model: 'claude-sonnet-4',
+      input: { messages: [{ role: 'user', content: 'hello' }] },
+      output: 'hi back',
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        cacheCreateTokens: 0,
+        cacheReadTokens: 0
+      },
+      costs: { realCost: 0.01, ratedCost: 0.012 },
+      sessionId: 'sess-1',
+      requestId: 'req-1',
+      stream: true
+    })
+
+    expect(traceMock).toHaveBeenCalledTimes(1)
+    const traceArgs = traceMock.mock.calls[0][0]
+    expect(traceArgs.sessionId).toBe('sess-1')
+    expect(traceArgs.userId).toBe('apikey-1')
+    expect(traceArgs.metadata.accountType).toBe('claude-official')
+    expect(traceArgs.metadata.realCost).toBe(0.01)
+    expect(traceArgs.tags).toEqual(expect.arrayContaining(['claude-official', 'stream']))
+
+    expect(generationMock).toHaveBeenCalledTimes(1)
+    const genArgs = generationMock.mock.calls[0][0]
+    expect(genArgs.model).toBe('claude-sonnet-4')
+    expect(genArgs.input).toEqual({ messages: [{ role: 'user', content: 'hello' }] })
+    expect(genArgs.output).toBe('hi back')
+    expect(genArgs.usage.input).toBe(10)
+    expect(genArgs.usage.output).toBe(5)
+    expect(genArgs.usage.totalCost).toBe(0.012)
+  })
+
+  test('captureBody=false strips input/output', () => {
+    const tracker = loadTracker({ captureBody: false })
+    tracker.captureGeneration({
+      apiKeyId: 'k1',
+      model: 'gpt-4',
+      input: { messages: [{ role: 'user', content: 'secret' }] },
+      output: 'reply',
+      usage: { inputTokens: 1, outputTokens: 1 }
+    })
+    expect(generationMock).toHaveBeenCalledTimes(1)
+    const genArgs = generationMock.mock.calls[0][0]
+    expect(genArgs.input).toBeUndefined()
+    expect(genArgs.output).toBeUndefined()
+    expect(genArgs.metadata.bodyCaptured).toBe(false)
+  })
+
+  test('marks generation as ERROR when error supplied', () => {
+    const tracker = loadTracker()
+    tracker.captureGeneration({
+      apiKeyId: 'k1',
+      model: 'gpt-4',
+      error: new Error('upstream blew up')
+    })
+    expect(generationMock).toHaveBeenCalledTimes(1)
+    const genArgs = generationMock.mock.calls[0][0]
+    expect(genArgs.level).toBe('ERROR')
+    expect(genArgs.statusMessage).toContain('upstream blew up')
+  })
+
+  test('does not throw when underlying client throws', () => {
+    const tracker = loadTracker()
+    traceMock.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+    expect(() =>
+      tracker.captureGeneration({
+        apiKeyId: 'k1',
+        model: 'gpt-4'
+      })
+    ).not.toThrow()
+  })
+
+  test('flush invokes underlying client flush without throwing on missing client', async () => {
+    const tracker = loadTracker()
+    tracker.captureGeneration({ apiKeyId: 'k1', model: 'gpt-4' })
+    await tracker.flush()
+    expect(flushAsyncMock).toHaveBeenCalled()
+  })
+
+  test('flush is no-op when client never initialized', async () => {
+    const tracker = loadTracker({ enabled: false })
+    await expect(tracker.flush()).resolves.toBeUndefined()
+    expect(flushAsyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/streamTextCollector.test.js
+++ b/tests/streamTextCollector.test.js
@@ -1,0 +1,109 @@
+const StreamTextCollector = require('../src/utils/streamTextCollector')
+
+describe('streamTextCollector', () => {
+  test('parses Anthropic content_block_delta SSE chunks', () => {
+    const collector = new StreamTextCollector({ format: 'anthropic' })
+    collector.onChunk(
+      'event: content_block_delta\n' +
+        'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello "}}\n\n'
+    )
+    collector.onChunk(
+      'event: content_block_delta\n' +
+        'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"world"}}\n\n'
+    )
+    collector.onChunk(
+      'event: content_block_delta\n' +
+        'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"!"}}\n\n'
+    )
+
+    expect(collector.getText()).toBe('Hello world!')
+  })
+
+  test('handles partial Anthropic chunks split across calls', () => {
+    const collector = new StreamTextCollector({ format: 'anthropic' })
+    const full =
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Streamed"}}\n\n'
+    collector.onChunk(full.slice(0, 30))
+    collector.onChunk(full.slice(30))
+    expect(collector.getText()).toBe('Streamed')
+  })
+
+  test('captures Anthropic thinking_delta chunks', () => {
+    const collector = new StreamTextCollector({ format: 'anthropic' })
+    collector.onChunk(
+      'data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"hmm"}}\n\n'
+    )
+    expect(collector.getText()).toBe('hmm')
+  })
+
+  test('parses OpenAI choices.delta.content SSE chunks', () => {
+    const collector = new StreamTextCollector({ format: 'openai' })
+    collector.onChunk('data: {"choices":[{"delta":{"content":"foo"}}]}\n\n')
+    collector.onChunk('data: {"choices":[{"delta":{"content":" bar"}}]}\n\n')
+    collector.onChunk('data: [DONE]\n\n')
+    expect(collector.getText()).toBe('foo bar')
+  })
+
+  test('parses OpenAI array content parts', () => {
+    const collector = new StreamTextCollector({ format: 'openai' })
+    collector.onChunk(
+      'data: {"choices":[{"delta":{"content":[{"type":"text","text":"alpha"},{"type":"text","text":" beta"}]}}]}\n\n'
+    )
+    expect(collector.getText()).toBe('alpha beta')
+  })
+
+  test('parses Gemini SSE candidates parts text', () => {
+    const collector = new StreamTextCollector({ format: 'gemini' })
+    collector.onChunk(
+      'data: {"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}\n\n' +
+        'data: {"candidates":[{"content":{"parts":[{"text":" Gemini"}]}}]}\n\n'
+    )
+    expect(collector.getText()).toBe('Hello Gemini')
+  })
+
+  test('parses Gemini wrapped response shape', () => {
+    const collector = new StreamTextCollector({ format: 'gemini' })
+    collector.onChunk(
+      'data: {"response":{"candidates":[{"content":{"parts":[{"text":"wrapped"}]}}]}}\n\n'
+    )
+    expect(collector.getText()).toBe('wrapped')
+  })
+
+  test('skips malformed JSON silently', () => {
+    const collector = new StreamTextCollector({ format: 'anthropic' })
+    collector.onChunk('data: {not json}\n\n')
+    collector.onChunk(
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ok"}}\n\n'
+    )
+    expect(collector.getText()).toBe('ok')
+  })
+
+  test('caps accumulated text at maxChars', () => {
+    const collector = new StreamTextCollector({ format: 'anthropic', maxChars: 16 })
+    collector.onChunk(
+      `data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"${'A'.repeat(10)}"}}\n\n`
+    )
+    collector.onChunk(
+      `data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"${'B'.repeat(20)}"}}\n\n`
+    )
+    expect(collector.getText().length).toBe(16)
+    expect(collector.isTruncated()).toBe(true)
+  })
+
+  test('accepts Buffer input', () => {
+    const collector = new StreamTextCollector({ format: 'anthropic' })
+    collector.onChunk(
+      Buffer.from('data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"buf"}}\n\n')
+    )
+    expect(collector.getText()).toBe('buf')
+  })
+
+  test('ignores null/undefined chunks', () => {
+    const collector = new StreamTextCollector({ format: 'anthropic' })
+    expect(() => {
+      collector.onChunk(null)
+      collector.onChunk(undefined)
+    }).not.toThrow()
+    expect(collector.getText()).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

为各 relay 服务接入 **Langfuse** 端到端可观测：每次请求可选地上报 trace，包含完整 input/output 文本、model、token 用量、耗时与成本。默认不开启，全部通过 env 变量配置。

- **`src/utils/langfuseTracker.js`**：懒初始化的 Langfuse 客户端，根据 `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` 控制启用；未配置时全部接口降级为 no-op；进程退出前批量 flush
- **`src/utils/streamTextCollector.js`**：跨 SSE 格式（`claude` / `openai` / `gemini`）累积输出文本，带大小上限和 `truncated` 标记
- **接入点**：
  - Claude 官方流 + 非流（`src/routes/api.js` / `claudeRelayService.js`）
  - Claude Console（`claudeConsoleRelayService.js`）
  - Bedrock（`bedrockRelayService.js`）
  - CCR（`ccrRelayService.js`）
  - OpenAI Responses（`src/routes/openaiRoutes.js`，流 + 非流）
  - Antigravity（`antigravityRelayService.js`）
  - Gemini handlers（`src/handlers/geminiHandlers.js`）
- **健壮性修复**：openaiRoutes 在原有 `createRequestDetailMeta(req, ...)` 返回值上挂载 `responseText` 字段，加 `|| {}` 防御以兼容把该函数 mock 为 `null` 的现有测试
- 依赖新增 `langfuse@^3.38.0`
- 新增 `tests/langfuseTracker.test.js` 与 `tests/streamTextCollector.test.js`

## Config

`.env.example` / `config/config.example.js` 新增 langfuse 段。未配置 keys 时整个模块不产生网络请求。

## Test plan

- [x] `npm test`（21 suites / 263 passed / 8 skipped）
- [x] 本地配上 Langfuse keys，跑通 Claude / OpenAI Responses 的流与非流，trace 正常上报
- [ ] reviewer 在自己环境验证一次（或确认仅在显式配置 keys 时启用）