### PR TITLE
feat(models): update Claude model list to latest 4.6+ series

### DIFF
--- a/src/services/modelService.js
+++ b/src/services/modelService.js
@@ -30,17 +30,11 @@ class ModelService {
         provider: 'anthropic',
         description: 'Claude models from Anthropic',
         models: [
-          'claude-opus-4-5-20251101',
-          'claude-haiku-4-5-20251001',
-          'claude-sonnet-4-5-20250929',
-          'claude-opus-4-1-20250805',
-          'claude-sonnet-4-20250514',
-          'claude-opus-4-20250514',
-          'claude-3-7-sonnet-20250219',
-          'claude-3-5-sonnet-20241022',
-          'claude-3-5-haiku-20241022',
-          'claude-3-opus-20240229',
-          'claude-3-haiku-20240307'
+          'claude-opus-4-8',
+          'claude-opus-4-7',
+          'claude-opus-4-6',
+          'claude-sonnet-4-6',
+          'claude-haiku-4-5'
         ]
       },
       openai: {


### PR DESCRIPTION
## Summary
- Replace legacy Claude model entries (3.x, 4.0, 4.1, 4.5 dated variants) with the current model lineup
- New list: `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`
- Use alias IDs without date suffixes for cleaner dropdown UX

## Motivation
The current default model list in `modelService.js` contains many deprecated/old models (claude-3-haiku, claude-3-opus, claude-3-5-*, claude-4-0, claude-4-1) that are no longer the recommended choices. This PR updates the list to reflect the latest Anthropic model lineup as of June 2025.

## Changes
- `src/services/modelService.js`: Updated the `claude.models` array in `getDefaultModels()`