### PR TITLE
feat(openai): add Codex-compatible models endpoints

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -10,6 +10,7 @@ const openaiResponsesAccountService = require('../services/account/openaiRespons
 const openaiResponsesRelayService = require('../services/relay/openaiResponsesRelayService')
 const apiKeyService = require('../services/apiKeyService')
 const redis = require('../models/redis')
+const modelService = require('../services/modelService')
 const crypto = require('crypto')
 const ProxyHelper = require('../utils/proxyHelper')
 const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
@@ -137,6 +138,88 @@ function applyCodexCliAdaptation(body = {}) {
   })
 
   body.instructions = CODEX_CLI_INSTRUCTIONS
+}
+
+function toCodexModelInfo(model, priority = 99) {
+  return {
+    slug: model.id,
+    display_name: model.id,
+    description: null,
+    default_reasoning_level: 'medium',
+    supported_reasoning_levels: [
+      { effort: 'low', description: 'Fast responses with lighter reasoning' },
+      { effort: 'medium', description: 'Balances speed and reasoning depth for everyday tasks' },
+      { effort: 'high', description: 'Greater reasoning depth for complex problems' },
+      { effort: 'xhigh', description: 'Extra high reasoning depth for complex problems' }
+    ],
+    shell_type: 'shell_command',
+    visibility: 'list',
+    supported_in_api: true,
+    priority,
+    additional_speed_tiers: [],
+    availability_nux: null,
+    upgrade: null,
+    base_instructions: CODEX_CLI_INSTRUCTIONS,
+    supports_reasoning_summaries: false,
+    default_reasoning_summary: 'auto',
+    support_verbosity: true,
+    default_verbosity: 'medium',
+    apply_patch_tool_type: 'freeform',
+    web_search_tool_type: 'text',
+    truncation_policy: {
+      mode: 'tokens',
+      limit: 10000
+    },
+    supports_parallel_tool_calls: true,
+    supports_image_detail_original: false,
+    context_window: 272000,
+    max_context_window: 272000,
+    auto_compact_token_limit: null,
+    effective_context_window_percent: 95,
+    experimental_supported_tools: [],
+    input_modalities: ['text', 'image'],
+    supports_search_tool: false
+  }
+}
+
+function getModelListForApiKey(apiKeyData = {}) {
+  let models = modelService.getAllModels()
+
+  if (apiKeyData.enableModelRestriction && apiKeyData.restrictedModels?.length > 0) {
+    models = models.filter((model) => !apiKeyData.restrictedModels.includes(model.id))
+  }
+
+  return models
+}
+
+async function handleModels(req, res) {
+  try {
+    if (!checkOpenAIPermissions(req.apiKey || {})) {
+      return res.status(403).json({
+        error: {
+          message: 'This API key does not have permission to access OpenAI',
+          type: 'permission_denied',
+          code: 'permission_denied'
+        }
+      })
+    }
+
+    const data = getModelListForApiKey(req.apiKey || {})
+
+    return res.json({
+      object: 'list',
+      data,
+      models: data.map((model, index) => toCodexModelInfo(model, index))
+    })
+  } catch (error) {
+    logger.error('Failed to get OpenAI/Codex models:', error)
+    return res.status(500).json({
+      error: {
+        message: 'Failed to retrieve models',
+        type: 'api_error'
+      }
+    })
+  }
 }
 
 async function applyRateLimitTracking(
@@ -1341,6 +1424,8 @@ async function handleImages(req, res) {
 router.post('/images/generations', authenticateApiKey, handleImages)
 router.post('/v1/images/generations', authenticateApiKey, handleImages)
 
+router.get('/models', authenticateApiKey, handleModels)
+router.get('/v1/models', authenticateApiKey, handleModels)
 router.post('/responses', authenticateApiKey, handleResponses)
 router.post('/v1/responses', authenticateApiKey, handleResponses)
 router.post('/responses/compact', authenticateApiKey, handleResponses)
@@ -1412,4 +1497,5 @@ router.get('/key-info', authenticateApiKey, async (req, res) => {
 
 module.exports = router
 module.exports.handleResponses = handleResponses
+module.exports.handleModels = handleModels
 module.exports.CODEX_CLI_INSTRUCTIONS = CODEX_CLI_INSTRUCTIONS

--- a/tests/openaiResponsesPayloadToggles.test.js
+++ b/tests/openaiResponsesPayloadToggles.test.js
@@ -58,6 +58,23 @@ jest.mock('../src/services/apiKeyService', () => ({
   recordUsage: jest.fn()
 }))
 
+jest.mock('../src/services/modelService', () => ({
+  getAllModels: jest.fn(() => [
+    {
+      id: 'gpt-5.5',
+      object: 'model',
+      created: 1770000000,
+      owned_by: 'openai'
+    },
+    {
+      id: 'claude-sonnet-4-20250514',
+      object: 'model',
+      created: 1770000000,
+      owned_by: 'anthropic'
+    }
+  ])
+}))
+
 jest.mock('../src/models/redis', () => ({
   getUsageStats: jest.fn()
 }))
@@ -546,5 +563,45 @@ describe('openai responses payload toggles', () => {
     expect(req.body.model).toBe('o1-mini')
     expect(req.body.prompt_cache_key).toBe('compact-key')
     expect(req.body.instructions).toBe(openaiRoutes.CODEX_CLI_INSTRUCTIONS)
+  })
+})
+
+describe('openai models endpoint', () => {
+  test('returns OpenAI-compatible data and Codex-compatible models metadata', async () => {
+    const req = {
+      apiKey: {
+        id: 'key_1',
+        permissions: ['openai']
+      }
+    }
+    const res = createRes()
+
+    await openaiRoutes.handleModels(req, res)
+
+    expect(res.payload.object).toBe('list')
+    expect(res.payload.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'gpt-5.5',
+          object: 'model',
+          owned_by: 'openai'
+        })
+      ])
+    )
+    expect(res.payload.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slug: 'gpt-5.5',
+          display_name: 'gpt-5.5',
+          shell_type: 'shell_command',
+          visibility: 'list',
+          supported_in_api: true,
+          truncation_policy: {
+            mode: 'tokens',
+            limit: 10000
+          }
+        })
+      ])
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Add `GET /openai/models` and `GET /openai/v1/models` for Codex clients whose base URL is configured as `/openai` or `/openai/v1`.
- Reuse the existing `modelService.getAllModels()` catalog and existing API key model restriction behavior instead of introducing a separate static model list.
- Return both OpenAI-compatible `object/data` and Codex-compatible top-level `models` metadata so existing OpenAI-compatible clients keep working and Codex can deserialize the response.

