### PR TITLE
fix: skip full rate-limit marking for transient 429 throttle on claude-official accounts

### DIFF
--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -849,17 +849,40 @@ class ClaudeRelayService {
                 }
               }
             } else {
-              isRateLimited = true
-              if (!Number.isNaN(parsedResetTimestamp)) {
-                rateLimitResetTimestamp = parsedResetTimestamp
-                logger.info(
-                  `🕐 Extracted rate limit reset timestamp: ${rateLimitResetTimestamp} (${new Date(rateLimitResetTimestamp * 1000).toISOString()})`
+              // 瞬时节流检测：无 reset 时间戳 + 5h-status 为 allowed
+              // → RPM/并发节流，非 session window 耗尽，仅应用短暂冷却
+              const nonStream5hStatus = response.headers
+                ? response.headers['anthropic-ratelimit-unified-5h-status'] ||
+                  response.headers['Anthropic-Ratelimit-Unified-5h-Status']
+                : null
+              const isTransientThrottle =
+                Number.isNaN(parsedResetTimestamp) && nonStream5hStatus === 'allowed'
+
+              if (isTransientThrottle) {
+                logger.warn(
+                  `⚡ [Non-Stream] Transient 429 for account ${accountId} (5h-status: allowed, no reset header) - skipping full rate limit marking, applying short cooldown only`
                 )
-              }
-              if (isDedicatedOfficialAccount) {
-                dedicatedRateLimitMessage = this._buildStandardRateLimitMessage(
-                  rateLimitResetTimestamp || account?.rateLimitEndAt
-                )
+                await upstreamErrorHelper
+                  .markTempUnavailable(
+                    accountId,
+                    accountType,
+                    429,
+                    upstreamErrorHelper.parseRetryAfter(response.headers)
+                  )
+                  .catch(() => {})
+              } else {
+                isRateLimited = true
+                if (!Number.isNaN(parsedResetTimestamp)) {
+                  rateLimitResetTimestamp = parsedResetTimestamp
+                  logger.info(
+                    `🕐 Extracted rate limit reset timestamp: ${rateLimitResetTimestamp} (${new Date(rateLimitResetTimestamp * 1000).toISOString()})`
+                  )
+                }
+                if (isDedicatedOfficialAccount) {
+                  dedicatedRateLimitMessage = this._buildStandardRateLimitMessage(
+                    rateLimitResetTimestamp || account?.rateLimitEndAt
+                  )
+                }
               }
             }
           }
@@ -2891,7 +2914,32 @@ class ClaudeRelayService {
               : null
             const parsedResetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN
 
-            if (isOpusModelRequest && !Number.isNaN(parsedResetTimestamp)) {
+            const isAgentViewAuxiliaryRequest = this._isAgentViewAuxiliaryRequest(
+              requestBody,
+              clientHeaders
+            )
+            // 瞬时节流检测：无 reset 时间戳 + 5h-status 为 allowed
+            // → RPM/并发节流，非 session window 耗尽，跳过长期限流标记
+            const isTransientThrottle =
+              Number.isNaN(parsedResetTimestamp) && sessionWindowStatus === 'allowed'
+
+            if (isAgentViewAuxiliaryRequest) {
+              logger.warn(
+                `🚫 [Stream] Agent View auxiliary request hit 429 for account ${accountId}; skipping account-level rate-limit marking`
+              )
+            } else if (isTransientThrottle) {
+              logger.warn(
+                `⚡ [Stream] Transient 429 for account ${accountId} (5h-status: allowed, no reset header) - skipping full rate limit marking, applying short cooldown only`
+              )
+              await upstreamErrorHelper
+                .markTempUnavailable(
+                  accountId,
+                  accountType,
+                  429,
+                  upstreamErrorHelper.parseRetryAfter(res.headers)
+                )
+                .catch(() => {})
+            } else if (isOpusModelRequest && !Number.isNaN(parsedResetTimestamp)) {
               await claudeAccountService.markAccountOpusRateLimited(accountId, parsedResetTimestamp)
               logger.warn(
                 `🚫 [Stream] Account ${accountId} hit Opus limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`


### PR DESCRIPTION
## Problem

When a `claude-official` (Claude Code OAuth) account receives a 429 inside an SSE stream, the relay service incorrectly treats it as a session window exhaustion and locks the account for hours (e.g., 293 minutes). In reality these are short-lived RPM/concurrency throttles that recover in seconds to minutes.

**Log evidence:**
```
[Stream] Rate limit detected for account df808989, status 429
Account marked as rate limited until estimated session window ends: xxxxxx - 293 minutes remaining
```
Yet the account's actual 5-hour utilization was only 9% and `sessionWindowStatus: "allowed"`.

## Root Cause

The stream-end handler (`if (rateLimitDetected || res.statusCode === 429)`) had no way to distinguish:
- **Transient RPM/concurrency throttle** — resolves in seconds, no `anthropic-ratelimit-unified-reset` header, `5h-status: allowed`
- **True session window exhaustion** — multi-hour lock, `anthropic-ratelimit-unified-reset` header present with a future timestamp

## Fix

Add `isTransientThrottle` detection using two signals already available at the point of handling:

| Signal | Transient throttle | True session limit |
|--------|-------------------|--------------------|
| `anthropic-ratelimit-unified-reset` header | absent | present (future timestamp) |
| `anthropic-ratelimit-unified-5h-status` | `allowed` | `rejected` |

When both signals confirm a transient throttle → only apply a short `markTempUnavailable` cooldown, skip `markAccountRateLimited` entirely.

**Two code paths fixed:**
1. **SSE stream-end handler** — uses `sessionWindowStatus` already extracted from the 200 HTTP response headers by `get5hStatus()` just above the block
2. **Non-stream 429 handler** — extracts `5h-status` from the 429 response headers (safe: if Anthropic doesn't include it, the condition stays false and existing behavior is preserved)

Also backports the `_isAgentViewAuxiliaryRequest` guard (added in #1188) to the SSE stream-end handler, which was the only 429 code path it was missing from.

## Verification

After deployment, look for the new warn log instead of the old lock message:
```
⚡ [Stream] Transient 429 for account <id> (5h-status: allowed, no reset header) - skipping full rate limit marking, applying short cooldown only
```
Account should recover in ~300s instead of being locked for hours.