### PR TITLE
fix: 429 限流处理修复——无 reset 头改短冷却 + 流式补齐 Agent View 守卫（#1199 #1195 #1183 #1203，覆盖 #1189）

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -53,7 +53,12 @@ const config = {
         // 验证配置值：限制在0-1440分钟(24小时)内
         return Math.max(0, Math.min(minutes, 1440))
       })()
-    }
+    },
+    // 🚦 无权威 reset 头的 429 限流冷却秒数（默认 60 秒）
+    // 上游 429 缺少 anthropic-ratelimit-unified-reset 头时，不再按整个 5 小时会话窗口封号，
+    // 仅做有上限的短冷却，避免单账号池被一次瞬时 / overage 429 打穿数小时
+    rateLimitNoResetCooldownSeconds:
+      parseInt(process.env.CLAUDE_RATE_LIMIT_NO_RESET_COOLDOWN_SECONDS) || 60
   },
 
   // ☁️ Bedrock API配置

--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -1450,23 +1450,18 @@ class ClaudeAccountService {
         const windowData = await this.updateSessionWindow(accountId, updatedAccountData)
         Object.assign(updatedAccountData, windowData)
 
-        // 限流结束时间 = 会话窗口结束时间
-        if (updatedAccountData.sessionWindowEnd) {
-          updatedAccountData.rateLimitEndAt = updatedAccountData.sessionWindowEnd
-          const windowEnd = new Date(updatedAccountData.sessionWindowEnd)
-          const now = new Date()
-          const minutesUntilEnd = Math.ceil((windowEnd - now) / (1000 * 60))
-          logger.warn(
-            `🚫 Account marked as rate limited until estimated session window ends: ${accountData.name} (${accountId}) - ${minutesUntilEnd} minutes remaining`
-          )
-        } else {
-          // 如果没有会话窗口，使用默认1小时（兼容旧逻辑）
-          const oneHourLater = new Date(Date.now() + 60 * 60 * 1000)
-          updatedAccountData.rateLimitEndAt = oneHourLater.toISOString()
-          logger.warn(
-            `🚫 Account marked as rate limited (1 hour default): ${accountData.name} (${accountId})`
-          )
-        }
+        // ⚠️ 没有上游权威 reset 头（anthropic-ratelimit-unified-reset）时，
+        // 不再按"整个 5 小时会话窗口"封号；无 reset 头的 429（overage /
+        // org_level_disabled / RPM / 瞬时抖动）多数不是真正的窗口耗尽，旧逻辑
+        // 直接封到窗口末（最长 ~5h）会让单账号池被一次抖动打穿数小时
+        // （见 #1183 / #1195 / #1199 / #1203）。改为有上限的短冷却，快速自愈。
+        // 会话窗口仍照常维护（用于使用量追踪与 5h 自动恢复），仅不再用作限流时长。
+        const cooldownSeconds = config.claude.rateLimitNoResetCooldownSeconds || 60
+        const cooldownEnd = new Date(Date.now() + cooldownSeconds * 1000)
+        updatedAccountData.rateLimitEndAt = cooldownEnd.toISOString()
+        logger.warn(
+          `🚫 Account marked as rate limited without reset header, applying ${cooldownSeconds}s cooldown: ${accountData.name} (${accountId})`
+        )
       }
 
       await redis.setClaudeAccount(accountId, updatedAccountData)

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -2907,20 +2907,33 @@ class ClaudeRelayService {
                 )
               }
 
