### PR TITLE
fix: Cookie 自动授权失败时不再崩溃，透传后端真实错误

### DIFF
--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -4871,6 +4871,12 @@ const handleCookieAuth = async () => {
       } else {
         result = await accountsStore.oauthWithCookie(payload)
       }
+      // 后端授权失败时 request() 不抛异常，store 返回 null（真实原因存于 accountsStore.error）。
+      // 这里必须显式拦截 null，否则它会被当成成功结果传入 handleOAuthSuccess →
+      // buildClaudeAccountData，触发 "Cannot read properties of null (reading 'claudeAiOauth')"。
+      if (!result) {
+        throw new Error(accountsStore.error || 'Cookie 授权失败，请检查 sessionKey 是否有效')
+      }
       results.push(result)
     } catch (error) {
       errors.push({
@@ -4896,7 +4902,11 @@ const handleCookieAuth = async () => {
   }
 
   if (errors.length > 0 && results.length === 0) {
-    cookieAuthError.value = '全部授权失败，请检查 sessionKey 是否有效'
+    // 单个 sessionKey 失败时直接展示后端返回的真实原因，便于排查（而非笼统提示）
+    cookieAuthError.value =
+      errors.length === 1
+        ? `授权失败：${errors[0].error}`
+        : '全部授权失败，请检查 sessionKey 是否有效'
   } else if (errors.length > 0) {
     cookieAuthError.value = `${errors.length} 个授权失败`
   }


### PR DESCRIPTION
## 问题

在「添加账户 → Cookie 自动授权」中，授权失败时前端会崩溃报错：

```
Cannot read properties of null (reading 'claudeAiOauth')
```

这个报错掩盖了后端返回的真实失败原因（如 sessionKey 失效、Cloudflare 拦截等），用户无法据此排查。

## 根因

1. `web/admin-spa/src/utils/request.js` 的 `request()` 始终 `resolve`（注释即「只会 resolve，调用方无需 try-catch」），授权失败（HTTP 500）时返回后端的 `{ success: false, message }`，而非抛异常。
2. `web/admin-spa/src/stores/accounts.js` 的 `oauthWithCookie` 在 `!res.success` 时返回 `null`，仅把真实原因写入 `accountsStore.error`。
3. `web/admin-spa/src/components/accounts/AccountForm.vue` 的 `handleCookieAuth` 未拦截该 `null`，直接 `results.push(null)`；其 `try/catch` 因全程没有异常而不会触发。
4. 随后 `results.length > 0` 成立（实际是 `[null]`）→ `handleOAuthSuccess([null])` → `buildClaudeAccountData(null)` 读取 `null.claudeAiOauth`，抛出上述错误。

提交 `7dc21cf2`（*migrate Claude OAuth endpoint to platform.claude.com and harden flow*）已为**手动 OAuth 流程**（`OAuthFlow.vue` 的 `exchangeCode`）补充了同类 `if (!tokenInfo)` 检查，但**遗漏了 Cookie 自动授权这条路径**。本 PR 补齐这一处。

## 改动

`web/admin-spa/src/components/accounts/AccountForm.vue`（`handleCookieAuth`）：

- 拦截 store 返回的 `null`，抛出 `accountsStore.error` 中的真实原因，交由既有 `catch` 收集到 `errors`，不再把 `null` 当作成功结果继续往下走。
- 单个 sessionKey 失败时直接展示后端真实错误信息（而非笼统的「全部授权失败」），便于排查。

## 行为变化

- 修复前：Cookie 授权失败 → 崩溃为 `Cannot read properties of null (reading 'claudeAiOauth')`。
- 修复后：Cookie 授权失败 → 展示后端真实原因，例如「授权失败：Cookie授权失败：无效的sessionKey或已过期」。

> 注：本 PR 仅修复前端的 `null` 处理，不改动后端授权逻辑。授权本身能否成功仍取决于 sessionKey / 网络 / 代理等实际情况，但失败原因将正确透传给用户。

## 测试

- `npm run build`（`web/admin-spa`）通过，构建产物正常。
- `prettier --write` 无改动、`eslint` 无告警。
- 以等价逻辑复现验证：修复前 `results = [null]` 触发 `null.claudeAiOauth` 崩溃；修复后被捕获进 `errors` 并展示真实 `message`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
