### PR TITLE
feat(admin): add re-authorization button for Claude accounts with 400/401 errors

### DIFF
--- a/web/admin-spa/src/components/accounts/ReAuthDialog.vue
+++ b/web/admin-spa/src/components/accounts/ReAuthDialog.vue
@@ -1,0 +1,196 @@
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center">
+    <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" @click="$emit('close')" />
+    <div
+      class="relative z-10 mx-4 w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-gray-800"
+    >
+      <!-- Header -->
+      <div class="mb-5 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <div
+            class="flex h-9 w-9 items-center justify-center rounded-full bg-orange-100 dark:bg-orange-900/40"
+          >
+            <i class="fas fa-key text-orange-600 dark:text-orange-400" />
+          </div>
+          <div>
+            <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+              {{ account.name || account.email || '账号重新授权' }}
+            </h3>
+            <p class="text-xs text-gray-500 dark:text-gray-400">Claude OAuth — Cookie 重新授权</p>
+          </div>
+        </div>
+        <button
+          class="flex h-7 w-7 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700"
+          @click="$emit('close')"
+        >
+          <i class="fas fa-times text-sm" />
+        </button>
+      </div>
+
+      <!-- Error banner -->
+      <div
+        v-if="account.errorMessage || account.status === 'error'"
+        class="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-800/60 dark:bg-red-900/20"
+      >
+        <p class="text-xs font-medium text-red-700 dark:text-red-400">
+          <i class="fas fa-exclamation-circle mr-1" />
+          {{ account.errorMessage || '账号授权已失效 (400/401)' }}
+        </p>
+      </div>
+
+      <!-- Instructions -->
+      <div class="mb-4 rounded-lg bg-blue-50 px-4 py-3 dark:bg-blue-900/20">
+        <p class="text-xs leading-relaxed text-blue-700 dark:text-blue-300">
+          <i class="fas fa-info-circle mr-1" />
+          登录 <strong>claude.ai</strong>，按 F12 → Application → Cookies → claude.ai， 找到
+          <code class="rounded bg-blue-100 px-1 py-0.5 font-mono dark:bg-blue-900/60"
+            >sessionKey</code
+          >
+          并复制完整值。
+        </p>
+      </div>
+
+      <!-- Input -->
+      <div class="mb-4">
+        <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+          sessionKey
+        </label>
+        <textarea
+          v-model="sessionKey"
+          class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          :disabled="loading"
+          placeholder="sk-ant-sid01-xxxxxxxxxxxxxxxx..."
+          rows="3"
+        />
+      </div>
+
+      <!-- Proxy field -->
+      <div class="mb-5">
+        <button
+          class="mb-2 flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          type="button"
+          @click="showProxy = !showProxy"
+        >
+          <i
+            class="text-[10px]"
+            :class="showProxy ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"
+          />
+          代理设置（无外网时必填）
+        </button>
+        <div v-if="showProxy">
+          <input
+            v-model="proxy"
+            class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            :disabled="loading"
+            placeholder="http://127.0.0.1:7890 或 socks5://host:port"
+            type="text"
+          />
+          <p class="mt-1 text-xs text-gray-400">用于访问 claude.ai 的代理，留空则直连</p>
+        </div>
+      </div>
+
+      <!-- Step indicator -->
+      <p v-if="loading && step" class="mb-3 text-center text-xs text-gray-400 dark:text-gray-500">
+        <i class="fas fa-spinner mr-1 animate-spin" />{{ step }}
+      </p>
+
+      <!-- Error msg -->
+      <div
+        v-if="errorMsg"
+        class="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-800/60 dark:bg-red-900/20"
+      >
+        <p class="text-xs text-red-600 dark:text-red-400">
+          <i class="fas fa-times-circle mr-1" />{{ errorMsg }}
+        </p>
+      </div>
+
+      <!-- Success msg -->
+      <div
+        v-if="successMsg"
+        class="mb-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 dark:border-green-800/60 dark:bg-green-900/20"
+      >
+        <p class="text-xs text-green-700 dark:text-green-400">
+          <i class="fas fa-check-circle mr-1" />{{ successMsg }}
+        </p>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex justify-end gap-3">
+        <button
+          class="rounded-lg px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+          :disabled="loading"
+          @click="$emit('close')"
+        >
+          取消
+        </button>
+        <button
+          class="flex items-center gap-2 rounded-lg bg-orange-500 px-4 py-2 text-sm font-medium text-white hover:bg-orange-600 disabled:opacity-50"
+          :disabled="loading || !sessionKey.trim()"
+          @click="handleReAuth"
+        >
+          <i v-if="loading" class="fas fa-spinner animate-spin" />
+          <i v-else class="fas fa-key" />
+          重新授权
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import * as httpApis from '@/utils/http_apis'
+
+const props = defineProps({
+  account: { type: Object, required: true }
+})
+const emit = defineEmits(['close', 'success'])
+
+const sessionKey = ref('')
+const proxy = ref(props.account.proxy || '')
+const showProxy = ref(!!props.account.proxy)
+const loading = ref(false)
+const step = ref('')
+const errorMsg = ref('')
+const successMsg = ref('')
+
+async function handleReAuth() {
+  const key = sessionKey.value.trim()
+  if (!key) return
+
+  loading.value = true
+  errorMsg.value = ''
+  successMsg.value = ''
+
+  try {
+    step.value = '步骤 1/2：通过 sessionKey 换取 OAuth token…'
+    const proxyVal = proxy.value.trim() || null
+    const oauthRes = await httpApis.claudeOAuthWithCookieApi({
+      sessionKey: key,
+      ...(proxyVal ? { proxy: proxyVal } : {})
+    })
+    if (!oauthRes.success) {
+      errorMsg.value = oauthRes.message || 'sessionKey 无效或已过期'
+      return
+    }
+
+    step.value = '步骤 2/2：更新账号 token…'
+    const updateRes = await httpApis.updateClaudeAccountApi(props.account.id, {
+      claudeAiOauth: oauthRes.data.claudeAiOauth
+    })
+    if (!updateRes.success) {
+      errorMsg.value = updateRes.message || 'Token 更新失败'
+      return
+    }
+
+    successMsg.value = '✓ 重新授权成功！Token 已更新。'
+    setTimeout(() => emit('success'), 1200)
+  } catch (err) {
+    const serverMsg = err?.response?.data?.message
+    errorMsg.value = serverMsg || err?.message || '请求出错，请重试'
+  } finally {
+    loading.value = false
+    step.value = ''
+  }
+}
+</script>

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -1386,6 +1386,19 @@
                       <span class="ml-1">编辑</span>
                     </button>
                     <button
