### PR TITLE
修复 Agent View 辅助请求 429 导致账号冷却的问题

### DIFF
--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -179,6 +179,54 @@ class ClaudeRelayService {
     return undefined
   }
 
+  _extractTextFromContent(content) {
+    if (typeof content === 'string') {
+      return content
+    }
+    if (!Array.isArray(content)) {
+      return ''
+    }
+    return content
+      .filter((block) => block && block.type === 'text' && typeof block.text === 'string')
+      .map((block) => block.text)
+      .join('\n')
+  }
+
+  _extractSystemText(system) {
+    if (typeof system === 'string') {
+      return system
+    }
+    if (!Array.isArray(system)) {
+      return ''
+    }
+    return system
+      .filter((block) => block && block.type === 'text' && typeof block.text === 'string')
+      .map((block) => block.text)
+      .join('\n')
+  }
+
+  _isAgentViewAuxiliaryRequest(requestBody, clientHeaders) {
+    const appHeader = this._getHeaderValueCaseInsensitive(clientHeaders, 'x-app')
+    if (appHeader !== 'cli-bg') {
+      return false
+    }
+    if (requestBody?.stream === true) {
+      return false
+    }
+
+    const systemText = this._extractSystemText(requestBody?.system)
+    const messageText = Array.isArray(requestBody?.messages)
+      ? requestBody.messages
+          .map((message) => this._extractTextFromContent(message?.content))
+          .join('\n')
+      : ''
+
+    return (
+      systemText.includes('A user kicked off a Claude Code agent') ||
+      messageText.includes('2-4 word lowercase label for this job')
+    )
+  }
+
   _isClaudeCodeCredentialError(body) {
     const message = this._extractErrorMessage(body)
     if (!message) {
@@ -840,29 +888,39 @@ class ClaudeRelayService {
         }
 
         if (isRateLimited) {
-          if (isDedicatedOfficialAccount && !dedicatedRateLimitMessage) {
-            dedicatedRateLimitMessage = this._buildStandardRateLimitMessage(
-              rateLimitResetTimestamp || account?.rateLimitEndAt
+          const isAgentViewAuxiliaryRequest = this._isAgentViewAuxiliaryRequest(
+            requestBody,
+            clientHeaders
+          )
+          if (isAgentViewAuxiliaryRequest) {
+            logger.warn(
+              `🚫 Agent View auxiliary request hit 429 for account ${accountId}; skipping account-level rate-limit marking`
             )
-          }
-          logger.warn(
-            `🚫 Rate limit detected for account ${accountId}, status: ${response.statusCode}`
-          )
-          // 标记账号为限流状态并删除粘性会话映射，传递准确的重置时间戳
-          await unifiedClaudeScheduler.markAccountRateLimited(
-            accountId,
-            accountType,
-            sessionHash,
-            rateLimitResetTimestamp
-          )
-          await upstreamErrorHelper
-            .markTempUnavailable(
+          } else {
+            if (isDedicatedOfficialAccount && !dedicatedRateLimitMessage) {
+              dedicatedRateLimitMessage = this._buildStandardRateLimitMessage(
+                rateLimitResetTimestamp || account?.rateLimitEndAt
+              )
+            }
+            logger.warn(
+              `🚫 Rate limit detected for account ${accountId}, status: ${response.statusCode}`
+            )
+            // 标记账号为限流状态并删除粘性会话映射，传递准确的重置时间戳
+            await unifiedClaudeScheduler.markAccountRateLimited(
               accountId,
               accountType,
-              429,
-              upstreamErrorHelper.parseRetryAfter(response.headers)
+              sessionHash,
+              rateLimitResetTimestamp
             )
-            .catch(() => {})
+            await upstreamErrorHelper
+              .markTempUnavailable(
+                accountId,
+                accountType,
+                429,
+                upstreamErrorHelper.parseRetryAfter(response.headers)
+              )
+              .catch(() => {})
+          }
 
           if (dedicatedRateLimitMessage) {
             return {
@@ -2175,23 +2233,33 @@ class ClaudeRelayService {
               const rateLimitResetTimestamp = Number.isNaN(parsedResetTimestamp)
                 ? null
                 : parsedResetTimestamp
-              await unifiedClaudeScheduler.markAccountRateLimited(
-                accountId,
-                accountType,
-                sessionHash,
-                rateLimitResetTimestamp
+              const isAgentViewAuxiliaryRequest = this._isAgentViewAuxiliaryRequest(
+                body,
+                clientHeaders
               )
-              await upstreamErrorHelper
-                .markTempUnavailable(
+              if (isAgentViewAuxiliaryRequest) {
+                logger.warn(
+                  `🚫 [Stream] Agent View auxiliary request hit 429 for account ${accountId}; skipping account-level rate-limit marking`
+                )
+              } else {
+                await unifiedClaudeScheduler.markAccountRateLimited(
                   accountId,
                   accountType,
-                  429,
-                  upstreamErrorHelper.parseRetryAfter(res.headers)
+                  sessionHash,
+                  rateLimitResetTimestamp
                 )
-                .catch(() => {})
-              logger.warn(`🚫 [Stream] Rate limit detected for account ${accountId}, status 429`)
+                await upstreamErrorHelper
+                  .markTempUnavailable(
+                    accountId,
+                    accountType,
+                    429,
+                    upstreamErrorHelper.parseRetryAfter(res.headers)
+                  )
+                  .catch(() => {})
+                logger.warn(`🚫 [Stream] Rate limit detected for account ${accountId}, status 429`)
+              }
 
-              if (isDedicatedOfficialAccount) {
+              if (isDedicatedOfficialAccount && !isAgentViewAuxiliaryRequest) {
                 const limitMessage = this._buildStandardRateLimitMessage(
                   rateLimitResetTimestamp || account?.rateLimitEndAt
                 )


### PR DESCRIPTION
## 概述

这个 PR 修复 Claude Code Agent View 的后台辅助请求触发 429 后，错误地让整个 Claude 账号进入限流冷却的问题。

实际观察到：Agent View 的主任务请求可以成功，但它额外发送的后台状态判断/标题生成请求可能返回 429。当前 relay 会把这个 429 当作账号级限流处理，进而调用 `markAccountRateLimited()` / `markTempUnavailable()`，清理 sticky session，导致后续正常请求也在冷却窗口内无法路由。

## 问题表现

Agent View 会额外发送非流式后台请求，例如：

- 状态判断请求
- 任务标题生成请求

这些请求的典型特征：

```text
x-app: cli-bg
stream: false
```

典型 prompt 包含：

```text
A user kicked off a Claude Code agent to do a coding task and walked away...
```

或：

```text
2-4 word lowercase label for this job
```

当这些辅助请求返回 429 时，不应直接认为整个账号已经达到账号级限流。

## 修改内容

- 增加 Agent View 辅助请求识别逻辑。
- 当这类辅助请求返回 429 时，只记录日志，不再标记账号为全局 rate limited / temp unavailable。
- 普通用户请求和非 Agent View 请求的 429 处理逻辑保持不变。

## 本地验证

已在本地模拟 CI：

```bash
npm ci
npx prettier --check src/services/relay/claudeRelayService.js
npx eslint src/services/relay/claudeRelayService.js --format stylish
npm run lint:check
cp config/config.example.js config/config.js
npm test -- --runInBand
rm -f config/config.js
```

结果：

- Prettier 检查通过
- ESLint 检查通过
- `npm run lint:check` 通过
- Jest 通过：19 个 test suites，247 个测试通过，8 个 skipped

## 备注

这个改动只避免 Agent View 后台辅助请求的 429 误伤整个账号；普通请求的账号级限流保护仍然保留。