## Why

Codex currently calls the provider-owned models endpoint as `GET {base_url}/models?client_version=...`. In the open-source Codex code:

- `codex-rs/codex-api/src/endpoint/models.rs` builds the path as `models` and appends `client_version`.
- The response is deserialized as `ModelsResponse { models: Vec<ModelInfo> }`.
- `codex-rs/protocol/src/openai_models.rs` defines `ModelsResponse` with a top-level `models` field.

CRS already has `/api/v1/models`, but that returns only the OpenAI-compatible shape:

```json
{ "object": "list", "data": [...] }
```

That shape is not enough for Codex's current `ModelsResponse` parser, and `/openai/models` was missing entirely, causing 404s before any response parsing could happen.

## Sanitized original requests observed

```http
GET /openai/models?client_version=0.133.0 HTTP/1.1
Host: <relay-host>
User-Agent: codex-tui/0.133.0
Authorization: Bearer <redacted>

HTTP/1.1 404 Not Found
```

```http
GET /openai/models?client_version=0.130.0 HTTP/1.1
Host: <relay-host>
User-Agent: Codex Desktop/0.130.0
Authorization: Bearer <redacted>

HTTP/1.1 404 Not Found
```

## Testing

- `npx jest tests/openaiResponsesPayloadToggles.test.js --runInBand`
- `npx eslint src/routes/openaiRoutes.js tests/openaiResponsesPayloadToggles.test.js`
- `git diff --check`