+                      v-if="
+                        account.platform === 'claude' &&
+                        (account.status === 'unauthorized' ||
+                          (account.status === 'error' && /40[01]/.test(account.errorMessage || '')))
+                      "
+                      class="rounded bg-orange-100 px-2.5 py-1 text-xs font-medium text-orange-700 transition-colors hover:bg-orange-200 dark:bg-orange-900/40 dark:text-orange-300"
+                      title="重新授权"
+                      @click="openReAuthDialog(account)"
+                    >
+                      <i class="fas fa-key" />
+                      <span class="ml-1">授权</span>
+                    </button>
+                    <button
                       class="rounded bg-red-100 px-2.5 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-200"
                       title="删除账户"
                       @click="deleteAccount(account)"
@@ -1419,6 +1432,19 @@
                     >
                       <i class="fas fa-edit" />
                       <span class="ml-1">编辑</span>
+                    </button>
+                    <button
+                      v-if="
+                        account.platform === 'claude' &&
+                        (account.status === 'unauthorized' ||
+                          (account.status === 'error' && /40[01]/.test(account.errorMessage || '')))
+                      "
+                      class="rounded bg-orange-100 px-2.5 py-1 text-xs font-medium text-orange-700 transition-colors hover:bg-orange-200 dark:bg-orange-900/40 dark:text-orange-300"
+                      title="重新授权"
+                      @click="openReAuthDialog(account)"
+                    >
+                      <i class="fas fa-key" />
+                      <span class="ml-1">授权</span>
                     </button>
                     <ActionDropdown :actions="getAccountActions(account)" />
                   </div>
@@ -1918,6 +1944,20 @@
             </button>
 
             <button
