### PR TITLE
feat(api-keys): add all-model weekly cost limit

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1293,6 +1293,41 @@ const authenticateApiKey = async (req, res, next) => {
       }
     }
 
+    // 检查全模型周费用限制（所有模型都计入此限额）
+    const weeklyCostLimit = validation.keyData.weeklyCostLimit || 0
+    if (weeklyCostLimit > 0) {
+      const weeklyCost = validation.keyData.weeklyCost || 0
+
+      if (weeklyCost >= weeklyCostLimit) {
+        logger.security(
+          `💰 Weekly cost limit exceeded for key: ${validation.keyData.id} (${
+            validation.keyData.name
+          }), cost: $${weeklyCost.toFixed(2)}/$${weeklyCostLimit}`
+        )
+
+        const resetDay = validation.keyData.weeklyResetDay || 1
+        const resetHour = validation.keyData.weeklyResetHour || 0
+        const resetDate = redis.getNextResetTime(resetDay, resetHour)
+
+        return res.status(402).json({
+          error: {
+            type: 'insufficient_quota',
+            message: `已达到全模型周费用限制 ($${weeklyCostLimit})`,
+            code: 'weekly_cost_limit_exceeded'
+          },
+          currentCost: weeklyCost,
+          costLimit: weeklyCostLimit,
+          resetAt: resetDate.toISOString()
+        })
+      }
+
+      logger.api(
+        `💰 Weekly cost usage for key: ${validation.keyData.id} (${
+          validation.keyData.name
+        }), current: $${weeklyCost.toFixed(2)}/$${weeklyCostLimit}`
+      )
+    }
+
     // 将验证信息添加到请求对象（只包含必要信息）
     req.apiKey = {
       id: validation.keyData.id,

--- a/src/models/redis.js
+++ b/src/models/redis.js
@@ -1955,6 +1955,51 @@ class RedisClient {
     await this.client.expire(weeklyKey, 14 * 24 * 3600)
   }
 
+  // 💰 获取本周全模型费用（支持自定义重置周期）
+  async getWeeklyCost(keyId, resetDay = 1, resetHour = 0) {
+    const periodStr = getPeriodString(resetDay, resetHour)
+    const costKey = `usage:weekly:${keyId}:${periodStr}`
+    const cost = await this.client.get(costKey)
+    const result = parseFloat(cost || 0)
+    logger.debug(
+      `💰 Getting weekly cost for ${keyId}, period: ${periodStr}, key: ${costKey}, value: ${cost}, result: ${result}`
+    )
+    return result
+  }
+
+  // 💰 增加本周全模型费用（支持倍率成本和真实成本，支持自定义重置周期）
+  // amount: 倍率后的成本（用于限额校验）
+  // realAmount: 真实成本（用于对账），如果不传则等于 amount
+  async incrementWeeklyCost(keyId, amount, realAmount = null, resetDay = 1, resetHour = 0) {
+    const periodStr = getPeriodString(resetDay, resetHour)
+    const weeklyKey = `usage:weekly:${keyId}:${periodStr}`
+    const realWeeklyKey = `usage:real:weekly:${keyId}:${periodStr}`
+    const actualRealAmount = realAmount !== null ? realAmount : amount
+
+    logger.debug(
+      `💰 Incrementing weekly cost for ${keyId}, period: ${periodStr}, rated: $${amount}, real: $${actualRealAmount}`
+    )
+
+    const pipeline = this.client.pipeline()
+    pipeline.incrbyfloat(weeklyKey, amount)
+    pipeline.incrbyfloat(realWeeklyKey, actualRealAmount)
+    // 设置周费用键的过期时间为 2 周
+    pipeline.expire(weeklyKey, 14 * 24 * 3600)
+    pipeline.expire(realWeeklyKey, 14 * 24 * 3600)
+
+    const results = await pipeline.exec()
+    logger.debug(`💰 Weekly cost incremented successfully, new weekly total: $${results[0][1]}`)
+  }
+
+  // 💰 覆盖设置本周全模型费用（用于回填/迁移，支持自定义周期标识）
+  async setWeeklyCost(keyId, amount, periodString = null, resetDay = 1, resetHour = 0) {
+    const currentPeriod = periodString || getPeriodString(resetDay, resetHour)
+    const weeklyKey = `usage:weekly:${keyId}:${currentPeriod}`
+
+    await this.client.set(weeklyKey, String(amount || 0))
+    await this.client.expire(weeklyKey, 14 * 24 * 3600)
+  }
+
   // 💰 计算账户的每日费用（基于模型使用，使用索引集合替代 KEYS）
   async getAccountDailyCost(accountId) {
     const CostCalculator = require('../utils/costCalculator')
@@ -4831,6 +4876,8 @@ redisClient.batchGetApiKeyStats = async function (keyIds) {
     pipeline.zcard(`concurrency:${keyId}`)
     // weekly opus cost (1 get)
     pipeline.get(`usage:opus:weekly:${keyId}:${currentWeek}`)
+    // weekly cost - all models (1 get)
+    pipeline.get(`usage:weekly:${keyId}:${currentWeek}`)
     // rate limit (4 get)
     pipeline.get(`rate_limit:requests:${keyId}`)
     pipeline.get(`rate_limit:tokens:${keyId}`)
@@ -4842,7 +4889,7 @@ redisClient.batchGetApiKeyStats = async function (keyIds) {
 
   const results = await pipeline.exec()
   const statsMap = new Map()
-  const FIELDS_PER_KEY = 14
+  const FIELDS_PER_KEY = 15
 
   for (let i = 0; i < keyIds.length; i++) {
     const keyId = keyIds[i]
@@ -4858,6 +4905,7 @@ redisClient.batchGetApiKeyStats = async function (keyIds) {
       [, costTotal],
       [, concurrency],
       [, weeklyOpusCost],
+      [, weeklyCost],
       [, rateLimitRequests],
       [, rateLimitTokens],
       [, rateLimitCost],
@@ -4878,6 +4926,7 @@ redisClient.batchGetApiKeyStats = async function (keyIds) {
       concurrency: concurrency || 0,
       dailyCost: parseFloat(costDaily || 0),
       weeklyOpusCost: parseFloat(weeklyOpusCost || 0),
+      weeklyCost: parseFloat(weeklyCost || 0),
       rateLimit: {
         requests: parseInt(rateLimitRequests || 0),
         tokens: parseInt(rateLimitTokens || 0),

--- a/src/routes/admin/apiKeys.js
+++ b/src/routes/admin/apiKeys.js
@@ -1031,6 +1031,7 @@ router.post('/api-keys/batch-stats', authenticateAdmin, async (req, res) => {
             formattedCost: '$0.00',
             dailyCost: 0,
             weeklyOpusCost: 0,
+            weeklyCost: 0,
             currentWindowCost: 0,
             currentWindowRequests: 0,
             currentWindowTokens: 0,
@@ -1115,6 +1116,7 @@ async function calculateKeyStats(keyId, timeRange, startDate, endDate) {
   // 获取实时限制数据（窗口数据不受时间范围筛选影响，始终获取当前窗口状态）
   let dailyCost = 0
   let weeklyOpusCost = 0 // 字段名沿用 weeklyOpusCost*，语义为"Claude 周费用"
+  let weeklyCost = 0 // 全模型周费用
   let currentWindowCost = 0
   let currentWindowRequests = 0 // 当前窗口请求次数
   let currentWindowTokens = 0 // 当前窗口 Token 使用量
@@ -1129,6 +1131,7 @@ async function calculateKeyStats(keyId, timeRange, startDate, endDate) {
     const rateLimitWindow = parseInt(apiKey?.rateLimitWindow) || 0
     const dailyCostLimit = parseFloat(apiKey?.dailyCostLimit) || 0
     const weeklyOpusCostLimit = parseFloat(apiKey?.weeklyOpusCostLimit) || 0
+    const weeklyCostLimit = parseFloat(apiKey?.weeklyCostLimit) || 0
 
     // 只在启用了每日费用限制时查询
     if (dailyCostLimit > 0) {
@@ -1144,6 +1147,13 @@ async function calculateKeyStats(keyId, timeRange, startDate, endDate) {
       const resetDay = parseInt(apiKey?.weeklyResetDay || 1)
       const resetHour = parseInt(apiKey?.weeklyResetHour || 0)
       weeklyOpusCost = await redis.getWeeklyOpusCost(keyId, resetDay, resetHour)
+    }
+
+    // 只在启用了全模型周费用限制时查询
+    if (weeklyCostLimit > 0) {
+      const resetDay = parseInt(apiKey?.weeklyResetDay || 1)
+      const resetHour = parseInt(apiKey?.weeklyResetHour || 0)
+      weeklyCost = await redis.getWeeklyCost(keyId, resetDay, resetHour)
     }
 
     // 只在启用了窗口限制时查询窗口数据
@@ -1185,6 +1195,7 @@ async function calculateKeyStats(keyId, timeRange, startDate, endDate) {
   const limitData = {
     dailyCost,
     weeklyOpusCost,
+    weeklyCost,
     currentWindowCost,
     currentWindowRequests,
     currentWindowTokens,
@@ -1487,6 +1498,7 @@ router.post('/api-keys', authenticateAdmin, async (req, res) => {
       dailyCostLimit,
       totalCostLimit,
       weeklyOpusCostLimit,
+      weeklyCostLimit,
       tags,
       activationDays, // 新增：激活后有效天数
       activationUnit, // 新增：激活时间单位 (hours/days)
@@ -1692,6 +1704,7 @@ router.post('/api-keys', authenticateAdmin, async (req, res) => {
       dailyCostLimit,
       totalCostLimit,
       weeklyOpusCostLimit,
+      weeklyCostLimit,
       tags,
       activationDays,
       activationUnit,
@@ -1750,6 +1763,7 @@ router.post('/api-keys/batch', authenticateAdmin, async (req, res) => {
       dailyCostLimit,
       totalCostLimit,
       weeklyOpusCostLimit,
+      weeklyCostLimit,
       tags,
       activationDays,
       activationUnit,
@@ -1815,6 +1829,7 @@ router.post('/api-keys/batch', authenticateAdmin, async (req, res) => {
           dailyCostLimit,
           totalCostLimit,
           weeklyOpusCostLimit,
+          weeklyCostLimit,
           tags,
           activationDays,
           activationUnit,
@@ -1954,6 +1969,9 @@ router.put('/api-keys/batch', authenticateAdmin, async (req, res) => {
         }
         if (updates.weeklyOpusCostLimit !== undefined) {
           finalUpdates.weeklyOpusCostLimit = updates.weeklyOpusCostLimit
+        }
+        if (updates.weeklyCostLimit !== undefined) {
+          finalUpdates.weeklyCostLimit = updates.weeklyCostLimit
         }
         if (updates.permissions !== undefined) {
           finalUpdates.permissions = updates.permissions
@@ -2117,6 +2135,7 @@ router.put('/api-keys/:keyId', authenticateAdmin, async (req, res) => {
       dailyCostLimit,
       totalCostLimit,
       weeklyOpusCostLimit,
+      weeklyCostLimit,
       tags,
       ownerId, // 新增：所有者ID字段
       serviceRates, // API Key 级别服务倍率
@@ -2297,6 +2316,15 @@ router.put('/api-keys/:keyId', authenticateAdmin, async (req, res) => {
           .json({ error: 'Weekly Opus cost limit must be a non-negative number' })
       }
       updates.weeklyOpusCostLimit = costLimit
+    }
+
+    // 处理全模型周费用限制
+    if (weeklyCostLimit !== undefined && weeklyCostLimit !== null && weeklyCostLimit !== '') {
+      const costLimit = Number(weeklyCostLimit)
+      if (isNaN(costLimit) || costLimit < 0) {
+        return res.status(400).json({ error: 'Weekly cost limit must be a non-negative number' })
+      }
+      updates.weeklyCostLimit = costLimit
     }
 
     // 处理标签

--- a/src/routes/apiStats.js
+++ b/src/routes/apiStats.js
@@ -514,6 +514,7 @@ router.post('/api/user-stats', async (req, res) => {
         dailyCostLimit: fullKeyData.dailyCostLimit || 0,
         totalCostLimit: fullKeyData.totalCostLimit || 0,
         weeklyOpusCostLimit: parseFloat(fullKeyData.weeklyOpusCostLimit) || 0, // Opus 周费用限制
+        weeklyCostLimit: parseFloat(fullKeyData.weeklyCostLimit) || 0, // 全模型周费用限制
         weeklyResetDay: parseInt(fullKeyData.weeklyResetDay) || 1, // 周费用重置日 (1-7)
         weeklyResetHour: parseInt(fullKeyData.weeklyResetHour) || 0, // 周费用重置时 (0-23)
         // 当前使用量
@@ -528,6 +529,12 @@ router.post('/api/user-stats', async (req, res) => {
             parseInt(fullKeyData.weeklyResetDay) || 1,
             parseInt(fullKeyData.weeklyResetHour) || 0
           )) || 0, // 当前 Opus 周费用
+        weeklyCost:
+          (await redis.getWeeklyCost(
+            keyId,
+            parseInt(fullKeyData.weeklyResetDay) || 1,
+            parseInt(fullKeyData.weeklyResetHour) || 0
+          )) || 0, // 当前全模型周费用
         // 时间窗口信息
         windowStartTime,
         windowEndTime,

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -328,6 +328,7 @@ class ApiKeyService {
       dailyCostLimit: parseFloat(keyData.dailyCostLimit || 0),
       totalCostLimit: parseFloat(keyData.totalCostLimit || 0),
       weeklyOpusCostLimit: parseFloat(keyData.weeklyOpusCostLimit || 0),
+      weeklyCostLimit: parseFloat(keyData.weeklyCostLimit || 0),
       tags: JSON.parse(keyData.tags || '[]'),
       activationDays: parseInt(keyData.activationDays || 0),
       activationUnit: keyData.activationUnit || 'days',

--- a/src/services/apiKeyService.js
+++ b/src/services/apiKeyService.js
@@ -196,6 +196,7 @@ class ApiKeyService {
       dailyCostLimit = 0,
       totalCostLimit = 0,
       weeklyOpusCostLimit = 0,
+      weeklyCostLimit = 0,
       tags = [],
       activationDays = 0, // 新增：激活后有效天数（0表示不使用此功能）
       activationUnit = 'days', // 新增：激活时间单位 'hours' 或 'days'
@@ -250,6 +251,7 @@ class ApiKeyService {
       dailyCostLimit: String(dailyCostLimit || 0),
       totalCostLimit: String(totalCostLimit || 0),
       weeklyOpusCostLimit: String(weeklyOpusCostLimit || 0),
+      weeklyCostLimit: String(weeklyCostLimit || 0),
       tags: JSON.stringify(tags || []),
       activationDays: String(activationDays || 0), // 新增：激活后有效天数
       activationUnit: activationUnit || 'days', // 新增：激活时间单位
@@ -432,6 +434,7 @@ class ApiKeyService {
       const dailyCostLimit = parseFloat(keyData.dailyCostLimit || 0)
       const totalCostLimit = parseFloat(keyData.totalCostLimit || 0)
       const weeklyOpusCostLimit = parseFloat(keyData.weeklyOpusCostLimit || 0)
+      const weeklyCostLimit = parseFloat(keyData.weeklyCostLimit || 0)
 
       const costQueries = []
       if (dailyCostLimit > 0) {
@@ -447,6 +450,13 @@ class ApiKeyService {
           redis
             .getWeeklyOpusCost(keyData.id, resetDay, resetHour)
             .then((v) => ({ weeklyOpusCost: v || 0 }))
+        )
+      }
+      if (weeklyCostLimit > 0) {
+        const resetDay = parseInt(keyData.weeklyResetDay || 1)
+        const resetHour = parseInt(keyData.weeklyResetHour || 0)
+        costQueries.push(
+          redis.getWeeklyCost(keyData.id, resetDay, resetHour).then((v) => ({ weeklyCost: v || 0 }))
         )
       }
 
@@ -530,9 +540,11 @@ class ApiKeyService {
           dailyCostLimit,
           totalCostLimit,
           weeklyOpusCostLimit,
+          weeklyCostLimit,
           dailyCost: costData.dailyCost || 0,
           totalCost: costData.totalCost || 0,
           weeklyOpusCost: costData.weeklyOpusCost || 0,
+          weeklyCost: costData.weeklyCost || 0,
           weeklyResetDay: parseInt(keyData.weeklyResetDay || 1),
           weeklyResetHour: parseInt(keyData.weeklyResetHour || 0),
           tags,
@@ -676,10 +688,17 @@ class ApiKeyService {
           dailyCostLimit: parseFloat(keyData.dailyCostLimit || 0),
           totalCostLimit: parseFloat(keyData.totalCostLimit || 0),
           weeklyOpusCostLimit: parseFloat(keyData.weeklyOpusCostLimit || 0),
+          weeklyCostLimit: parseFloat(keyData.weeklyCostLimit || 0),
           dailyCost: dailyCost || 0,
           totalCost: costStats?.total || 0,
           weeklyOpusCost:
             (await redis.getWeeklyOpusCost(
+              keyData.id,
+              parseInt(keyData.weeklyResetDay || 1),
+              parseInt(keyData.weeklyResetHour || 0)
+            )) || 0,
+          weeklyCost:
+            (await redis.getWeeklyCost(
               keyData.id,
               parseInt(keyData.weeklyResetDay || 1),
               parseInt(keyData.weeklyResetHour || 0)
@@ -899,9 +918,16 @@ class ApiKeyService {
         key.dailyCostLimit = parseFloat(key.dailyCostLimit || 0)
         key.totalCostLimit = parseFloat(key.totalCostLimit || 0)
         key.weeklyOpusCostLimit = parseFloat(key.weeklyOpusCostLimit || 0)
+        key.weeklyCostLimit = parseFloat(key.weeklyCostLimit || 0)
         key.dailyCost = (await redis.getDailyCost(key.id)) || 0
         key.weeklyOpusCost =
           (await redis.getWeeklyOpusCost(
+            key.id,
+            parseInt(key.weeklyResetDay || 1),
+            parseInt(key.weeklyResetHour || 0)
+          )) || 0
+        key.weeklyCost =
+          (await redis.getWeeklyCost(
             key.id,
             parseInt(key.weeklyResetDay || 1),
             parseInt(key.weeklyResetHour || 0)
@@ -1132,6 +1158,7 @@ class ApiKeyService {
         key.totalCost = stats.costStats?.total || 0
         key.dailyCost = stats.dailyCost || 0
         key.weeklyOpusCost = stats.weeklyOpusCost || 0
+        key.weeklyCost = stats.weeklyCost || 0
 
         // 并发
         key.currentConcurrency = stats.concurrency || 0
@@ -1145,6 +1172,7 @@ class ApiKeyService {
         key.dailyCostLimit = parseFloat(key.dailyCostLimit) || 0
         key.totalCostLimit = parseFloat(key.totalCostLimit) || 0
         key.weeklyOpusCostLimit = parseFloat(key.weeklyOpusCostLimit) || 0
+        key.weeklyCostLimit = parseFloat(key.weeklyCostLimit) || 0
         key.activationDays = parseInt(key.activationDays) || 0
         key.isActive = key.isActive === 'true' || key.isActive === true
         key.enableModelRestriction =
@@ -1353,6 +1381,7 @@ class ApiKeyService {
         'dailyCostLimit',
         'totalCostLimit',
         'weeklyOpusCostLimit',
+        'weeklyCostLimit',
         'tags',
         'userId', // 新增：用户ID（所有者变更）
         'userUsername', // 新增：用户名（所有者变更）
@@ -1724,6 +1753,8 @@ class ApiKeyService {
 
         // 记录 Opus 周费用（如果适用）
         await this.recordOpusCost(keyId, ratedCost, realCost, model, accountType)
+        // 记录全模型周费用（所有模型 + 所有账户类型）
+        await this.recordWeeklyCost(keyId, ratedCost, realCost)
       } else {
         logger.debug(`💰 No cost recorded for ${keyId} - zero cost for model: ${model}`)
       }
@@ -1847,6 +1878,24 @@ class ApiKeyService {
     }
   }
 
+  // 📊 记录全模型周费用（不做模型/账户类型过滤，所有请求都累加）
+  // ratedCost: 倍率后的成本（用于限额校验）
+  // realCost: 真实成本（用于对账），如果不传则等于 ratedCost
+  async recordWeeklyCost(keyId, ratedCost, realCost) {
+    try {
+      const keyData = await redis.getApiKey(keyId)
+      const resetDay = parseInt(keyData?.weeklyResetDay || 1)
+      const resetHour = parseInt(keyData?.weeklyResetHour || 0)
+
+      await redis.incrementWeeklyCost(keyId, ratedCost, realCost, resetDay, resetHour)
+      logger.database(
+        `💰 Recorded weekly cost for ${keyId}: rated=$${ratedCost.toFixed(6)}, real=$${realCost.toFixed(6)}`
+      )
+    } catch (error) {
+      logger.error('❌ Failed to record weekly cost:', error)
+    }
+  }
+
   // 📊 记录使用情况（新版本，支持详细的缓存类型）
   async recordUsageWithDetails(
     keyId,
@@ -1961,6 +2010,8 @@ class ApiKeyService {
           model,
           accountType
         )
+        // 记录全模型周费用（所有模型 + 所有账户类型）
+        await this.recordWeeklyCost(keyId, ratedCostWithDetails, realCostWithDetails)
 
         // 记录详细的缓存费用（如果有）
         if (costInfo.ephemeral5mCost > 0 || costInfo.ephemeral1hCost > 0) {

--- a/src/services/weeklyClaudeCostInitService.js
+++ b/src/services/weeklyClaudeCostInitService.js
@@ -250,11 +250,7 @@ class WeeklyClaudeCostInitService {
 
             // ----- Opus bucket：保留运行时 recordOpusCost 的过滤条件 -----
             const opusAccountType = inferAccountType(keyData)
-            if (
-              isClaudeModel &&
-              opusAccountType &&
-              OPUS_ACCOUNT_TYPES.includes(opusAccountType)
-            ) {
+            if (isClaudeModel && opusAccountType && OPUS_ACCOUNT_TYPES.includes(opusAccountType)) {
               matchedClaudeEntries++
               const opusService = serviceRatesService.getService(opusAccountType, entry.model)
 
@@ -277,10 +273,7 @@ class WeeklyClaudeCostInitService {
                 opusCostByKeyDate.set(entry.keyId, new Map())
               }
               const opusDateMap = opusCostByKeyDate.get(entry.keyId)
-              opusDateMap.set(
-                entry.dateStr,
-                (opusDateMap.get(entry.dateStr) || 0) + opusRatedCost
-              )
+              opusDateMap.set(entry.dateStr, (opusDateMap.get(entry.dateStr) || 0) + opusRatedCost)
             }
 
             // ----- 全模型 bucket：所有模型 + 所有账户类型 -----

--- a/src/services/weeklyClaudeCostInitService.js
+++ b/src/services/weeklyClaudeCostInitService.js
@@ -27,7 +27,40 @@ function inferAccountType(keyData) {
   if (keyData?.claudeAccountId) {
     return 'claude-official'
   }
-  // bedrock/azure/gemini 等不计入周费用
+  // bedrock/azure/gemini 等不计入 Opus 周费用
+  return null
+}
+
+// 用于全模型周费用回填：覆盖所有 account 类型（按 Claude 优先，其次 OpenAI/Gemini/Bedrock/Droid）
+// serviceRatesService.getService 接受 null accountType 时会按 model fallback，所以推断不到也没关系
+function inferAnyAccountType(keyData) {
+  if (!keyData) {
+    return null
+  }
+  if (keyData.ccrAccountId) {
+    return 'ccr'
+  }
+  if (keyData.claudeConsoleAccountId) {
+    return 'claude-console'
+  }
+  if (keyData.claudeAccountId) {
+    return 'claude-official'
+  }
+  if (keyData.azureOpenaiAccountId) {
+    return 'azure-openai'
+  }
+  if (keyData.openaiAccountId) {
+    return 'openai'
+  }
+  if (keyData.geminiAccountId) {
+    return 'gemini'
+  }
+  if (keyData.bedrockAccountId) {
+    return 'bedrock'
+  }
+  if (keyData.droidAccountId) {
+    return 'droid'
+  }
   return null
 }
 
@@ -56,54 +89,60 @@ class WeeklyClaudeCostInitService {
     return `usage:opus:weekly:${keyId}:${periodString}`
   }
 
+  _buildWeeklyKey(keyId, periodString) {
+    return `usage:weekly:${keyId}:${periodString}`
+  }
+
   /**
-   * 启动回填：从"按日/按模型"统计中反算 Claude 模型费用，
-   * 根据每个 API Key 的 weeklyResetDay/weeklyResetHour 计算周期，
-   * 写入 `usage:opus:weekly:*`，保证周限额在重启后不归零。
+   * 启动回填：从"按日/按模型"统计中反算费用，根据每个 API Key 的
+   * weeklyResetDay/weeklyResetHour 计算周期，双写两个 bucket：
+   *   - `usage:opus:weekly:*`：仅 Claude 模型 + claude-official/claude-console/ccr 账户
+   *   - `usage:weekly:*`：全模型 + 全账户类型
    *
    * 说明：
    * - 回填最近 8 天数据（覆盖任意重置配置的完整 7 天周期）
    * - 会加分布式锁，避免多实例重复跑
    * - 会写 done 标记：同一天内重启默认不重复回填
+   * - done 标记 key 名已升级（init:weekly_cost），旧标记会被忽略，第一次启动会重新回填一次以确保两个 bucket 都填上
    */
   async backfillCurrentWeekClaudeCosts() {
     const client = redis.getClientSafe()
     if (!client) {
-      logger.warn('⚠️ Claude 周费用回填跳过：Redis client 不可用')
+      logger.warn('⚠️ 周费用回填跳过：Redis client 不可用')
       return { success: false, reason: 'redis_unavailable' }
     }
 
     if (!pricingService || !pricingService.pricingData) {
-      logger.warn('⚠️ Claude 周费用回填跳过：pricing service 未初始化')
+      logger.warn('⚠️ 周费用回填跳过：pricing service 未初始化')
       return { success: false, reason: 'pricing_uninitialized' }
     }
 
     const todayStr = redis.getDateStringInTimezone()
-    const doneKey = `init:weekly_opus_cost:${todayStr}:done`
+    const doneKey = `init:weekly_cost:${todayStr}:done`
 
     try {
       const alreadyDone = await client.get(doneKey)
       if (alreadyDone) {
-        logger.info(`ℹ️ Claude 周费用回填已完成（${todayStr}），跳过`)
+        logger.info(`ℹ️ 周费用回填已完成（${todayStr}），跳过`)
         return { success: true, skipped: true }
       }
     } catch (e) {
       // 尽力而为：读取失败不阻断启动回填流程。
     }
 
-    const lockKey = `lock:init:weekly_opus_cost:${todayStr}`
+    const lockKey = `lock:init:weekly_cost:${todayStr}`
     const lockValue = `${process.pid}:${Date.now()}`
     const lockTtlMs = 15 * 60 * 1000
 
     const lockAcquired = await redis.setAccountLock(lockKey, lockValue, lockTtlMs)
     if (!lockAcquired) {
-      logger.info(`ℹ️ Claude 周费用回填已在运行（${todayStr}），跳过`)
+      logger.info(`ℹ️ 周费用回填已在运行（${todayStr}），跳过`)
       return { success: true, skipped: true, reason: 'locked' }
     }
 
     const startedAt = Date.now()
     try {
-      logger.info(`💰 开始回填 Claude 周费用（${todayStr}）...`)
+      logger.info(`💰 开始回填周费用（${todayStr}）...`)
 
       const keyIds = await redis.scanApiKeyIds()
       const dates = this._getLast7DaysInTimezone()
@@ -128,10 +167,14 @@ class WeeklyClaudeCostInitService {
       }
       logger.info(`💰 预加载 ${keyDataCache.size} 个 API Key 数据`)
 
-      // 收集每个 key 每天的费用: Map<keyId, Map<dateStr, ratedCost>>
-      const costByKeyDate = new Map()
+      // 两个独立累加桶：
+      // - opusCostByKeyDate：仅 Claude 模型 + claude-official/claude-console/ccr 账户（保留运行时 recordOpusCost 逻辑）
+      // - allCostByKeyDate：全模型 + 全账户类型（对应运行时 recordWeeklyCost）
+      const opusCostByKeyDate = new Map()
+      const allCostByKeyDate = new Map()
       let scannedKeys = 0
-      let matchedClaudeKeys = 0
+      let matchedClaudeEntries = 0
+      let totalEntries = 0
 
       for (const dateStr of dates) {
         let cursor = '0'
@@ -142,19 +185,14 @@ class WeeklyClaudeCostInitService {
           cursor = nextCursor
           scannedKeys += keys.length
 
+          // 不在准备阶段过滤 model，全部进入处理（Opus 桶在后面按需累加）
           const entries = []
           for (const usageKey of keys) {
             const match = usageKey.match(/^usage:([^:]+):model:daily:(.+):(\d{4}-\d{2}-\d{2})$/)
             if (!match) {
               continue
             }
-            const keyId = match[1]
-            const model = match[2]
-            if (!isClaudeFamilyModel(model)) {
-              continue
-            }
-            matchedClaudeKeys++
-            entries.push({ usageKey, keyId, model, dateStr })
+            entries.push({ usageKey, keyId: match[1], model: match[2], dateStr })
           }
 
           if (entries.length === 0) {
@@ -205,44 +243,81 @@ class WeeklyClaudeCostInitService {
             if (realCost <= 0) {
               continue
             }
+            totalEntries++
 
             const keyData = keyDataCache.get(entry.keyId)
-            const accountType = inferAccountType(keyData)
+            const isClaudeModel = isClaudeFamilyModel(entry.model)
 
-            if (!accountType || !OPUS_ACCOUNT_TYPES.includes(accountType)) {
-              continue
+            // ----- Opus bucket：保留运行时 recordOpusCost 的过滤条件 -----
+            const opusAccountType = inferAccountType(keyData)
+            if (
+              isClaudeModel &&
+              opusAccountType &&
+              OPUS_ACCOUNT_TYPES.includes(opusAccountType)
+            ) {
+              matchedClaudeEntries++
+              const opusService = serviceRatesService.getService(opusAccountType, entry.model)
+
+              let globalRate = globalRateCache.get(opusService)
+              if (globalRate === undefined) {
+                globalRate = await serviceRatesService.getServiceRate(opusService)
+                globalRateCache.set(opusService, globalRate)
+              }
+
+              let keyRates = {}
+              try {
+                keyRates = JSON.parse(keyData?.serviceRates || '{}')
+              } catch (e) {
+                keyRates = {}
+              }
+              const keyRate = keyRates[opusService] ?? 1.0
+              const opusRatedCost = realCost * globalRate * keyRate
+
+              if (!opusCostByKeyDate.has(entry.keyId)) {
+                opusCostByKeyDate.set(entry.keyId, new Map())
+              }
+              const opusDateMap = opusCostByKeyDate.get(entry.keyId)
+              opusDateMap.set(
+                entry.dateStr,
+                (opusDateMap.get(entry.dateStr) || 0) + opusRatedCost
+              )
             }
 
-            const service = serviceRatesService.getService(accountType, entry.model)
+            // ----- 全模型 bucket：所有模型 + 所有账户类型 -----
+            const anyAccountType = inferAnyAccountType(keyData)
+            const anyService = serviceRatesService.getService(anyAccountType, entry.model)
 
-            let globalRate = globalRateCache.get(service)
-            if (globalRate === undefined) {
-              globalRate = await serviceRatesService.getServiceRate(service)
-              globalRateCache.set(service, globalRate)
+            let anyRatedCost = realCost
+            if (anyService) {
+              let anyGlobalRate = globalRateCache.get(anyService)
+              if (anyGlobalRate === undefined) {
+                anyGlobalRate = await serviceRatesService.getServiceRate(anyService)
+                globalRateCache.set(anyService, anyGlobalRate)
+              }
+
+              let anyKeyRates = {}
+              try {
+                anyKeyRates = JSON.parse(keyData?.serviceRates || '{}')
+              } catch (e) {
+                anyKeyRates = {}
+              }
+              const anyKeyRate = anyKeyRates[anyService] ?? 1.0
+              anyRatedCost = realCost * anyGlobalRate * anyKeyRate
             }
 
-            let keyRates = {}
-            try {
-              keyRates = JSON.parse(keyData?.serviceRates || '{}')
-            } catch (e) {
-              keyRates = {}
+            if (!allCostByKeyDate.has(entry.keyId)) {
+              allCostByKeyDate.set(entry.keyId, new Map())
             }
-            const keyRate = keyRates[service] ?? 1.0
-            const ratedCost = realCost * globalRate * keyRate
-
-            // 按 keyId+dateStr 累加
-            if (!costByKeyDate.has(entry.keyId)) {
-              costByKeyDate.set(entry.keyId, new Map())
-            }
-            const dateMap = costByKeyDate.get(entry.keyId)
-            dateMap.set(entry.dateStr, (dateMap.get(entry.dateStr) || 0) + ratedCost)
+            const allDateMap = allCostByKeyDate.get(entry.keyId)
+            allDateMap.set(entry.dateStr, (allDateMap.get(entry.dateStr) || 0) + anyRatedCost)
           }
         } while (cursor !== '0')
       }
 
-      // 为每个 API Key 按其重置配置计算当前周期费用
+      // 为每个 API Key 按其重置配置计算当前周期费用，双写两个 bucket
       const ttlSeconds = 14 * 24 * 3600
-      let filledCount = 0
+      let filledOpus = 0
+      let filledAll = 0
       for (let i = 0; i < keyIds.length; i += batchSize) {
         const batch = keyIds.slice(i, i + batchSize)
         const pipeline = client.pipeline()
@@ -251,28 +326,42 @@ class WeeklyClaudeCostInitService {
           const resetDay = parseInt(keyData?.weeklyResetDay || 1)
           const resetHour = parseInt(keyData?.weeklyResetHour || 0)
 
-          // 获取当前周期的起始日期
           const periodStart = redis.getPeriodStartDate(resetDay, resetHour)
           const periodStartDateStr = formatTzDateYmd(periodStart)
           const periodString = redis.getPeriodString(resetDay, resetHour)
 
-          // 汇总该 key 在当前周期内的费用
-          const dateMap = costByKeyDate.get(keyId)
-          let periodCost = 0
-          if (dateMap) {
-            for (const [dateStr, cost] of dateMap) {
+          // Opus bucket
+          let opusPeriodCost = 0
+          const opusDateMap = opusCostByKeyDate.get(keyId)
+          if (opusDateMap) {
+            for (const [dateStr, cost] of opusDateMap) {
               if (dateStr >= periodStartDateStr) {
-                periodCost += cost
+                opusPeriodCost += cost
               }
             }
           }
-
-          if (periodCost > 0) {
-            filledCount++
+          if (opusPeriodCost > 0) {
+            filledOpus++
           }
+          const opusKey = this._buildWeeklyOpusKey(keyId, periodString)
+          pipeline.set(opusKey, String(opusPeriodCost))
+          pipeline.expire(opusKey, ttlSeconds)
 
-          const weeklyKey = this._buildWeeklyOpusKey(keyId, periodString)
-          pipeline.set(weeklyKey, String(periodCost))
+          // 全模型 bucket
+          let allPeriodCost = 0
+          const allDateMap = allCostByKeyDate.get(keyId)
+          if (allDateMap) {
+            for (const [dateStr, cost] of allDateMap) {
+              if (dateStr >= periodStartDateStr) {
+                allPeriodCost += cost
+              }
+            }
+          }
+          if (allPeriodCost > 0) {
+            filledAll++
+          }
+          const weeklyKey = this._buildWeeklyKey(keyId, periodString)
+          pipeline.set(weeklyKey, String(allPeriodCost))
           pipeline.expire(weeklyKey, ttlSeconds)
         }
         await pipeline.exec()
@@ -283,7 +372,7 @@ class WeeklyClaudeCostInitService {
 
       const durationMs = Date.now() - startedAt
       logger.info(
-        `✅ Claude 周费用回填完成（${todayStr}）：keys=${keyIds.length}, scanned=${scannedKeys}, matchedClaude=${matchedClaudeKeys}, filled=${filledCount}（${durationMs}ms）`
+        `✅ 周费用回填完成（${todayStr}）：keys=${keyIds.length}, scanned=${scannedKeys}, entries=${totalEntries}, matchedClaude=${matchedClaudeEntries}, filledOpus=${filledOpus}, filledAll=${filledAll}（${durationMs}ms）`
       )
 
       return {
@@ -291,12 +380,14 @@ class WeeklyClaudeCostInitService {
         todayStr,
         keyCount: keyIds.length,
         scannedKeys,
-        matchedClaudeKeys,
-        filledKeys: filledCount,
+        totalEntries,
+        matchedClaudeEntries,
+        filledOpus,
+        filledAll,
         durationMs
       }
     } catch (error) {
-      logger.error(`❌ Claude 周费用回填失败（${todayStr}）：`, error)
+      logger.error(`❌ 周费用回填失败（${todayStr}）：`, error)
       return { success: false, error: error.message }
     } finally {
       await redis.releaseAccountLock(lockKey, lockValue)
@@ -331,22 +422,26 @@ class WeeklyClaudeCostInitService {
       const resetDay = parseInt(keyData.weeklyResetDay || 1)
       const resetHour = parseInt(keyData.weeklyResetHour || 0)
 
-      const accountType = inferAccountType(keyData)
-      if (!accountType || !OPUS_ACCOUNT_TYPES.includes(accountType)) {
-        // 非 Claude 账户，写入 0 即可
-        const periodString = redis.getPeriodString(resetDay, resetHour)
-        await redis.setWeeklyOpusCost(keyId, 0, periodString)
-        return { success: true, cost: 0, reason: 'non_claude_account' }
-      }
-
       const periodStart = redis.getPeriodStartDate(resetDay, resetHour)
       const periodStartDateStr = formatTzDateYmd(periodStart)
       const periodString = redis.getPeriodString(resetDay, resetHour)
 
+      const opusAccountType = inferAccountType(keyData)
+      const anyAccountType = inferAnyAccountType(keyData)
+      const opusEligible = opusAccountType && OPUS_ACCOUNT_TYPES.includes(opusAccountType)
+
       // 扫描最近 8 天的每日使用数据
       const dates = this._getLast7DaysInTimezone()
       const globalRateCache = new Map()
-      let totalCost = 0
+      let opusCost = 0
+      let allCost = 0
+
+      let keyRates = {}
+      try {
+        keyRates = JSON.parse(keyData.serviceRates || '{}')
+      } catch (e) {
+        keyRates = {}
+      }
 
       for (const dateStr of dates) {
         if (dateStr < periodStartDateStr) {
@@ -364,11 +459,12 @@ class WeeklyClaudeCostInitService {
             continue
           }
 
+          // 不过滤 model，全部进入处理
           const pipeline = client.pipeline()
           const models = []
           for (const usageKey of keys) {
             const match = usageKey.match(/^usage:[^:]+:model:daily:(.+):(\d{4}-\d{2}-\d{2})$/)
-            if (!match || !isClaudeFamilyModel(match[1])) {
+            if (!match) {
               continue
             }
             models.push(match[1])
@@ -420,32 +516,45 @@ class WeeklyClaudeCostInitService {
               continue
             }
 
-            const service = serviceRatesService.getService(accountType, model)
+            const isClaudeModel = isClaudeFamilyModel(model)
 
-            let globalRate = globalRateCache.get(service)
-            if (globalRate === undefined) {
-              globalRate = await serviceRatesService.getServiceRate(service)
-              globalRateCache.set(service, globalRate)
+            // Opus bucket：保留现有过滤
+            if (opusEligible && isClaudeModel) {
+              const opusService = serviceRatesService.getService(opusAccountType, model)
+              let globalRate = globalRateCache.get(opusService)
+              if (globalRate === undefined) {
+                globalRate = await serviceRatesService.getServiceRate(opusService)
+                globalRateCache.set(opusService, globalRate)
+              }
+              const keyRate = keyRates[opusService] ?? 1.0
+              opusCost += realCost * globalRate * keyRate
             }
 
-            let keyRates = {}
-            try {
-              keyRates = JSON.parse(keyData.serviceRates || '{}')
-            } catch (e) {
-              keyRates = {}
+            // 全模型 bucket：所有模型
+            const anyService = serviceRatesService.getService(anyAccountType, model)
+            if (anyService) {
+              let anyGlobalRate = globalRateCache.get(anyService)
+              if (anyGlobalRate === undefined) {
+                anyGlobalRate = await serviceRatesService.getServiceRate(anyService)
+                globalRateCache.set(anyService, anyGlobalRate)
+              }
+              const anyKeyRate = keyRates[anyService] ?? 1.0
+              allCost += realCost * anyGlobalRate * anyKeyRate
+            } else {
+              allCost += realCost
             }
-            const keyRate = keyRates[service] ?? 1.0
-            totalCost += realCost * globalRate * keyRate
           }
         } while (cursor !== '0')
       }
 
-      await redis.setWeeklyOpusCost(keyId, totalCost, periodString)
+      // 双写两个 bucket（即使 cost=0 也要写，确保旧值被覆盖）
+      await redis.setWeeklyOpusCost(keyId, opusCost, periodString)
+      await redis.setWeeklyCost(keyId, allCost, periodString)
       logger.info(
-        `💰 单 Key 回填完成 (${keyId})：period=${periodString}, cost=$${totalCost.toFixed(6)}`
+        `💰 单 Key 回填完成 (${keyId})：period=${periodString}, opus=$${opusCost.toFixed(6)}, all=$${allCost.toFixed(6)}`
       )
 
-      return { success: true, cost: totalCost, periodString }
+      return { success: true, opusCost, allCost, periodString }
     } catch (error) {
       logger.error(`❌ 单 Key 回填失败 (${keyId})：`, error)
       return { success: false, error: error.message }

--- a/web/admin-spa/src/components/apikeys/BatchEditApiKeyModal.vue
+++ b/web/admin-spa/src/components/apikeys/BatchEditApiKeyModal.vue
@@ -249,7 +249,10 @@
               设置 Claude 模型的周费用限制，仅对 Claude 模型请求生效
             </p>
             <div
-              v-if="form.weeklyOpusCostLimit && Number(form.weeklyOpusCostLimit) > 0"
+              v-if="
+                (form.weeklyOpusCostLimit && Number(form.weeklyOpusCostLimit) > 0) ||
+                (form.weeklyCostLimit && Number(form.weeklyCostLimit) > 0)
+              "
               class="mt-2 flex gap-3"
             >
               <div class="flex-1">
@@ -285,6 +288,24 @@
                 </select>
               </div>
             </div>
+          </div>
+
+          <!-- 全模型周费用限制 -->
+          <div>
+            <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300">
+              全模型周费用限制 (美元)
+            </label>
+            <input
+              v-model="form.weeklyCostLimit"
+              class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+              min="0"
+              placeholder="不修改 (0 表示无限制)"
+              step="0.01"
+              type="number"
+            />
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              所有模型（含 Claude）请求都计入此额度，重置日/时与上方共用
+            </p>
           </div>
 
           <!-- 并发限制 -->
@@ -548,6 +569,7 @@ const form = reactive({
   dailyCostLimit: '',
   totalCostLimit: '',
   weeklyOpusCostLimit: '', // 新增Claude周费用限制
+  weeklyCostLimit: '', // 全模型周费用限制
   weeklyResetDay: '',
   weeklyResetHour: '',
   permissions: '', // 空字符串表示不修改
@@ -775,6 +797,9 @@ const batchUpdateApiKeys = async () => {
     }
     if (form.weeklyOpusCostLimit !== '' && form.weeklyOpusCostLimit !== null) {
       updates.weeklyOpusCostLimit = parseFloat(form.weeklyOpusCostLimit)
+    }
+    if (form.weeklyCostLimit !== '' && form.weeklyCostLimit !== null) {
+      updates.weeklyCostLimit = parseFloat(form.weeklyCostLimit)
     }
     if (form.weeklyResetDay !== '' && form.weeklyResetDay !== null) {
       updates.weeklyResetDay = Number(form.weeklyResetDay)

--- a/web/admin-spa/src/components/apikeys/CreateApiKeyModal.vue
+++ b/web/admin-spa/src/components/apikeys/CreateApiKeyModal.vue
@@ -431,7 +431,10 @@
                 设置 Claude 模型的周费用限制，仅对 Claude 模型请求生效，0 或留空表示无限制
               </p>
               <div
-                v-if="form.weeklyOpusCostLimit && Number(form.weeklyOpusCostLimit) > 0"
+                v-if="
+                  (form.weeklyOpusCostLimit && Number(form.weeklyOpusCostLimit) > 0) ||
+                  (form.weeklyCostLimit && Number(form.weeklyCostLimit) > 0)
+                "
                 class="mt-2 flex gap-3"
               >
                 <div class="flex-1">
@@ -465,6 +468,55 @@
                   </select>
                 </div>
               </div>
+            </div>
+          </div>
+
+          <div>
+            <label class="mb-2 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+              >全模型周费用限制 (美元)</label
+            >
+            <div class="space-y-2">
+              <div class="flex gap-2">
+                <button
+                  class="rounded bg-gray-100 px-2 py-1 text-xs font-medium hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  type="button"
+                  @click="form.weeklyCostLimit = '100'"
+                >
+                  $100
+                </button>
+                <button
+                  class="rounded bg-gray-100 px-2 py-1 text-xs font-medium hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  type="button"
+                  @click="form.weeklyCostLimit = '500'"
+                >
+                  $500
+                </button>
+                <button
+                  class="rounded bg-gray-100 px-2 py-1 text-xs font-medium hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  type="button"
+                  @click="form.weeklyCostLimit = '1000'"
+                >
+                  $1000
+                </button>
+                <button
+                  class="rounded bg-gray-100 px-2 py-1 text-xs font-medium hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  type="button"
+                  @click="form.weeklyCostLimit = ''"
+                >
+                  自定义
+                </button>
+              </div>
+              <input
+                v-model="form.weeklyCostLimit"
+                class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                min="0"
+                placeholder="0 表示无限制"
+                step="0.01"
+                type="number"
+              />
+              <p class="text-xs text-gray-500 dark:text-gray-400">
+                所有模型（含 Claude）请求都计入此额度，重置日/时与上方共用，0 或留空表示无限制
+              </p>
             </div>
           </div>
 
@@ -1095,6 +1147,7 @@ const form = reactive({
   dailyCostLimit: '',
   totalCostLimit: '',
   weeklyOpusCostLimit: '',
+  weeklyCostLimit: '',
   weeklyResetDay: 1,
   weeklyResetHour: 0,
   expireDuration: '',
@@ -1530,6 +1583,10 @@ const createApiKey = async () => {
       weeklyOpusCostLimit:
         form.weeklyOpusCostLimit !== '' && form.weeklyOpusCostLimit !== null
           ? parseFloat(form.weeklyOpusCostLimit)
+          : 0,
+      weeklyCostLimit:
+        form.weeklyCostLimit !== '' && form.weeklyCostLimit !== null
+          ? parseFloat(form.weeklyCostLimit)
           : 0,
       weeklyResetDay: form.weeklyResetDay,
       weeklyResetHour: form.weeklyResetHour,

--- a/web/admin-spa/src/components/apikeys/EditApiKeyModal.vue
+++ b/web/admin-spa/src/components/apikeys/EditApiKeyModal.vue
@@ -414,7 +414,10 @@
                 设置 Claude 模型的周费用限制，仅对 Claude 模型请求生效，0 或留空表示无限制
               </p>
               <div
-                v-if="form.weeklyOpusCostLimit && Number(form.weeklyOpusCostLimit) > 0"
+                v-if="
+                  (form.weeklyOpusCostLimit && Number(form.weeklyOpusCostLimit) > 0) ||
+                  (form.weeklyCostLimit && Number(form.weeklyCostLimit) > 0)
+                "
                 class="mt-3 flex gap-3"
               >
                 <div class="flex-1">
@@ -448,6 +451,55 @@
                   </select>
                 </div>
               </div>
+            </div>
+          </div>
+
+          <div>
+            <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+              >全模型周费用限制 (美元)</label
+            >
+            <div class="space-y-3">
+              <div class="flex gap-2">
+                <button
+                  class="rounded-lg bg-gray-100 px-3 py-1 text-sm font-medium hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  type="button"
+                  @click="form.weeklyCostLimit = '100'"
+                >
+                  $100
+                </button>
+                <button
+                  class="rounded-lg bg-gray-100 px-3 py-1 text-sm font-medium hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  type="button"
+                  @click="form.weeklyCostLimit = '500'"
+                >
+                  $500
+                </button>
+                <button
+                  class="rounded-lg bg-gray-100 px-3 py-1 text-sm font-medium hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  type="button"
+                  @click="form.weeklyCostLimit = '1000'"
+                >
+                  $1000
+                </button>
+                <button
+                  class="rounded-lg bg-gray-100 px-3 py-1 text-sm font-medium hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  type="button"
+                  @click="form.weeklyCostLimit = ''"
+                >
+                  自定义
+                </button>
+              </div>
+              <input
+                v-model="form.weeklyCostLimit"
+                class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
+                min="0"
+                placeholder="0 表示无限制"
+                step="0.01"
+                type="number"
+              />
+              <p class="text-xs text-gray-500 dark:text-gray-400">
+                所有模型（含 Claude）请求都计入此额度，重置日/时与上方共用，0 或留空表示无限制
+              </p>
             </div>
           </div>
 
@@ -1154,6 +1206,7 @@ const form = reactive({
   dailyCostLimit: '',
   totalCostLimit: '',
   weeklyOpusCostLimit: '',
+  weeklyCostLimit: '',
   weeklyResetDay: 1,
   weeklyResetHour: 0,
   permissions: [], // 数组格式，空数组表示全部服务
@@ -1363,6 +1416,10 @@ const updateApiKey = async () => {
       weeklyOpusCostLimit:
         form.weeklyOpusCostLimit !== '' && form.weeklyOpusCostLimit !== null
           ? parseFloat(form.weeklyOpusCostLimit)
+          : 0,
+      weeklyCostLimit:
+        form.weeklyCostLimit !== '' && form.weeklyCostLimit !== null
+          ? parseFloat(form.weeklyCostLimit)
           : 0,
       weeklyResetDay: form.weeklyResetDay,
       weeklyResetHour: form.weeklyResetHour,
@@ -1692,6 +1749,7 @@ onMounted(async () => {
   form.dailyCostLimit = props.apiKey.dailyCostLimit || ''
   form.totalCostLimit = props.apiKey.totalCostLimit || ''
   form.weeklyOpusCostLimit = props.apiKey.weeklyOpusCostLimit || ''
+  form.weeklyCostLimit = props.apiKey.weeklyCostLimit || ''
   form.weeklyResetDay = props.apiKey.weeklyResetDay || 1
   form.weeklyResetHour = props.apiKey.weeklyResetHour || 0
   // 处理权限数据，兼容旧格式（字符串）和新格式（数组）

--- a/web/admin-spa/src/components/apikeys/UsageDetailModal.vue
+++ b/web/admin-spa/src/components/apikeys/UsageDetailModal.vue
@@ -181,6 +181,19 @@
                 </div>
               </div>
 
+              <div v-if="Number(apiKey.weeklyCostLimit) > 0" class="space-y-1.5">
+                <LimitProgressBar
+                  :current="Number(weeklyCost) || 0"
+                  label="全模型周费用限制"
+                  :limit="Number(apiKey.weeklyCostLimit) || 0"
+                  :show-shine="true"
+                  type="total"
+                />
+                <div class="text-right text-xs text-gray-500 dark:text-gray-400">
+                  已使用 {{ Math.min(weeklyUsagePercentage, 100).toFixed(1) }}%
+                </div>
+              </div>
+
               <div v-if="Number(apiKey.totalCostLimit) > 0" class="space-y-1.5">
                 <LimitProgressBar
                   :current="Number(totalCost) || 0"
@@ -350,6 +363,8 @@ const dailyCost = computed(() => props.apiKey.dailyCost || 0)
 const totalCostLimit = computed(() => props.apiKey.totalCostLimit || 0)
 const weeklyOpusCost = computed(() => props.apiKey.weeklyOpusCost || 0)
 const weeklyOpusCostLimit = computed(() => props.apiKey.weeklyOpusCostLimit || 0)
+const weeklyCost = computed(() => props.apiKey.weeklyCost || 0)
+const weeklyCostLimit = computed(() => props.apiKey.weeklyCostLimit || 0)
 const inputTokens = computed(() => props.apiKey.usage?.total?.inputTokens || 0)
 const outputTokens = computed(() => props.apiKey.usage?.total?.outputTokens || 0)
 const cacheCreateTokens = computed(() => props.apiKey.usage?.total?.cacheCreateTokens || 0)
@@ -394,6 +409,7 @@ const hasLimits = computed(() => {
     Number(props.apiKey.totalCostLimit) > 0 ||
     Number(props.apiKey.concurrencyLimit) > 0 ||
     Number(props.apiKey.weeklyOpusCostLimit) > 0 ||
+    Number(props.apiKey.weeklyCostLimit) > 0 ||
     Number(props.apiKey.rateLimitWindow) > 0 ||
     Number(props.apiKey.rateLimitRequests) > 0 ||
     Number(props.apiKey.rateLimitCost) > 0 ||
@@ -415,6 +431,11 @@ const totalUsagePercentage = computed(() => {
 const opusUsagePercentage = computed(() => {
   if (!weeklyOpusCostLimit.value || weeklyOpusCostLimit.value === 0) return 0
   return (weeklyOpusCost.value / weeklyOpusCostLimit.value) * 100
+})
+
+const weeklyUsagePercentage = computed(() => {
+  if (!weeklyCostLimit.value || weeklyCostLimit.value === 0) return 0
+  return (weeklyCost.value / weeklyCostLimit.value) * 100
 })
 
 // 方法

--- a/web/admin-spa/src/components/apistats/LimitConfig.vue
+++ b/web/admin-spa/src/components/apistats/LimitConfig.vue
@@ -199,6 +199,38 @@
           </p>
         </div>
 
+        <!-- 全模型周费用限制 -->
+        <div v-if="statsData.limits.weeklyCostLimit > 0">
+          <div class="mb-2 flex items-center justify-between">
+            <span class="text-sm font-medium text-gray-600 dark:text-gray-400 md:text-base"
+              >全模型周费用限制</span
+            >
+            <span class="text-xs text-gray-500 dark:text-gray-400 md:text-sm">
+              ${{ (statsData.limits.weeklyCost || 0).toFixed(4) }} / ${{
+                statsData.limits.weeklyCostLimit.toFixed(2)
+              }}
+            </span>
+          </div>
+          <div class="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+            <div
+              class="h-2 rounded-full transition-all duration-300"
+              :class="getWeeklyCostProgressColor()"
+              :style="{ width: getWeeklyCostProgress() + '%' }"
+            />
+          </div>
+          <p
+            v-if="statsData.limits.weeklyResetDay"
+            class="mt-1 text-xs text-gray-400 dark:text-gray-500"
+          >
+            每{{
+              ['', '周一', '周二', '周三', '周四', '周五', '周六', '周日'][
+                statsData.limits.weeklyResetDay || 1
+              ]
+            }}
+            {{ String(statsData.limits.weeklyResetHour || 0).padStart(2, '0') }}:00 (UTC+8) 重置
+          </p>
+        </div>
+
         <!-- 时间窗口限制 -->
         <div
           v-if="
@@ -413,6 +445,23 @@ const getOpusWeeklyCostProgressColor = () => {
   if (progress >= 100) return 'bg-red-500'
   if (progress >= 80) return 'bg-yellow-500'
   return 'bg-indigo-500' // 使用紫色表示Opus模型
+}
+
+// 获取全模型周费用进度
+const getWeeklyCostProgress = () => {
+  if (!statsData.value.limits.weeklyCostLimit || statsData.value.limits.weeklyCostLimit === 0)
+    return 0
+  const percentage =
+    (statsData.value.limits.weeklyCost / statsData.value.limits.weeklyCostLimit) * 100
+  return Math.min(percentage, 100)
+}
+
+// 获取全模型周费用进度条颜色
+const getWeeklyCostProgressColor = () => {
+  const progress = getWeeklyCostProgress()
+  if (progress >= 100) return 'bg-red-500'
+  if (progress >= 80) return 'bg-yellow-500'
+  return 'bg-cyan-500'
 }
 
 // 格式化数字

--- a/web/admin-spa/src/views/ApiKeysView.vue
+++ b/web/admin-spa/src/views/ApiKeysView.vue
@@ -647,6 +647,7 @@
                             v-if="
                               isStatsLoading(key.id) &&
                               (key.weeklyOpusCostLimit > 0 ||
+                                key.weeklyCostLimit > 0 ||
                                 key.dailyCostLimit > 0 ||
                                 key.totalCostLimit > 0 ||
                                 (key.rateLimitWindow > 0 && key.rateLimitCost > 0))
@@ -670,6 +671,16 @@
                               label="Claude 周限制"
                               :limit="key.weeklyOpusCostLimit"
                               type="opus"
+                              variant="compact"
+                            />
+
+                            <!-- 全模型周额度限制 - 独立显示 -->
+                            <LimitProgressBar
+                              v-if="key.weeklyCostLimit > 0"
+                              :current="getCachedStats(key.id)?.weeklyCost || 0"
+                              label="全模型周限制"
+                              :limit="key.weeklyCostLimit"
+                              type="total"
                               variant="compact"
                             />
 
@@ -740,6 +751,7 @@
                             <div
                               v-if="
                                 !(key.weeklyOpusCostLimit > 0) &&
+                                !(key.weeklyCostLimit > 0) &&
                                 !(key.dailyCostLimit > 0) &&
                                 !(key.totalCostLimit > 0) &&
                                 !(key.rateLimitWindow > 0 && key.rateLimitCost > 0)
@@ -4278,6 +4290,7 @@ const showUsageDetails = (apiKey) => {
     ...apiKey,
     dailyCost: cachedStats?.dailyCost ?? apiKey.dailyCost ?? 0,
     weeklyOpusCost: cachedStats?.weeklyOpusCost ?? apiKey.weeklyOpusCost ?? 0,
+    weeklyCost: cachedStats?.weeklyCost ?? apiKey.weeklyCost ?? 0,
     currentWindowCost: cachedStats?.currentWindowCost ?? apiKey.currentWindowCost ?? 0,
     currentWindowRequests: cachedStats?.currentWindowRequests ?? apiKey.currentWindowRequests ?? 0,
     currentWindowTokens: cachedStats?.currentWindowTokens ?? apiKey.currentWindowTokens ?? 0,


### PR DESCRIPTION
## Summary
- 新增 `weeklyCostLimit` 字段，对 API Key 的所有模型请求（Claude/GPT/Gemini/Bedrock/Droid 等）统一按周限额
- 原有 `weeklyOpusCostLimit`（仅 Claude 生效）行为保持不变，两个限额独立校验
- 共享现有 `weeklyResetDay` / `weeklyResetHour` 重置周期，前端无需新增重置选择器
- **启动回填**：服务启动时根据历史日费用统计自动回填当前周期，重启后限额不归零（与 Opus 周限额行为一致）

## Motivation
当前 `weeklyOpusCostLimit` 只对 Claude 系列模型 + `claude-official` / `claude-console` / `ccr` 三种账户类型生效（`apiKeyService.recordOpusCost` 双重过滤）。GPT、Gemini、Bedrock 等模型既不累加也不被校验，无法对 API Key 设置跨模型的统一周预算。

## Changes
**Backend**
- `src/models/redis.js`: 新增 `getWeeklyCost` / `incrementWeeklyCost` / `setWeeklyCost`，独立 Redis key `usage:weekly:{keyId}:{period}` + `usage:real:weekly:...`，14 天 TTL；`batchGetApiKeyStats` pipeline 扩展第 15 个字段
- `src/services/apiKeyService.js`: 新增 `recordWeeklyCost`（无模型/账户过滤），在 `recordUsage` / `recordUsageWithDetails` 中追加调用；createApiKey/validateApiKey/字段白名单/3 个 enrichment 路径全部镜像
- `src/services/weeklyClaudeCostInitService.js`: 单次 SCAN 双写两个 bucket
  - Opus bucket 保留原有 `isClaudeFamilyModel + OPUS_ACCOUNT_TYPES` 过滤，行为完全不变
  - 全模型 bucket 新增 `inferAnyAccountType` 覆盖 openai/gemini/bedrock/azure-openai/droid；推断不到时退回 realCost（`serviceRatesService.getService` 按 model fallback）
  - `backfillSingleKey` 同样双写（reset day/hour 变更时两个 bucket 一起回填）
  - done 标记 key 从 `init:weekly_opus_cost:<date>:done` 升级为 `init:weekly_cost:<date>:done`，确保升级后第一次启动会重新回填把全模型 bucket 也填上
  - 调用入口（`app.js`、`admin/apiKeys.js`）函数名保持不变
- `src/middleware/auth.js`: Claude 周限制检查之后追加全模型检查，超限返回 402 `weekly_cost_limit_exceeded`
- `src/routes/admin/apiKeys.js`: 8 处 create/update/batchUpdate/getKeyById 全部支持 `weeklyCostLimit`，校验非负数
- `src/routes/apiStats.js`: `limits` payload 加 `weeklyCostLimit` / `weeklyCost`

**Frontend**
- Create/Edit/BatchEdit API Key Modal: 新增「全模型周费用限制」输入框（与 Claude 限额共享重置日/时）
- UsageDetailModal / LimitConfig / ApiKeysView: 新增独立进度条

## Design Notes
- Claude 请求同时计入两个 bucket（Opus + 全模型），触发任一上限均拦截
- `weeklyOpusCostLimit` 字段语义和存储不变，完全向后兼容
- 启动回填扫描的是同一批 `usage:*:model:daily:*` daily usage key，单次 SCAN 同时填两个 bucket，扫描开销不增

## Test Plan
- [x] \`npm run lint\` 通过
- [x] \`npm test\` 通过
- [x] 端到端：创建 Key 设置 \`weeklyCostLimit=\$0.01\`，发 GPT 请求第一次成功累加，第二次返回 402 \`weekly_cost_limit_exceeded\`
- [x] 端到端：发 Claude 请求验证 \`usage:opus:weekly:*\` 和 \`usage:weekly:*\` 两个 Redis key 同时累加
- [x] 回填：手动删除 \`usage:weekly:*\` 和 \`init:weekly_cost:*:done\` 标记后重启，验证 \`usage:weekly:*\` 被根据 daily 使用数据正确填回
- [x] 回填：admin 接口改 \`weeklyResetDay/Hour\` 后验证 \`usage:opus:weekly:*\` 和 \`usage:weekly:*\` 两个 key 都被刷新
- [x] UI：Create/Edit Modal 看到新输入框，保存后重新打开值还在；UsageDetailModal/LimitConfig 看到两个独立进度条