### PR TITLE
fix(claude): detect Team plans and preserve anthropic-beta header

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ yarn-error.log*
 # Logs
 logs/
 *.log
+*.har
 
 # Data files
 data/

--- a/docs/claude-long-context-alias.md
+++ b/docs/claude-long-context-alias.md
@@ -1,0 +1,118 @@
+# Claude 1M Context Alias Normalization
+
+## Background
+
+Claude Code enables 1M context by sending the normal upstream model name together with the Anthropic beta header:
+
+```text
+model: claude-opus-4-8
+anthropic-beta: ...,context-1m-2025-08-07,...
+```
+
+CRS may expose `[1m]` suffixed model names such as `claude-opus-4-8[1m]` to users and tooling as an internal convenience for selecting or accounting for long-context mode. Anthropic does not recognize the `[1m]` suffix as part of the model id.
+
+This mismatch can break Claude Code auto mode safety checks. Auto mode uses a small non-streaming classifier request, for example:
+
+```text
+POST /v1/messages?beta=true
+model: claude-opus-4-8
+max_tokens: 64
+stream: false
+```
+
+If CRS forwards the internal alias as `claude-opus-4-8[1m]`, upstream can reject the model. Claude Code then reports the classifier as unavailable, for example:
+
+```text
+claude-opus-4-8[1m] is temporarily unavailable,
+so auto mode cannot determine the safety of Bash right now.
+```
+
+## Change
+
+The long-context handling is now centralized in `src/utils/claudeLongContextHelper.js`.
+
+The helper treats `[1m]` as a CRS-local alias:
+
+- Strip a trailing `[1m]` suffix before forwarding requests upstream.
+- Preserve the original request semantics by adding `context-1m-2025-08-07` to `anthropic-beta`.
+- Merge beta headers without duplicating beta flags.
+- Leave ordinary model names unchanged.
+
+Example:
+
+```js
+normalizeClaudePayloadForUpstream(
+  { model: 'claude-opus-4-8[1m]' },
+  'oauth-2025-04-20'
+)
+```
+
+returns:
+
+```js
+{
+  body: { model: 'claude-opus-4-8' },
+  betaHeader: 'oauth-2025-04-20,context-1m-2025-08-07',
+  isLongContextAlias: true
+}
+```
+
+## Relay Coverage
+
+The helper is applied at the relay boundary, after scheduling and model mapping but before the request is sent upstream.
+
+Covered paths:
+
+- `src/services/relay/claudeRelayService.js`
+  - Claude Official OAuth relay.
+  - Shared request preparation for streaming and non-streaming requests.
+- `src/services/relay/claudeConsoleRelayService.js`
+  - Claude Console non-streaming relay.
+  - Claude Console streaming relay.
+- `src/services/relay/ccrRelayService.js`
+  - CCR non-streaming relay.
+  - CCR streaming relay.
+
+This keeps upstream normalization close to the outbound boundary while allowing CRS internals to keep using the original requested model for scheduling, restrictions, usage records, and pricing decisions.
+
+## Why This Shape
+
+The `[1m]` suffix is useful inside CRS because it is visible in model selection and usage accounting. It should not become part of the Anthropic wire request.
+
+Centralizing the behavior avoids three separate relay implementations drifting apart:
+
+- Official OAuth already rebuilds `anthropic-beta` dynamically.
+- Console and CCR pass selected headers through axios.
+- All three need the same model normalization rule.
+
+Keeping the helper small also makes the invariant easy to test:
+
+```text
+CRS internal model alias: claude-opus-4-8[1m]
+Anthropic upstream model: claude-opus-4-8
+Required beta flag:       context-1m-2025-08-07
+```
+
+## Verification
+
+Syntax checks:
+
+```bash
+node --check src/utils/claudeLongContextHelper.js
+node --check src/services/relay/claudeRelayService.js
+node --check src/services/relay/claudeConsoleRelayService.js
+node --check src/services/relay/ccrRelayService.js
+```
+
+Manual helper check:
+
+```bash
+node -e "const h=require('./src/utils/claudeLongContextHelper'); console.log(h.normalizeClaudePayloadForUpstream({model:'claude-opus-4-8[1m]'}, 'oauth-2025-04-20'))"
+```
+
+Expected behavior:
+
+- Upstream model is `claude-opus-4-8`.
+- `anthropic-beta` contains `context-1m-2025-08-07`.
+- Existing beta flags are preserved.
+- The beta flag is not duplicated if the client already sent it.

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -28,6 +28,19 @@ const {
 } = require('../services/anthropicGeminiBridgeService')
 const router = express.Router()
 
