### PR TITLE
fix: update OAuth token endpoint to platform.claude.com (console endpoint now 404s)

### DIFF
--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -41,7 +41,7 @@ function isProAccount(info) {
 
 class ClaudeAccountService {
   constructor() {
-    this.claudeApiUrl = 'https://console.anthropic.com/v1/oauth/token'
+    this.claudeApiUrl = 'https://platform.claude.com/v1/oauth/token'
     this.claudeOauthClientId = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
     let maxWarnings = parseInt(process.env.CLAUDE_5H_WARNING_MAX_NOTIFICATIONS || '', 10)
 

--- a/src/utils/oauthHelper.js
+++ b/src/utils/oauthHelper.js
@@ -11,7 +11,7 @@ const logger = require('./logger')
 // OAuth 配置常量 - 从claude-code-login.js提取
 const OAUTH_CONFIG = {
   AUTHORIZE_URL: 'https://claude.ai/oauth/authorize',
-  TOKEN_URL: 'https://console.anthropic.com/v1/oauth/token',
+  TOKEN_URL: 'https://platform.claude.com/v1/oauth/token',
   CLIENT_ID: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   REDIRECT_URI: 'https://platform.claude.com/oauth/code/callback',
   SCOPES: 'org:create_api_key user:profile user:inference user:sessions:claude_code',


### PR DESCRIPTION
## Problem

Anthropic has decommissioned the `https://console.anthropic.com/v1/oauth/token` endpoint. Well-formed token requests to it now return **`404 not_found_error`**.

This breaks **both** OAuth code paths in CRS:
- **Authorization** (manual + Setup Token) — `exchangeCodeForTokens` / `exchangeSetupTokenCode` in `oauthHelper.js`
- **Token refresh** — `refreshAccountToken` in `claudeAccountService.js`

The failure is gradual and easy to misdiagnose: existing access tokens keep working until they expire, then refresh fails with `404`, and the account silently flips to `status: error` ("Request failed with status code 404") and stops being schedulable. Over a few hours/days an entire account pool can drain to all-errored. Re-authorizing also fails with the same 404 (surfaced in the web UI as the confusing `Cannot read properties of null (reading 'claudeAiOauth')` because the frontend reads `data.claudeAiOauth` on the error response).

## Root cause

Two hardcoded references to the retired endpoint:

| File | Symbol | Used by |
|------|--------|---------|
| `src/utils/oauthHelper.js` | `OAUTH_CONFIG.TOKEN_URL` | authorize + setup-token code exchange |
| `src/services/account/claudeAccountService.js` | `this.claudeApiUrl` | access-token refresh |

## Verification

Live probe of the same well-formed POST from a server (real `client_id` + `redirect_uri`, dummy `code`):

```
POST https://console.anthropic.com/v1/oauth/token -> HTTP 404  {"type":"error","error":{"type":"not_found_error","message":"Not found"}}
POST https://platform.claude.com/v1/oauth/token   -> HTTP 400  {"error":"invalid_grant","error_description":"Invalid 'code' in request."}
```

`platform.claude.com` is the same host already used for `REDIRECT_URI` in `oauthHelper.js`, so it's the natural replacement. After switching:
- new-account authorization succeeds again, and
- `refresh_token` grants succeed — several previously-errored accounts recovered via a plain token refresh (no manual re-auth required).

## Change

Both occurrences updated `console.anthropic.com` → `platform.claude.com` (2 lines, no behavioral change beyond the host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)