### PR TITLE
fix: OAuth 令牌交换失败 — TOKEN_URL 过时、scope 缺失、前端无错误处理

### DIFF
--- a/src/models/redis.js
+++ b/src/models/redis.js
@@ -2571,6 +2571,10 @@ class RedisClient {
     const key = `oauth:${sessionId}`
     const data = await this.client.hgetall(key)
 
+    if (!data || Object.keys(data).length === 0) {
+      return null
+    }
+
     // 反序列化 proxy 字段
     if (data.proxy) {
       try {

--- a/src/utils/oauthHelper.js
+++ b/src/utils/oauthHelper.js
@@ -11,10 +11,13 @@ const logger = require('./logger')
 // OAuth 配置常量 - 从claude-code-login.js提取
 const OAUTH_CONFIG = {
   AUTHORIZE_URL: 'https://claude.ai/oauth/authorize',
-  TOKEN_URL: 'https://console.anthropic.com/v1/oauth/token',
+  TOKEN_URL: 'https://platform.claude.com/v1/oauth/token',
   CLIENT_ID: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   REDIRECT_URI: 'https://platform.claude.com/oauth/code/callback',
-  SCOPES: 'org:create_api_key user:profile user:inference user:sessions:claude_code',
+  SCOPES:
+    'org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload',
+  SCOPES_API:
+    'user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload',
   SCOPES_SETUP: 'user:inference' // Setup Token 只需要推理权限
 }
 
@@ -838,7 +841,7 @@ async function oauthWithCookie(sessionKey, proxyConfig = null, isSetupToken = fa
   const { organizationUuid, capabilities } = await getOrganizationInfo(sessionKey, proxyConfig)
 
   // 步骤2：确定scope并获取授权code
-  const scope = isSetupToken ? OAUTH_CONFIG.SCOPES_SETUP : 'user:profile user:inference'
+  const scope = isSetupToken ? OAUTH_CONFIG.SCOPES_SETUP : OAUTH_CONFIG.SCOPES_API
 
   logger.debug('Step 2/3: Getting authorization code...', { scope })
   const { authorizationCode, codeVerifier, state } = await authorizeWithCookie(

--- a/web/admin-spa/src/components/accounts/OAuthFlow.vue
+++ b/web/admin-spa/src/components/accounts/OAuthFlow.vue
@@ -1163,6 +1163,11 @@ const exchangeCode = async () => {
       stopCountdown()
     }
 
+    if (!tokenInfo) {
+      showToast('授权码交换失败，请重新生成授权链接并重试', 'error')
+      return
+    }
+
     emit('success', tokenInfo)
   } catch (error) {
     showToast(error.message || '授权失败，请检查授权码是否正确', 'error')


### PR DESCRIPTION
## 问题

通过手动 OAuth 添加 Claude 账户时始终报错：
```
Cannot read properties of null (reading 'claudeAiOauth')
```

**同一 IP、同一账户的授权码在 sub2api 中可以正常工作，但在 CRS 中失败。**

## 根因分析（CRS vs sub2api 对比）

通过逐行对比 CRS 的 `oauthHelper.js` 和 sub2api 的 `oauth.go` / `oauth_service.go`，发现三处配置不匹配：

### 1. TOKEN_URL（主要原因）

| | CRS（修改前） | sub2api |
|---|---|---|
| Token 端点 | `console.anthropic.com/v1/oauth/token` | `platform.claude.com/v1/oauth/token` |

授权码来源相同（`claude.ai/oauth/authorize`），但 CRS 将其发送到旧的 `console.anthropic.com` 端点交换。Anthropic 现在只接受 `platform.claude.com` 的令牌交换请求，因此 CRS 的交换请求被拒绝。

### 2. Scopes（能力缺失）

| | CRS（修改前） | sub2api |
|---|---|---|
| 浏览器授权流程 | `org:create_api_key user:profile user:inference user:sessions:claude_code` | 额外包含 `user:mcp_servers user:file_upload` |
| Cookie/API 流程 | 硬编码 `'user:profile user:inference'` | `SCOPES_API` = 完整 scope 去掉 `org:create_api_key` |

sub2api 区分了 `ScopeOAuth`（浏览器授权URL用，包含 `org:create_api_key`）和 `ScopeAPI`（内部 API 调用用，不含 `org:create_api_key`，因为"API 不支持该 scope"）。CRS 之前没有这个区分——Cookie 授权使用了硬编码的窄 scope。

### 3. 前端交换失败时崩溃

当令牌交换失败时，`exchangeClaudeCode()` 返回 `null`。sub2api 的前端：
- `useAccountOAuth.ts` 捕获错误，通过 `appStore.showError()` 显示 toast，返回 `null`
- `CreateAccountModal.vue` 检查 `if (!tokenInfo) return` —— 优雅停止

CRS 的前端：
- `OAuthFlow.vue` 直接执行 `emit('success', tokenInfo)` 而不检查 `null`
- `AccountForm.vue` 对 `null` 访问 `tokenInfo.claudeAiOauth` → 崩溃

### 4. Redis 会话查找（防御性修复）

`getOAuthSession()` 使用 Redis `hgetall`，当 key 不存在或已过期时返回 `{}`（空对象）。路由中的检查 `if (!oauthSession)` 是错误的，因为 JavaScript 中 `!{}` 为 `false`。过期会话会通过验证。

## 修改内容

- **`src/utils/oauthHelper.js`**
  - `TOKEN_URL`：`console.anthropic.com` → `platform.claude.com`
  - `SCOPES`：新增 `user:mcp_servers user:file_upload`
  - 新增 `SCOPES_API` 常量（完整 scope 去掉 `org:create_api_key`，用于 Cookie/API 流程）
  - Cookie 授权：使用 `SCOPES_API` 替代硬编码的 `'user:profile user:inference'`

- **`src/models/redis.js`**
  - `getOAuthSession()`：当 `hgetall` 返回空对象时返回 `null`

- **`web/admin-spa/src/components/accounts/OAuthFlow.vue`**
  - 在 `emit('success', tokenInfo)` 前添加 null 检查 —— 显示错误 toast 而非崩溃

## 测试计划

- [ ] 手动 OAuth 流程：生成授权链接 → 浏览器授权 → 粘贴授权码 → 验证账户创建成功
- [ ] Cookie 授权：验证 sessionKey 授权以完整 scope 完成
- [ ] Setup Token 流程：验证仍然正常（使用 `SCOPES_SETUP`，未修改）
- [ ] 过期会话：验证显示"Invalid or expired OAuth session"而非崩溃
- [ ] 无效授权码：验证显示错误 toast 而非崩溃 UI