### PR TITLE
fix: 专属账号的无 reset 头 429 不再被改写为 403「限流控制」，透传上游原始错误

### DIFF
--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -897,21 +897,20 @@ class ClaudeRelayService {
               `🚫 Agent View auxiliary request hit 429 for account ${accountId}; skipping account-level rate-limit marking`
             )
           } else {
-            if (isDedicatedOfficialAccount && !dedicatedRateLimitMessage) {
-              dedicatedRateLimitMessage = this._buildStandardRateLimitMessage(
-                rateLimitResetTimestamp || account?.rateLimitEndAt
-              )
-            }
             if (!rateLimitResetTimestamp) {
               // 无权威 reset 头的 429 大概率不是真实限流，不标记账号、不进入冷却，直接透传错误
               logger.warn(
                 `⚠️ Rate limit without reset header for account ${accountId}, status: ${response.statusCode}, skipping rate limit marking`
               )
             } else {
+              if (isDedicatedOfficialAccount && !dedicatedRateLimitMessage) {
+                dedicatedRateLimitMessage = this._buildStandardRateLimitMessage(
+                  rateLimitResetTimestamp || account?.rateLimitEndAt
+                )
+              }
               logger.warn(
                 `🚫 Rate limit detected for account ${accountId}, status: ${response.statusCode}`
               )
-              // 标记账号为限流状态并删除粘性会话映射，传递准确的重置时间戳
               await unifiedClaudeScheduler.markAccountRateLimited(
                 accountId,
                 accountType,
@@ -2271,7 +2270,7 @@ class ClaudeRelayService {
                 logger.warn(`🚫 [Stream] Rate limit detected for account ${accountId}, status 429`)
               }
 
-              if (isDedicatedOfficialAccount && !isAgentViewAuxiliaryRequest) {
+              if (isDedicatedOfficialAccount && !isAgentViewAuxiliaryRequest && rateLimitResetTimestamp) {
                 const limitMessage = this._buildStandardRateLimitMessage(
                   rateLimitResetTimestamp || account?.rateLimitEndAt
                 )


### PR DESCRIPTION
## 问题

v1.1.307/308 修复了「无 reset 头的 429 按 5 小时会话窗口封号」的核心问题（`58d4210d`），但遗漏了一处：对于**专属（dedicated）绑定的 Claude OAuth 账号**，即使进入了"跳过账号标记"分支，仍然会将上游的 429 **改写**为 CRS 自身的 403 `upstream_rate_limited` + "此专属账号已触发 Anthropic 限流控制。"。

### 现象

客户端（如 Claude Code）频繁收到：
```
Please run /login · API Error: 403 此专属账号已触发 Anthropic 限流控制。
```

但实际上：
- 账号并未被标记为限流（Redis 中 `rateLimitStatus` 为空、`schedulable=true`）
- 下一次请求往往立刻成功
- 同一场景下 sub2api **没有此问题**

### 根因（日志实锤，本地 CRS 服务器 今日 61 次）

从 `service.log` 可以清晰看到交替模式：

```
18:09:31 ✅ Request completed in 888ms for key: me_cc
18:09:31 ⚠️ Rate limit without reset header for account 8a65c671, status: 429, skipping rate limit marking
18:09:32 ⚠️ 403 POST /api/v1/messages  962ms
         ├─ res: {"error":"upstream_rate_limited","message":"此专属账号已触发 Anthropic 限流控制。"}
```

**一个请求成功 → 紧接着一个 429（无 reset 头）→ CRS 正确跳过了账号标记 → 但仍然把 429 改写成 403 返回给客户端。**

代码路径分析：

**非流式（`relayRequest`）：**
```javascript
// 行 900：在 "有没有 reset 头" 判断之前就构建了限流消息
if (isDedicatedOfficialAccount && !dedicatedRateLimitMessage) {
  dedicatedRateLimitMessage = this._buildStandardRateLimitMessage(...)  // ← 无条件构建
}
if (!rateLimitResetTimestamp) {
  // 跳过标记（正确）
} else {
  // 标记账号（正确）
}

// 行 932：无论上面走了哪个分支，dedicatedRateLimitMessage 都已被设置
if (dedicatedRateLimitMessage) {
  return { statusCode: 403, ... }  // ← 把 429 改写成 403（bug）
}
```

**流式 stream-end 路径：**
```javascript
// 行 2275：即使无 reset 头（已跳过标记），仍对专属账号返回 403
if (isDedicatedOfficialAccount && !isAgentViewAuxiliaryRequest) {  // ← 缺少 rateLimitResetTimestamp 条件
  responseStream.status(403)
}
```

### 为什么 sub2api 没有这个问题

sub2api **不改写** 上游 429 的状态码。429 作为 429 原样返回给客户端 → Claude Code 的 SDK 识别到 429 后自动退避重试 → 用户体验为"稍等几秒就恢复"。

CRS 将 429 改写为 403 后，Claude Code 不知道这是临时的限流（它认为 403 = 权限/认证问题），所以提示 "Please run /login" 而非自动重试。

## 修复

**将 `dedicatedRateLimitMessage` 的构建从"通用 429 分支"移入"有 reset 头"子分支：**

- **非流式**：只在 `rateLimitResetTimestamp` 非空时才构建 `dedicatedRateLimitMessage`，确保无 reset 头的 429 不触发 403 改写
- **流式 stream-end**：给专属账号 403 改写加上 `rateLimitResetTimestamp` 前置条件

### 行为变化

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 专属账号 + 无 reset 头的 429 | 改写为 403"限流控制"（客户端提示 /login） | **透传上游 429**（客户端自动重试） |
| 专属账号 + 有 reset 头的 429 | 403"限流控制"+ 标记账号 | **不变** |
| 非专属账号 | 不受影响 | **不变** |

## 测试计划

- [ ] 专属账号 + 无 reset 头 429：客户端收到 429（非 403），不再提示 /login
- [ ] 专属账号 + 有 reset 头 429：仍收到 403 + 重置时间（行为不变）
- [ ] 非专属账号：无影响
- [ ] 流式 + 非流式两条路径均验证

