### PR TITLE
fix(openai): mark accounts unauthorized after invalid refresh token

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -242,11 +242,31 @@ async function getOpenAIAuthToken(apiKeyData, sessionId = null, requestedModel =
             logger.info(`✅ Token refreshed successfully in route handler`)
           } catch (refreshError) {
             logger.error(`Failed to refresh token for ${account.name}:`, refreshError)
+            if (openaiAccountService.isTokenRefreshUnauthorizedError(refreshError)) {
+              const reason = `OpenAI账号认证失败（Refresh Token 无效）：${refreshError.message}`
+              await unifiedOpenAIScheduler
+                .markAccountUnauthorized(result.accountId, 'openai', sessionHash, reason)
+                .catch((markError) => {
+                  logger.error(
+                    '❌ Failed to mark OpenAI account unauthorized after refresh failure:',
+                    markError
+                  )
+                })
+            }
             const error = new Error(`Token expired and refresh failed: ${refreshError.message}`)
             error.statusCode = 403 // Forbidden - 认证失败
             throw error
           }
         } else {
+          const reason = `OpenAI账号认证失败（Refresh Token 缺失）：Token expired and no refresh token available for account ${account.name}`
+          await unifiedOpenAIScheduler
+            .markAccountUnauthorized(result.accountId, 'openai', sessionHash, reason)
+            .catch((markError) => {
+              logger.error(
+                '❌ Failed to mark OpenAI account unauthorized after missing refresh token:',
+                markError
+              )
+            })
           const error = new Error(
             `Token expired and no refresh token available for account ${account.name}`
           )

--- a/src/services/account/openaiAccountService.js
+++ b/src/services/account/openaiAccountService.js
@@ -254,6 +254,34 @@ function isTokenExpired(account) {
   return new Date(account.expiresAt) <= new Date()
 }
 
+function isTokenRefreshUnauthorizedError(error) {
+  const status = error?.status || error?.response?.status
+  const errorCode = error?.details?.error?.code || error?.response?.data?.error?.code || error?.code
+  const errorType = error?.details?.error?.type || error?.response?.data?.error?.type
+  const message = [
+    error?.message,
+    error?.details?.error?.message,
+    error?.details?.error_description,
+    error?.response?.data?.error?.message,
+    error?.response?.data?.error_description,
+    error?.response?.data?.message
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  if (status === 401) {
+    return true
+  }
+
+  return (
+    /refresh_token_reused|invalid_grant|token_invalidated/i.test(String(errorCode || '')) ||
+    /invalid_request_error/i.test(String(errorType || '')) ||
+    /refresh token.*(invalid|expired|reused)|token.*invalidated|Refresh Token 无效|认证失败/.test(
+      message
+    )
+  )
+}
+
 /**
  * 检查账户订阅是否过期
  * @param {Object} account - 账户对象
@@ -1240,6 +1268,7 @@ module.exports = {
   selectAvailableAccount,
   refreshAccountToken,
   isTokenExpired,
+  isTokenRefreshUnauthorizedError,
   setAccountRateLimited,
   markAccountUnauthorized,
   resetAccountStatus,

--- a/src/services/scheduler/unifiedOpenAIScheduler.js
+++ b/src/services/scheduler/unifiedOpenAIScheduler.js
@@ -395,6 +395,17 @@ class UnifiedOpenAIScheduler {
             logger.warn(
               `⚠️ OpenAI account ${account.name} token expired and no refresh token available`
             )
+            await this.markAccountUnauthorized(
+              accountId,
+              'openai',
+              null,
+              `OpenAI账号认证失败（Refresh Token 缺失）：Token expired and no refresh token available for account ${account.name}`
+            ).catch((markError) => {
+              logger.error(
+                `❌ Failed to mark OpenAI account ${account.name} unauthorized after missing refresh token:`,
+                markError
+              )
+            })
             continue
           }
 
@@ -407,6 +418,19 @@ class UnifiedOpenAIScheduler {
             logger.info(`✅ Token refreshed successfully for ${account.name}`)
           } catch (refreshError) {
             logger.error(`❌ Failed to refresh token for ${account.name}:`, refreshError.message)
+            if (openaiAccountService.isTokenRefreshUnauthorizedError(refreshError)) {
+              await this.markAccountUnauthorized(
+                account.id,
+                'openai',
+                null,
+                `OpenAI账号认证失败（Refresh Token 无效）：${refreshError.message}`
+              ).catch((markError) => {
+                logger.error(
+                  `❌ Failed to mark OpenAI account ${account.name} unauthorized after refresh failure:`,
+                  markError
+                )
+              })
+            }
             continue // 刷新失败，跳过此账户
           }
         }


### PR DESCRIPTION
## 背景

线上排查 `/openai/responses` 间歇性返回 `403 Permission denied` 时，发现真实根因不是 API Key 权限不足，而是被调度到的 OpenAI/Codex OAuth 账号 access token 过期后刷新失败：上游返回 `refresh_token_reused`，服务内部记录为 `Refresh Token 无效`。

当前代码会把刷新失败包装成 `statusCode = 403` 返回给客户端，但没有把该账号标记为 `unauthorized` 或关闭 `schedulable`，因此坏账号仍留在共享池/服务状态中，后续请求会继续被调度到它，造成重复 403。

## 脱敏原始请求/日志

客户端请求（敏感 header 与长上下文已脱敏）：

```http
POST /openai/responses HTTP/2
Host: crs.uuid.im
User-Agent: codex-tui/0.133.0 (Mac OS 26.3.1; arm64) ghostty/1.3.1 (codex-tui; 0.133.0)
Authorization: Bearer cr_***
Content-Type: application/json
CF-Ray: a01a52762fd94cb5-NRT
X-Request-Id: gvonw33q2xg

{
  "model": "gpt-5.5",
  "stream": true,
  "instructions": "<redacted: Codex system/developer instructions>",
  "input": "<redacted: conversation/request payload>",
  "store": false
}
```

服务端错误链路（账号名与错误码保留，token/用户内容未包含）：

```text
Failed to refresh token for 6: 认证失败：Refresh Token 无效
status: 401
details.error.code: refresh_token_reused
details.error.message: Your refresh token has already been used to generate a new access token. Please try signing in again.

Failed to get OpenAI auth token: Token expired and refresh failed: 认证失败：Refresh Token 无效
statusCode: 403

Proxy to ChatGPT codex/responses failed: Token expired and refresh failed: 认证失败：Refresh Token 无效
statusCode: 403
```

## 根因

有两个路径只“跳过/返回错误”，没有持久化账号状态：

1. `openaiRoutes.getOpenAIAuthToken()` 的 fallback refresh 失败后，只抛出 403。
2. `unifiedOpenAIScheduler._getAllAvailableAccounts()` 扫描共享池时 refresh 失败后，只 `continue` 跳过本轮。

因为没有调用 `markAccountUnauthorized()`，Redis 中账号仍可能保持：

```json
{
  "status": "active",
  "schedulable": true
}
```

## 修复

- 新增 `openaiAccountService.isTokenRefreshUnauthorizedError()`，识别 refresh token 已永久失效的错误：
  - HTTP `401`
  - `refresh_token_reused`
  - `invalid_grant`
  - `token_invalidated`
  - `Refresh Token 无效` / `认证失败` 等消息
- 在路由 fallback refresh 失败时，如果判断为认证类 refresh 失败，调用：
  - `unifiedOpenAIScheduler.markAccountUnauthorized(accountId, 'openai', sessionHash, reason)`
- 在共享池调度器刷新过期 token 失败时，同样标记账号 `unauthorized`。
- 对“token 已过期但没有 refresh token”的账号，也标记为 `unauthorized`，避免继续留在可调度池里。

这样账号会被更新为：

```json
{
  "status": "unauthorized",
  "schedulable": "false",
  "errorMessage": "OpenAI账号认证失败（Refresh Token 无效）：..."
}
```

## 验证

- `npx eslint src/services/account/openaiAccountService.js src/routes/openaiRoutes.js src/services/scheduler/unifiedOpenAIScheduler.js`
- `npx prettier --check src/services/account/openaiAccountService.js src/routes/openaiRoutes.js src/services/scheduler/unifiedOpenAIScheduler.js`
- `npx jest tests/openaiResponsesPayloadToggles.test.js --runInBand`