+              v-if="
+                account.platform === 'claude' &&
+                (account.status === 'unauthorized' ||
+                  (account.status === 'error' && /40[01]/.test(account.errorMessage || '')))
+              "
+              class="flex flex-1 items-center justify-center gap-1 rounded-lg bg-orange-50 px-3 py-2 text-xs text-orange-600 transition-colors hover:bg-orange-100 dark:bg-orange-900/40 dark:text-orange-300"
+              title="重新授权"
+              @click="openReAuthDialog(account)"
+            >
+              <i class="fas fa-key" />
+              授权
+            </button>
+
+            <button
               class="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-600 transition-colors hover:bg-red-100"
               @click="deleteAccount(account)"
             >
@@ -2041,6 +2081,14 @@
       :account="editingAccount"
       @close="showEditAccountModal = false"
       @success="handleEditSuccess"
+    />
+
+    <!-- 重新授权弹窗 -->
+    <ReAuthDialog
+      v-if="showReAuthModal && reAuthAccount"
+      :account="reAuthAccount"
+      @close="showReAuthModal = false"
+      @success="handleReAuthSuccess"
     />
 
     <!-- 确认弹窗 -->
@@ -2274,6 +2322,7 @@ import ActionDropdown from '@/components/common/ActionDropdown.vue'
 import GroupManagementModal from '@/components/accounts/GroupManagementModal.vue'
 import BalanceDisplay from '@/components/accounts/BalanceDisplay.vue'
 import AccountBalanceScriptModal from '@/components/accounts/AccountBalanceScriptModal.vue'
+import ReAuthDialog from '@/components/accounts/ReAuthDialog.vue'
 
 // 确认弹窗状态
 const showConfirmModal = ref(false)
@@ -2419,6 +2468,10 @@ const showAccountStatsModal = ref(false)
 
 // 分组管理弹窗状态
 const showGroupManagementModal = ref(false)
+
+// 重新授权弹窗状态
+const showReAuthModal = ref(false)
+const reAuthAccount = ref(null)
 
 // 表格横向滚动检测
 const tableContainerRef = ref(null)
@@ -3953,6 +4006,18 @@ const closeCreateAccountModal = () => {
 const editAccount = (account) => {
   editingAccount.value = account
   showEditAccountModal.value = true
+}
+
+// 重新授权
+const openReAuthDialog = (account) => {
+  reAuthAccount.value = account
+  showReAuthModal.value = true
+}
+
+const handleReAuthSuccess = () => {
+  showReAuthModal.value = false
+  showToast('账号重新授权成功', 'success')
+  loadAccounts()
 }
 
 const getBoundApiKeysForAccount = (account) => {


### PR DESCRIPTION
## Summary

- Add `ReAuthDialog.vue`: a dialog component that lets admins re-authorize a Claude OAuth account by entering a new `sessionKey` cookie from claude.ai. Includes optional proxy configuration for environments without direct internet access.
- Update `AccountsView.vue`: the re-auth button now appears **only** when an account has a 400 or 401 error (`status === 'unauthorized'` or `status === 'error'` with `errorMessage` matching `/40[01]/`), rather than for all Claude platform accounts.

## Flow

1. User clicks the key icon on an account with a 400/401 error.
2. Dialog opens; user pastes the `sessionKey` cookie from claude.ai DevTools (F12 → Application → Cookies).
3. `POST /admin/claude-accounts/oauth-with-cookie` exchanges the cookie for fresh OAuth tokens (accessToken + refreshToken via full OAuth2 code exchange).
4. `PUT /admin/claude-accounts/:id` persists the new `claudeAiOauth` object.
5. Account status resets to active; dialog closes and account list refreshes automatically.

## Test plan

- [ ] Account with `status=unauthorized` (401 error): button appears, re-auth dialog opens
- [ ] Account with `status=error` and errorMessage containing 400: button appears
- [ ] Active Claude account (`status=active`): button does **not** appear
- [ ] Non-Claude account: button does **not** appear
- [ ] Proxy field collapses by default; expands when clicked
- [ ] Invalid sessionKey shows server error message
- [ ] Network-restricted environment without proxy returns a descriptive error

Generated with [Claude Code](https://claude.com/claude-code)