### PR TITLE
fix: respect OpenAI Responses auto protection setting

### DIFF
--- a/src/services/scheduler/unifiedOpenAIScheduler.js
+++ b/src/services/scheduler/unifiedOpenAIScheduler.js
@@ -683,16 +683,19 @@ class UnifiedOpenAIScheduler {
         await openaiAccountService.setAccountRateLimited(accountId, true, resetsInSeconds)
       } else if (accountType === 'openai-responses') {
         // 对于 OpenAI-Responses 账户，使用与普通 OpenAI 账户类似的处理方式
+        const account = await openaiResponsesAccountService.getAccount(accountId)
         const duration = resetsInSeconds ? Math.ceil(resetsInSeconds / 60) : null
         await openaiResponsesAccountService.markAccountRateLimited(accountId, duration)
 
         // 同时更新调度状态，避免继续被调度
-        await openaiResponsesAccountService.updateAccount(accountId, {
-          schedulable: 'false',
-          rateLimitResetAt: resetsInSeconds
-            ? new Date(Date.now() + resetsInSeconds * 1000).toISOString()
-            : new Date(Date.now() + 3600000).toISOString() // 默认1小时
-        })
+        if (account?.disableAutoProtection !== true && account?.disableAutoProtection !== 'true') {
+          await openaiResponsesAccountService.updateAccount(accountId, {
+            schedulable: 'false',
+            rateLimitResetAt: resetsInSeconds
+              ? new Date(Date.now() + resetsInSeconds * 1000).toISOString()
+              : new Date(Date.now() + 3600000).toISOString() // 默认1小时
+          })
+        }
       }
 
       // 删除会话映射

--- a/tests/unifiedOpenAIScheduler.test.js
+++ b/tests/unifiedOpenAIScheduler.test.js
@@ -1,0 +1,75 @@
+jest.mock('../src/services/account/openaiAccountService', () => ({
+  setAccountRateLimited: jest.fn()
+}))
+
+jest.mock('../src/services/account/openaiResponsesAccountService', () => ({
+  getAccount: jest.fn(),
+  markAccountRateLimited: jest.fn(),
+  updateAccount: jest.fn()
+}))
+
+jest.mock('../src/services/accountGroupService', () => ({}))
+jest.mock('../src/models/redis', () => ({}))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn()
+}))
+jest.mock('../src/utils/commonHelper', () => ({
+  isSchedulable: jest.fn((value) => value !== false && value !== 'false'),
+  sortAccountsByPriority: jest.fn((accounts) => accounts)
+}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({}))
+
+const openaiResponsesAccountService = require('../src/services/account/openaiResponsesAccountService')
+const unifiedOpenAIScheduler = require('../src/services/scheduler/unifiedOpenAIScheduler')
+
+describe('UnifiedOpenAIScheduler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('markAccountRateLimited', () => {
+    it('does not disable scheduling again when OpenAI-Responses auto protection is disabled', async () => {
+      openaiResponsesAccountService.getAccount.mockResolvedValue({
+        id: 'account-1',
+        disableAutoProtection: 'true'
+      })
+
+      await unifiedOpenAIScheduler.markAccountRateLimited(
+        'account-1',
+        'openai-responses',
+        null,
+        120
+      )
+
+      expect(openaiResponsesAccountService.markAccountRateLimited).toHaveBeenCalledWith(
+        'account-1',
+        2
+      )
+      expect(openaiResponsesAccountService.updateAccount).not.toHaveBeenCalled()
+    })
+
+    it('keeps disabling scheduling for protected OpenAI-Responses accounts', async () => {
+      openaiResponsesAccountService.getAccount.mockResolvedValue({
+        id: 'account-1',
+        disableAutoProtection: 'false'
+      })
+
+      await unifiedOpenAIScheduler.markAccountRateLimited(
+        'account-1',
+        'openai-responses',
+        null,
+        120
+      )
+
+      expect(openaiResponsesAccountService.updateAccount).toHaveBeenCalledWith(
+        'account-1',
+        expect.objectContaining({
+          schedulable: 'false'
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- avoid forcing OpenAI-Responses accounts to `schedulable=false` when `disableAutoProtection` is enabled
- keep existing rate-limit scheduling disable behavior for protected accounts
- add scheduler regression coverage for both paths

## Tests
- `npm test -- tests/unifiedOpenAIScheduler.test.js --runInBand`
- `npm run lint:check`
- `npx eslint tests/unifiedOpenAIScheduler.test.js`