+function getHeaderValueCaseInsensitive(headers, key) {
+  if (!headers || typeof headers !== 'object') {
+    return undefined
+  }
+  const lowerKey = key.toLowerCase()
+  for (const candidate of Object.keys(headers)) {
+    if (candidate.toLowerCase() === lowerKey) {
+      return headers[candidate]
+    }
+  }
+  return undefined
+}
+
 function queueRateLimitUpdate(
   rateLimitInfo,
   usageSummary,
@@ -566,6 +579,7 @@ async function handleMessagesRequest(req, res) {
         const _requestBodyConsole = req.body
         const _apiKeyConsole = req.apiKey
         const _headersConsole = req.headers
+        const _betaHeaderConsole = getHeaderValueCaseInsensitive(_headersConsole, 'anthropic-beta')
 
         await claudeConsoleRelayService.relayStreamRequestWithUsageCapture(
           _requestBodyConsole,
@@ -693,7 +707,8 @@ async function handleMessagesRequest(req, res) {
               )
             }
           },
-          accountId
+          accountId,
+          { betaHeader: _betaHeaderConsole }
         )
       } else if (accountType === 'bedrock') {
         // Bedrock账号使用Bedrock转发服务
@@ -797,6 +812,7 @@ async function handleMessagesRequest(req, res) {
         const _requestBodyCcr = req.body
         const _apiKeyCcr = req.apiKey
         const _headersCcr = req.headers
+        const _betaHeaderCcr = getHeaderValueCaseInsensitive(_headersCcr, 'anthropic-beta')
 
         await ccrRelayService.relayStreamRequestWithUsageCapture(
           _requestBodyCcr,
@@ -921,7 +937,8 @@ async function handleMessagesRequest(req, res) {
               )
             }
           },
-          accountId
+          accountId,
+          { betaHeader: _betaHeaderCcr }
         )
       }
 
@@ -1152,7 +1169,8 @@ async function handleMessagesRequest(req, res) {
           req, // clientRequest 保留用于断开检测
           res,
           _headersNonStream,
-          accountId
+          accountId,
+          { betaHeader: getHeaderValueCaseInsensitive(_headersNonStream, 'anthropic-beta') }
         )
       } else if (accountType === 'bedrock') {
         // Bedrock账号使用Bedrock转发服务
@@ -1201,7 +1219,8 @@ async function handleMessagesRequest(req, res) {
           req, // clientRequest 保留用于断开检测
           res,
           _headersNonStream,
-          accountId
+          accountId,
+          { betaHeader: getHeaderValueCaseInsensitive(_headersNonStream, 'anthropic-beta') }
         )
       }
 

--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -36,7 +36,11 @@ function isProAccount(info) {
     return true
   }
   // Local configured account type
