### PR TITLE
fix(logger): prevent binary TLS session data from bloating error logs

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -909,7 +909,15 @@ const handleResponses = async (req, res) => {
     req.on('close', cleanup)
     req.on('aborted', cleanup)
   } catch (error) {
-    logger.error('Proxy to ChatGPT codex/responses failed:', error)
+    logger.error(`Proxy to ChatGPT codex/responses failed: ${error.message}`, {
+      name: error.name,
+      code: error.code,
+      url: error.config?.url,
+      method: error.config?.method,
+      timeout: error.config?.timeout,
+      status: error.response?.status,
+      stack: error.stack,
+    })
     // 优先使用主动设置的 statusCode，然后是上游响应的状态码，最后默认 500
     const status = error.statusCode || error.response?.status || 500
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -38,15 +38,32 @@ const safeStringify = (obj, maxDepth = Infinity) => {
       }
       seen.add(value)
 
-      // 过滤掉常见的循环引用对象
+      // 过滤掉常见的循环引用对象及 HTTP/网络内部对象
       if (value.constructor) {
         const constructorName = value.constructor.name
         if (
-          ['Socket', 'TLSSocket', 'HTTPParser', 'IncomingMessage', 'ServerResponse'].includes(
-            constructorName
-          )
+          [
+            'Socket',
+            'TLSSocket',
+            'HTTPParser',
+            'IncomingMessage',
+            'ServerResponse',
+            'ClientRequest',
+            'RedirectableRequest',
+            'Agent',
+          ].includes(constructorName)
         ) {
           return `[${constructorName} Object]`
+        }
+      }
+
+      // 检测 Buffer/TLS session 以数字键存储的二进制对象（如 {0:48,1:130,...}）
+      // 这类对象来自 Axios config.httpsAgent._sessionCache，序列化后体积极大
+      const objKeys = Object.keys(value)
+      if (objKeys.length > 50 && objKeys.every(k => /^\d+$/.test(k))) {
+        const sample = objKeys.slice(0, 8).map(k => value[k])
+        if (sample.every(v => typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 255)) {
+          return `[Binary: ${objKeys.length} bytes]`
         }
       }
 


### PR DESCRIPTION
## Problem

Axios timeout errors on `/openai/responses` (codex endpoint) were generating **~2.7 MB log entries** each. Today alone this caused 198 such errors, generating hundreds of MB of raw log data.

**Root cause:** `AxiosError.request` is a `RedirectableRequest` (from `follow-redirects`), which holds a reference to the `https.Agent`. The agent's `_sessionCache` stores TLS sessions as plain objects with numeric keys (`{0:48, 1:130, ...}`). Neither the request object type nor the binary-encoded buffers were caught by `safeStringify`, so they were fully serialised into every error log entry.

## Fix

### 1. `src/utils/logger.js` — `safeStringify`

- Extend the constructor filter to also drop `ClientRequest`, `RedirectableRequest`, and `Agent` objects.
- Add a heuristic for Buffer-like objects encoded as plain objects (all-numeric keys, all byte values 0–255, length > 50) → replaced with `"[Binary: N bytes]"`.

### 2. `src/routes/openaiRoutes.js` — `handleResponses` catch block

Destructure only useful fields (`name`, `code`, `url`, `method`, `timeout`, `status`, `stack`) before passing to `logger.error`, keeping the raw `request`/`response` objects out of the log entry entirely.

## Impact

| Before | After |
|--------|-------|
| ~2.7 MB per timeout error log entry | < 1 KB per entry |
| TLS session bytes serialised as `"416215":116,...` | `[Binary: N bytes]` |
| `RedirectableRequest` fully expanded | `[RedirectableRequest Object]` |
