### PR TITLE
fix: migrate OAuth token endpoint to platform.claude.com (refresh_token grant 404 on old domain)

### DIFF
--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -41,7 +41,8 @@ function isProAccount(info) {
 
 class ClaudeAccountService {
   constructor() {
-    this.claudeApiUrl = 'https://console.anthropic.com/v1/oauth/token'
+    // console.anthropic.com 已迁移至 platform.claude.com，旧域名对 refresh_token grant 返回 404
+    this.claudeApiUrl = 'https://platform.claude.com/v1/oauth/token'
     this.claudeOauthClientId = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
     let maxWarnings = parseInt(process.env.CLAUDE_5H_WARNING_MAX_NOTIFICATIONS || '', 10)
 

--- a/src/utils/oauthHelper.js
+++ b/src/utils/oauthHelper.js
@@ -11,7 +11,8 @@ const logger = require('./logger')
 // OAuth 配置常量 - 从claude-code-login.js提取
 const OAUTH_CONFIG = {
   AUTHORIZE_URL: 'https://claude.ai/oauth/authorize',
-  TOKEN_URL: 'https://console.anthropic.com/v1/oauth/token',
+  // console.anthropic.com 已迁移至 platform.claude.com，旧域名对 refresh_token grant 返回 404
+  TOKEN_URL: 'https://platform.claude.com/v1/oauth/token',
   CLIENT_ID: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   REDIRECT_URI: 'https://platform.claude.com/oauth/code/callback',
   SCOPES: 'org:create_api_key user:profile user:inference user:sessions:claude_code',


### PR DESCRIPTION
## 问题描述

约 2026-06-12 19:00 (UTC) 起，Anthropic 旧域名 `console.anthropic.com` 的 OAuth token 端点对 `refresh_token` grant 开始返回 **404 not_found_error**：

```json
{"type":"error","error":{"type":"not_found_error","message":"Not found"}}
```

导致所有 Claude OAuth 账户的 token 自动刷新失败（`logs/token-refresh-error.log` 中大量 `Request failed with status code 404`），账户进入 `status=error` 被调度器排除，整个账户池不可用，且 24 小时内不会自动恢复。

## 根因验证

用同一请求体（`grant_type: refresh_token`）分别请求新旧两个域名：

| 端点 | 结果 |
|---|---|
| `https://console.anthropic.com/v1/oauth/token` | **404 not_found_error**（无论 User-Agent） |
| `https://platform.claude.com/v1/oauth/token` | **400 invalid_grant "Refresh token not found or invalid"**（端点正常，正确拒绝了测试用的假 token） |

说明 Anthropic 已将 OAuth 端点迁移至 `platform.claude.com`，旧域名对 refresh_token grant 已下线。项目中 `REDIRECT_URI` 已经是 `platform.claude.com`，但 `TOKEN_URL` / `claudeApiUrl` 仍指向旧域名。

## 修复内容

将 token 端点统一迁移到 `https://platform.claude.com/v1/oauth/token`（共 2 处）：

- `src/utils/oauthHelper.js` — `OAUTH_CONFIG.TOKEN_URL`（OAuth 授权码交换 + 刷新）
- `src/services/account/claudeAccountService.js` — `this.claudeApiUrl`（账户 token 刷新）

## 验证

部署后对 3 个处于 `status=error` 的账户调用 `POST /admin/claude-accounts/:id/refresh`，全部成功取得新 access token 并恢复 `status=active`，中转请求恢复正常。

---

**English summary:** Anthropic's legacy OAuth token endpoint on `console.anthropic.com` started returning 404 for `refresh_token` grants (~2026-06-12 19:00 UTC), breaking automatic token refresh and locking all Claude OAuth accounts into error status. The same request succeeds on `platform.claude.com/v1/oauth/token` (returns a proper `invalid_grant` for an invalid test token). This PR updates the two hardcoded endpoint URLs accordingly; `REDIRECT_URI` had already been migrated. Verified by force-refreshing three errored accounts — all recovered.