-  return info.accountType === 'claude_pro'
+  return info.accountType === 'claude_pro' || info.accountType === 'claude_team_standard'
+}
+
+function isFreeAccount(info) {
+  return info.accountType === 'free' || info.accountType === 'claude_free'
 }
 
 class ClaudeAccountService {
@@ -974,7 +978,7 @@ class ClaudeAccountService {
               const info = JSON.parse(account.subscriptionInfo)
 
               // Free account: does not support any Opus model
-              if (info.accountType === 'free') {
+              if (isFreeAccount(info)) {
                 return false
               }
 
@@ -1100,7 +1104,7 @@ class ClaudeAccountService {
               const info = JSON.parse(account.subscriptionInfo)
 
               // Free account: does not support any Opus model
-              if (info.accountType === 'free') {
+              if (isFreeAccount(info)) {
                 return false
               }
 
@@ -2253,9 +2257,46 @@ class ClaudeAccountService {
         const organizationType = String(
           profileData.organization?.organization_type || ''
         ).toLowerCase()
+        const rateLimitTier = String(profileData.organization?.rate_limit_tier || '').toLowerCase()
+        const seatTier = String(profileData.organization?.seat_tier || '').toLowerCase()
+        const subscriptionStatus = String(
+          profileData.organization?.subscription_status || ''
+        ).toLowerCase()
         const isEnterpriseOrg = organizationType === 'claude_enterprise'
-        const hasClaudeMax = profileData.account?.has_claude_max === true || isEnterpriseOrg
-        const hasClaudePro = profileData.account?.has_claude_pro === true && !hasClaudeMax
+        const isTeamOrg = organizationType === 'claude_team'
+        const hasTeamPremiumSeat = isTeamOrg && seatTier.includes('premium')
+        const hasTeamStandardSeat = isTeamOrg && seatTier.includes('standard')
+        const hasTeamMaxTier = isTeamOrg && rateLimitTier.includes('claude_max')
+        const hasActiveTeamMax = isTeamOrg && subscriptionStatus === 'active' && hasTeamMaxTier
+        const hasActiveTeamStandard =
+          isTeamOrg && subscriptionStatus === 'active' && hasTeamStandardSeat && !hasActiveTeamMax
+        const hasClaudeMax =
+          profileData.account?.has_claude_max === true ||
+          isEnterpriseOrg ||
+          hasActiveTeamMax ||
+          hasTeamPremiumSeat
+        const hasClaudePro =
+          (profileData.account?.has_claude_pro === true || hasActiveTeamStandard) && !hasClaudeMax
+        const planKind =
+          isEnterpriseOrg || hasActiveTeamMax || hasTeamPremiumSeat
+            ? 'team_premium'
+            : hasActiveTeamStandard
+              ? 'team_standard'
+              : hasClaudeMax
+                ? 'individual_max'
+                : hasClaudePro
+                  ? 'individual_pro'
+                  : 'free'
+        const accountType =
+          isEnterpriseOrg || hasActiveTeamMax || hasTeamPremiumSeat
+            ? 'claude_team_premium'
+            : hasActiveTeamStandard
+              ? 'claude_team_standard'
+              : hasClaudeMax
+                ? 'claude_max'
+                : hasClaudePro
+                  ? 'claude_pro'
+                  : 'claude_free'
 
         // 构建订阅信息
         const subscriptionInfo = {
@@ -2272,10 +2313,16 @@ class ClaudeAccountService {
           organizationUuid: profileData.organization?.uuid,
           billingType: profileData.organization?.billing_type,
           rateLimitTier: profileData.organization?.rate_limit_tier,
+          seatTier: profileData.organization?.seat_tier,
+          subscriptionStatus: profileData.organization?.subscription_status,
           organizationType: profileData.organization?.organization_type,
+          planKind,
+          isTeamPlan: isTeamOrg || isEnterpriseOrg,
+          isTeamPremium: hasTeamPremiumSeat,
+          isTeamStandard: hasActiveTeamStandard,
 
-          // 账号类型：Enterprise 组织按 Max 能力处理，确保可调度 Opus
-          accountType: hasClaudeMax ? 'claude_max' : hasClaudePro ? 'claude_pro' : 'claude_max',
+          // 账号类型：Team Premium 权限等效 Max，Team Standard 权限等效 Pro
+          accountType,
 
           // 更新时间
           profileFetchedAt: new Date().toISOString()

--- a/src/services/relay/ccrRelayService.js
+++ b/src/services/relay/ccrRelayService.js
@@ -6,6 +6,9 @@ const { parseVendorPrefixedModel } = require('../../utils/modelHelper')
 const userMessageQueueService = require('../userMessageQueueService')
 const { isStreamWritable } = require('../../utils/streamHelper')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
+const {
+  normalizeClaudePayloadForUpstream
+} = require('../../utils/claudeLongContextHelper')
 
 class CcrRelayService {
   constructor() {
@@ -117,9 +120,18 @@ class CcrRelayService {
       }
 
       // 创建修改后的请求体，使用去前缀后的模型名
-      const modifiedRequestBody = {
+      let modifiedRequestBody = {
         ...requestBody,
         model: mappedModel
+      }
+      const normalizedLongContext = normalizeClaudePayloadForUpstream(
+        modifiedRequestBody,
+        options.betaHeader || this._getHeaderValueCaseInsensitive(clientHeaders, 'anthropic-beta')
+      )
+      modifiedRequestBody = normalizedLongContext.body
+      options = {
+        ...options,
+        betaHeader: normalizedLongContext.betaHeader
       }
 
       // 创建代理agent
@@ -481,9 +493,18 @@ class CcrRelayService {
       }
 
       // 创建修改后的请求体，使用去前缀后的模型名
-      const modifiedRequestBody = {
+      let modifiedRequestBody = {
         ...requestBody,
         model: mappedModel
+      }
+      const normalizedLongContext = normalizeClaudePayloadForUpstream(
+        modifiedRequestBody,
+        options.betaHeader || this._getHeaderValueCaseInsensitive(clientHeaders, 'anthropic-beta')
+      )
+      modifiedRequestBody = normalizedLongContext.body
+      options = {
+        ...options,
+        betaHeader: normalizedLongContext.betaHeader
       }
 
       // 创建代理agent
@@ -952,6 +973,19 @@ class CcrRelayService {
     }
 
     return filteredHeaders
+  }
+
+  _getHeaderValueCaseInsensitive(headers, key) {
+    if (!headers || typeof headers !== 'object') {
+      return undefined
+    }
+    const lowerKey = key.toLowerCase()
+    for (const candidate of Object.keys(headers)) {
+      if (candidate.toLowerCase() === lowerKey) {
+        return headers[candidate]
+      }
+    }
+    return undefined
   }
 
   // ⏰ 更新账户最后使用时间

--- a/src/services/relay/claudeConsoleRelayService.js
+++ b/src/services/relay/claudeConsoleRelayService.js
@@ -13,6 +13,9 @@ const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
 const userMessageQueueService = require('../userMessageQueueService')
 const { isStreamWritable } = require('../../utils/streamHelper')
 const { filterForClaude } = require('../../utils/headerFilter')
+const {
+  normalizeClaudePayloadForUpstream
+} = require('../../utils/claudeLongContextHelper')
 
 class ClaudeConsoleRelayService {
   constructor() {
@@ -158,9 +161,18 @@ class ClaudeConsoleRelayService {
       }
 
       // 创建修改后的请求体
-      const modifiedRequestBody = {
+      let modifiedRequestBody = {
         ...requestBody,
         model: mappedModel
+      }
+      const normalizedLongContext = normalizeClaudePayloadForUpstream(
+        modifiedRequestBody,
+        options.betaHeader || this._getHeaderValueCaseInsensitive(clientHeaders, 'anthropic-beta')
+      )
+      modifiedRequestBody = normalizedLongContext.body
+      options = {
+        ...options,
+        betaHeader: normalizedLongContext.betaHeader
       }
 
       // 模型兼容性检查已经在调度器中完成，这里不需要再检查
@@ -644,9 +656,18 @@ class ClaudeConsoleRelayService {
       }
 
       // 创建修改后的请求体
-      const modifiedRequestBody = {
+      let modifiedRequestBody = {
         ...requestBody,
         model: mappedModel
+      }
+      const normalizedLongContext = normalizeClaudePayloadForUpstream(
+        modifiedRequestBody,
+        options.betaHeader || this._getHeaderValueCaseInsensitive(clientHeaders, 'anthropic-beta')
+      )
+      modifiedRequestBody = normalizedLongContext.body
+      options = {
+        ...options,
+        betaHeader: normalizedLongContext.betaHeader
       }
 
       // 模型兼容性检查已经在调度器中完成，这里不需要再检查
@@ -1372,6 +1393,19 @@ class ClaudeConsoleRelayService {
     // 使用统一的 headerFilter 工具类（白名单模式）
     // 与 claudeRelayService 保持一致，避免透传 CDN headers 触发上游 API 安全检查
     return filterForClaude(clientHeaders)
+  }
+
+  _getHeaderValueCaseInsensitive(headers, key) {
+    if (!headers || typeof headers !== 'object') {
+      return undefined
+    }
+    const lowerKey = key.toLowerCase()
+    for (const candidate of Object.keys(headers)) {
+      if (candidate.toLowerCase() === lowerKey) {
+        return headers[candidate]
+      }
+    }
+    return undefined
   }
 
   // 🕐 更新最后使用时间

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -19,6 +19,9 @@ const { isStreamWritable } = require('../../utils/streamHelper')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
 const metadataUserIdHelper = require('../../utils/metadataUserIdHelper')
 const {
+  normalizeClaudePayloadForUpstream
+} = require('../../utils/claudeLongContextHelper')
+const {
   getHttpsAgentForStream,
   getHttpsAgentForNonStream,
   getPricingData
@@ -1589,6 +1592,14 @@ class ClaudeRelayService {
     requestPayload = extensionResult.body
     finalHeaders = extensionResult.headers
 
+    const clientBetaHeader = this._getHeaderValueCaseInsensitive(clientHeaders, 'anthropic-beta')
+    const normalizedLongContext = normalizeClaudePayloadForUpstream(
+      requestPayload,
+      clientBetaHeader
+    )
+    requestPayload = normalizedLongContext.body
+    const normalizedClientBetaHeader = normalizedLongContext.betaHeader
+
     let toolNameMap = null
     if (!isRealClaudeCode) {
       toolNameMap = this._transformToolNamesInRequestBody(requestPayload, {
@@ -1632,8 +1643,7 @@ class ClaudeRelayService {
 
     // 根据模型和客户端传递的 anthropic-beta 动态设置 header
     const modelId = requestPayload?.model || body?.model
-    const clientBetaHeader = this._getHeaderValueCaseInsensitive(clientHeaders, 'anthropic-beta')
-    headers['anthropic-beta'] = this._getBetaHeader(modelId, clientBetaHeader)
+    headers['anthropic-beta'] = this._getBetaHeader(modelId, normalizedClientBetaHeader)
     return {
       requestPayload,
       bodyString,

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -32,7 +32,11 @@ function isProAccount(info) {
     return true
   }
   // Local configured account type
-  return info.accountType === 'claude_pro'
+  return info.accountType === 'claude_pro' || info.accountType === 'claude_team_standard'
+}
+
+function isFreeAccount(info) {
+  return info.accountType === 'free' || info.accountType === 'claude_free'
 }
 
 class UnifiedClaudeScheduler {
@@ -80,7 +84,7 @@ class UnifiedClaudeScheduler {
                 : account.subscriptionInfo
 
             // Free account: does not support any Opus model
-            if (info.accountType === 'free') {
+            if (isFreeAccount(info)) {
               logger.info(
                 `🚫 Claude account ${account.name} (Free) does not support Opus model${context ? ` ${context}` : ''}`
               )

--- a/src/utils/claudeLongContextHelper.js
+++ b/src/utils/claudeLongContextHelper.js
@@ -1,0 +1,68 @@
+const CONTEXT_1M_BETA = 'context-1m-2025-08-07'
+const LONG_CONTEXT_SUFFIX_RE = /\s*\[1m\]\s*$/i
+
+function normalizeClaudeModelForUpstream(model) {
+  if (typeof model !== 'string') {
+    return { model, isLongContextAlias: false }
+  }
+
+  const normalized = model.replace(LONG_CONTEXT_SUFFIX_RE, '').trim()
+  return {
+    model: normalized || model,
+    isLongContextAlias: normalized !== model.trim()
+  }
+}
+
+function mergeAnthropicBetaHeader(betaHeader, requiredBeta) {
+  const betaList = []
+  const seen = new Set()
+
+  const addBeta = (beta) => {
+    if (!beta || typeof beta !== 'string') {
+      return
+    }
+
+    beta
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .forEach((part) => {
+        if (!seen.has(part)) {
+          seen.add(part)
+          betaList.push(part)
+        }
+      })
+  }
+
+  addBeta(betaHeader)
+  addBeta(requiredBeta)
+
+  return betaList.join(',')
+}
+
+function normalizeClaudePayloadForUpstream(body, betaHeader) {
+  if (!body || typeof body !== 'object') {
+    return { body, betaHeader, isLongContextAlias: false }
+  }
+
+  const normalized = normalizeClaudeModelForUpstream(body.model)
+  if (!normalized.isLongContextAlias) {
+    return { body, betaHeader, isLongContextAlias: false }
+  }
+
+  return {
+    body: {
+      ...body,
+      model: normalized.model
+    },
+    betaHeader: mergeAnthropicBetaHeader(betaHeader, CONTEXT_1M_BETA),
+    isLongContextAlias: true
+  }
+}
+
+module.exports = {
+  CONTEXT_1M_BETA,
+  normalizeClaudeModelForUpstream,
+  mergeAnthropicBetaHeader,
+  normalizeClaudePayloadForUpstream
+}

--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -1807,6 +1807,24 @@
                     v-model="form.subscriptionType"
                     class="mr-2 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
                     type="radio"
+                    value="claude_team_premium"
+                  />
+                  <span class="text-sm text-gray-700 dark:text-gray-300">Claude Team Premium</span>
+                </label>
+                <label class="flex cursor-pointer items-center">
+                  <input
+                    v-model="form.subscriptionType"
+                    class="mr-2 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                    type="radio"
+                    value="claude_team_standard"
+                  />
+                  <span class="text-sm text-gray-700 dark:text-gray-300">Claude Team Standard</span>
+                </label>
+                <label class="flex cursor-pointer items-center">
+                  <input
+                    v-model="form.subscriptionType"
+                    class="mr-2 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                    type="radio"
                     value="claude_pro"
                   />
                   <span class="text-sm text-gray-700 dark:text-gray-300">Claude Pro</span>
@@ -2827,6 +2845,24 @@
                   value="claude_max"
                 />
                 <span class="text-sm text-gray-700 dark:text-gray-300">Claude Max</span>
+              </label>
+              <label class="flex cursor-pointer items-center">
+                <input
+                  v-model="form.subscriptionType"
+                  class="mr-2 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                  type="radio"
+                  value="claude_team_premium"
+                />
+                <span class="text-sm text-gray-700 dark:text-gray-300">Claude Team Premium</span>
+              </label>
+              <label class="flex cursor-pointer items-center">
+                <input
+                  v-model="form.subscriptionType"
+                  class="mr-2 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                  type="radio"
+                  value="claude_team_standard"
+                />
+                <span class="text-sm text-gray-700 dark:text-gray-300">Claude Team Standard</span>
               </label>
               <label class="flex cursor-pointer items-center">
                 <input
@@ -4408,6 +4444,24 @@ const form = ref({
   expiresAt: props.account?.expiresAt || null
 })
 
+const isClaudeMaxSubscriptionType = (subscriptionType) =>
+  subscriptionType === 'claude_max' ||
+  subscriptionType === 'claude_team_premium' ||
+  subscriptionType === 'claude_team_max'
+
+const isClaudeProSubscriptionType = (subscriptionType) =>
+  subscriptionType === 'claude_pro' || subscriptionType === 'claude_team_standard'
+
+const getClaudePlanKind = (subscriptionType) => {
+  if (subscriptionType === 'claude_team_premium' || subscriptionType === 'claude_team_max') {
+    return 'team_premium'
+  }
+  if (subscriptionType === 'claude_team_standard') {
+    return 'team_standard'
+  }
+  return undefined
+}
+
 const buildClaudeTempUnavailablePolicyPayload = () => ({
   disableTempUnavailable: !!form.value.disableTempUnavailable,
   tempUnavailable503TtlSeconds: normalizeAccountCooldownOverride(
@@ -4946,8 +5000,9 @@ const buildClaudeAccountData = (tokenInfo, accountName, clientId) => {
     maxConcurrency: form.value.serialQueueEnabled ? 1 : 0,
     subscriptionInfo: {
       accountType: form.value.subscriptionType || 'claude_max',
-      hasClaudeMax: form.value.subscriptionType === 'claude_max',
-      hasClaudePro: form.value.subscriptionType === 'claude_pro',
+      hasClaudeMax: isClaudeMaxSubscriptionType(form.value.subscriptionType),
+      hasClaudePro: isClaudeProSubscriptionType(form.value.subscriptionType),
+      planKind: getClaudePlanKind(form.value.subscriptionType),
       manuallySet: true
     }
   }
@@ -5086,8 +5141,9 @@ const handleOAuthSuccess = async (tokenInfoOrList) => {
       // 添加订阅类型信息
       data.subscriptionInfo = {
         accountType: form.value.subscriptionType || 'claude_max',
-        hasClaudeMax: form.value.subscriptionType === 'claude_max',
-        hasClaudePro: form.value.subscriptionType === 'claude_pro',
+        hasClaudeMax: isClaudeMaxSubscriptionType(form.value.subscriptionType),
+        hasClaudePro: isClaudeProSubscriptionType(form.value.subscriptionType),
+        planKind: getClaudePlanKind(form.value.subscriptionType),
         manuallySet: true // 标记为手动设置
       }
     } else if (currentPlatform === 'gemini' || currentPlatform === 'gemini-antigravity') {
@@ -5424,8 +5480,9 @@ const createAccount = async () => {
       // 添加订阅类型信息
       data.subscriptionInfo = {
         accountType: form.value.subscriptionType || 'claude_max',
-        hasClaudeMax: form.value.subscriptionType === 'claude_max',
-        hasClaudePro: form.value.subscriptionType === 'claude_pro',
+        hasClaudeMax: isClaudeMaxSubscriptionType(form.value.subscriptionType),
+        hasClaudePro: isClaudeProSubscriptionType(form.value.subscriptionType),
+        planKind: getClaudePlanKind(form.value.subscriptionType),
         manuallySet: true // 标记为手动设置
       }
     } else if (form.value.platform === 'gemini') {
@@ -5831,8 +5888,9 @@ const updateAccount = async () => {
       // 更新订阅类型信息
       data.subscriptionInfo = {
         accountType: form.value.subscriptionType || 'claude_max',
-        hasClaudeMax: form.value.subscriptionType === 'claude_max',
-        hasClaudePro: form.value.subscriptionType === 'claude_pro',
+        hasClaudeMax: isClaudeMaxSubscriptionType(form.value.subscriptionType),
+        hasClaudePro: isClaudeProSubscriptionType(form.value.subscriptionType),
+        planKind: getClaudePlanKind(form.value.subscriptionType),
         manuallySet: true // 标记为手动设置
       }
     }
@@ -6429,7 +6487,11 @@ watch(
             ? JSON.parse(newAccount.subscriptionInfo)
             : newAccount.subscriptionInfo
 
-        if (info.accountType) {
+        if (info.accountType === 'claude_team_max') {
+          subscriptionType = 'claude_team_premium'
+        } else if (info.planKind === 'team_max_premium') {
+          subscriptionType = 'claude_team_premium'
+        } else if (info.accountType) {
           subscriptionType = info.accountType
         } else if (info.hasClaudeMax) {
           subscriptionType = 'claude_max'

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -4400,10 +4400,7 @@ const getClaudeAccountType = (account) => {
         info.accountType === 'claude_team_max'
       ) {
         return 'Claude Team Premium'
-      } else if (
-        info.planKind === 'team_standard' ||
-        info.accountType === 'claude_team_standard'
-      ) {
+      } else if (info.planKind === 'team_standard' || info.accountType === 'claude_team_standard') {
         return 'Claude Team Standard'
       } else if (info.hasClaudeMax === true || info.accountType === 'claude_max') {
         return 'Claude Max'

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -4393,10 +4393,21 @@ const getClaudeAccountType = (account) => {
 
       // 订阅信息已解析
 
-      // 根据 has_claude_max 和 has_claude_pro 判断
-      if (info.hasClaudeMax === true) {
+      if (
+        info.planKind === 'team_premium' ||
+        info.planKind === 'team_max_premium' ||
+        info.accountType === 'claude_team_premium' ||
+        info.accountType === 'claude_team_max'
+      ) {
+        return 'Claude Team Premium'
+      } else if (
+        info.planKind === 'team_standard' ||
+        info.accountType === 'claude_team_standard'
+      ) {
+        return 'Claude Team Standard'
+      } else if (info.hasClaudeMax === true || info.accountType === 'claude_max') {
         return 'Claude Max'
-      } else if (info.hasClaudePro === true) {
+      } else if (info.hasClaudePro === true || info.accountType === 'claude_pro') {
         return 'Claude Pro'
       } else {
         return 'Claude Free'


### PR DESCRIPTION
This PR improves Claude account capability detection and request forwarding for official Claude accounts.

Changes include:

- Detect Claude Team Premium and Team Standard from `/api/oauth/profile` organization fields.
- Treat Team Premium as Max-equivalent capability for scheduling.
- Treat Team Standard as Pro-equivalent capability for scheduling.
- Display Team accounts as `Claude Team Premium` / `Claude Team Standard` in the admin UI.
- Add manual account type options for Team Premium and Team Standard.
- Forward client `anthropic-beta` headers through relay paths so beta features such as 1M context are not dropped.