-              await unifiedClaudeScheduler.markAccountRateLimited(
-                accountId,
-                accountType,
-                sessionHash,
-                rateLimitResetTimestamp
+              // 🛡️ Agent View 辅助请求（x-app: cli-bg 的后台标题/标签生成请求）命中 429 时，
+              // 不应把账号标记为限流：它们非用户主动请求，误摘账号会放大限流影响、打空账号池。
+              // 与 relayRequest 非流式分支及本函数 early-error 分支保持一致（见 #1188 / da3470df）。
+              const isAgentViewAuxiliaryRequest = this._isAgentViewAuxiliaryRequest(
+                body,
+                clientHeaders
               )
-              await upstreamErrorHelper
-                .markTempUnavailable(
+              if (isAgentViewAuxiliaryRequest) {
+                logger.warn(
+                  `🚫 [Stream] Agent View auxiliary request hit 429 for account ${accountId}; skipping account-level rate-limit marking`
+                )
+              } else {
+                await unifiedClaudeScheduler.markAccountRateLimited(
                   accountId,
                   accountType,
-                  429,
-                  upstreamErrorHelper.parseRetryAfter(res.headers)
+                  sessionHash,
+                  rateLimitResetTimestamp
                 )
-                .catch(() => {})
+                await upstreamErrorHelper
+                  .markTempUnavailable(
+                    accountId,
+                    accountType,
+                    429,
+                    upstreamErrorHelper.parseRetryAfter(res.headers)
+                  )
+                  .catch(() => {})
+              }
             }
           } else if (res.statusCode === 200) {
             // 请求成功，清除401和500错误计数


### PR DESCRIPTION
> Draft：聚焦「429 被误判为 5h 会话窗口耗尽 → 整号长时间摘除 → 单账号池打穿」这条主链。更深的结构性改造（429 请求内换号、模型级限流）见末尾「后续」。

本 PR 修复一个会让 CRS 被**一次 429 打成数小时不可用**的限流处理缺陷，关联 #1199 / #1195 / #1183 / #1203，并在行为上**覆盖 #1189**。

## 背景：四个看似无关的 issue 其实同一根因

- **#1199** 请求被判定为外部工具调用、频繁 429
- **#1195** 单 user 也频繁 429（评论确认「测试下来不是 1M 上下文的影响」）
- **#1183** 限流状态与实际不一致、重置无效
- **#1203** 偶发 502（重试即恢复）

同一条因果链：**一次上游 429 → 账号被按 5 小时会话窗口整号封禁 → 单账号池被打空 → 后续请求全部 500/502**。

## 根因（真实日志端到端复现）

`markAccountRateLimited`（`claudeAccountService.js`）在 429 且**无**上游权威 reset 头 `anthropic-ratelimit-unified-reset` 时，落进「预估」分支：把限流结束时间设为**当前 5 小时会话窗口末尾**（最长 ~5h）并 `schedulable=false` 停掉**整个账号**。

某单账号实例事故时间线：

```
14:25:10  上游 429 | Account: lovinrain.jw2
14:25:10  Account marked as rate limited until estimated session window ends — 215 minutes remaining
14:25:12+ No available Claude accounts support the requested model → 500（×138，横跨 ~2.5h）
```

即 **1 次 429 → 唯一账号被封 215 分钟 → 池空 → 后续 ~2.5h 全部失败**（反代层即表现为 #1203 的 502 no-body）。

三个叠加放大器：
1. **无 reset 头按 5h 窗口封号**（而非短冷却）
2. **账号级而非模型级**（sonnet 的一次 429 连带 opus / fable 一起挂）
3. **429 无请求内换号**（relay 仅对 403 做同号重试）

> **时间线澄清**：该「5h 预估封号」逻辑自 2025-07-31（`7ebcdbe7`）即存在，并非近期回归；真正变化的是上游 429 触发频率上升，把旧放大器频繁点着。`_isExtraUsageRequired429`（2026-03 加入）仅在 body 含 `extra usage` 字样时跳过，而 overage / `org_level_disabled` 信号只在响应头、且常不带 reset 头，会漏判而落入 5h 封号分支。

## 本 PR 改动（两个 commit，最小且对症）

**commit 1 — 无权威 reset 头的 429 改为有上限短冷却**（`claudeAccountService.js` + `config/config.example.js`）
- `markAccountRateLimited` 在**无 reset 头**时不再按 5h 会话窗口封号，改为**短冷却**（默认 60s，可配 `CLAUDE_RATE_LIMIT_NO_RESET_COOLDOWN_SECONDS`）。
- 改在**流式 / 非流式共用的同一函数**，一处覆盖两条路径。
- 会话窗口仍照常维护（用量统计 + 5h 自动恢复），仅不再用作限流时长。
- **带准确 reset 头的 429 行为完全不变**（仍按上游真实重置时间封禁）。

**commit 2 — 流式 stream-end 429 分支补齐 Agent View 守卫**（`claudeRelayService.js`）
- `_makeClaudeStreamRequestWithUsageCapture` 的 stream-end 限流分支（`if (rateLimitDetected || res.statusCode === 429)`）此前缺少 `_isAgentViewAuxiliaryRequest` 守卫：后台辅助请求（`x-app: cli-bg` 的标题/标签生成）命中 429 会误把整个账号标记为限流。
- 非流式 `relayRequest` 与本函数的 early-error 分支已有该守卫（#1188 / `da3470df`），本次补齐**第三处缺口**，使流式两条 429 路径行为一致。

## 与 #1189 的关系：本 PR 现已覆盖

#1189（同一 bug 的另一修复，已开 ~2 周未评审）同样修「无 reset 头 429 被当成 5h 耗尽」。逐项对照：

| 维度 | #1189（relay 层，两处各改一遍） | 本 PR #1204 |
|---|---|---|
| 触发「跳过 5h 封」的条件 | 无 reset 头 **且** `5h-status: allowed`（双信号） | **仅需无 reset 头**（单信号） |
| headerless overage / `org_level_disabled` 429 | `5h-status` 缺失 → 条件不成立 → **仍 5h 封** | 命中短冷却（**能兜住**） |
| 覆盖 stream + 非 stream | 手动改两处，有改漏/逻辑漂移风险 | 改公共函数，**一处全覆盖** |
| Agent View 流式守卫 | 有 | 有（commit 2 补齐） |
| 可配置冷却时长 | 无 | 有 |

**关键**：实测把账号池打穿的那次 429 **无任何限流头**（日志里 `overage` / `org_level_disabled` / `extra usage` 均为 0），不满足 #1189 的 `5h-status: allowed` 正向信号，**#1189 单独上线兜不住**；本 PR 只看「无 reset 头」即可覆盖。补齐 commit 2 后，本 PR 在行为上已是 #1189 的**超集**——若二选一，可直接关闭 #1189。

## 与 sub2api（作者的下一代重写）对照

| 维度 | CRS 现状 | sub2api |
|---|---|---|
| 无 reset 头冷却 | 预估到 5h 窗口末 | 短冷却 / 精确 resetAt |
| 限流粒度 | 整号 | 模型级 |
| 请求内换号 | 仅 403 | 429 等可配置状态码换号重试 |
| 单账号组 | 无特判 | 专门特判，避免级联 |

本 PR 先解决最致命的「无 reset 头 5h 封号 + 流式守卫缺口」。

## 后续（非本 PR）

- 429 支持请求内换号（复用现有 403 failover 脚手架）
- 账号级 → 模型级限流
- 池空时返回带 body 的 503，而非让连接掉成 502

## 测试计划

- [ ] 无 reset 头的 429：账号冷却 ~60s 后自动恢复调度（而非 ~5h）
- [ ] 带 reset 头的 429：行为不变，按上游真实重置时间封禁
- [ ] 流式 Agent View 辅助请求（`x-app: cli-bg`）命中 429：跳过账号级限流标记
- [ ] `npm run lint` / `npm test`
