### PR TITLE
fix: Fable 模型限流独立成桶，避免拖垮账号内其他模型调度

### DIFF
--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -550,13 +550,19 @@ class ClaudeAccountService {
       // 处理返回数据，移除敏感信息并添加限流状态和会话窗口信息
       const processedAccounts = await Promise.all(
         accounts.map(async (account) => {
-          const [rateLimitInfo, sessionWindowInfo, opusRateLimitStatus, isOverloaded] =
-            await Promise.all([
-              this.getAccountRateLimitInfo(account.id),
-              this.getSessionWindowInfo(account.id),
-              this.getAccountOpusRateLimitInfo(account.id, account),
-              this.isAccountOverloaded(account.id)
-            ])
+          const [
+            rateLimitInfo,
+            sessionWindowInfo,
+            opusRateLimitStatus,
+            fableRateLimitStatus,
+            isOverloaded
+          ] = await Promise.all([
+            this.getAccountRateLimitInfo(account.id),
+            this.getSessionWindowInfo(account.id),
+            this.getAccountOpusRateLimitInfo(account.id, account),
+            this.getAccountFableRateLimitInfo(account.id, account),
+            this.isAccountOverloaded(account.id)
+          ])
 
           // 构建 Claude Usage 快照（从 Redis 读取）
           const claudeUsage = this.buildClaudeUsageSnapshot(account)
@@ -616,6 +622,8 @@ class ClaudeAccountService {
               : null,
             // Opus 专属限流状态（仅影响 Opus 模型路由）
             opusRateLimitStatus,
+            // Fable 专属限流状态（仅影响 Fable 模型路由）
+            fableRateLimitStatus,
             // 过载状态（429/529 自动保护）
             overloadStatus: {
               isOverloaded,
@@ -1655,6 +1663,173 @@ class ClaudeAccountService {
     }
   }
 
+  // 🚫 标记账号的 Fable 限流状态（不影响其他模型调度）
+  async markAccountFableRateLimited(accountId, rateLimitResetTimestamp = null) {
+    try {
+      const accountData = await redis.getClaudeAccount(accountId)
+      if (!accountData || Object.keys(accountData).length === 0) {
+        throw new Error('Account not found')
+      }
+
+      const updatedAccountData = { ...accountData }
+      const now = new Date()
+      updatedAccountData.fableRateLimitedAt = now.toISOString()
+
+      if (rateLimitResetTimestamp) {
+        const resetTime = new Date(rateLimitResetTimestamp * 1000)
+        updatedAccountData.fableRateLimitEndAt = resetTime.toISOString()
+        logger.warn(
+          `🚫 Account ${accountData.name} (${accountId}) reached Fable weekly cap, resets at ${resetTime.toISOString()}`
+        )
+      } else {
+        // 如果缺少准确时间戳，保留现有值但记录警告，便于后续人工干预
+        logger.warn(
+          `⚠️ Account ${accountData.name} (${accountId}) reported Fable limit without reset timestamp`
+        )
+      }
+
+      await redis.setClaudeAccount(accountId, updatedAccountData)
+      return { success: true }
+    } catch (error) {
+      logger.error(`❌ Failed to mark Fable rate limit for account: ${accountId}`, error)
+      throw error
+    }
+  }
+
+  // ✅ 清除账号的 Fable 限流状态
+  async clearAccountFableRateLimit(accountId) {
+    try {
+      const accountData = await redis.getClaudeAccount(accountId)
+      if (!accountData || Object.keys(accountData).length === 0) {
+        return { success: true }
+      }
+
+      const updatedAccountData = { ...accountData }
+      delete updatedAccountData.fableRateLimitedAt
+      delete updatedAccountData.fableRateLimitEndAt
+
+      await redis.setClaudeAccount(accountId, updatedAccountData)
+
+      const redisKey = `claude:account:${accountId}`
+      if (redis.client && typeof redis.client.hdel === 'function') {
+        await redis.client.hdel(redisKey, 'fableRateLimitedAt', 'fableRateLimitEndAt')
+      }
+
+      logger.info(`✅ Cleared Fable rate limit state for account ${accountId}`)
+      return { success: true }
+    } catch (error) {
+      logger.error(`❌ Failed to clear Fable rate limit for account: ${accountId}`, error)
+      throw error
+    }
+  }
+
+  // 📊 获取账号 Fable 限流信息（自动清理过期状态）
+  async getAccountFableRateLimitInfo(accountId, accountData = null) {
+    try {
+      const data = accountData || (await redis.getClaudeAccount(accountId))
+      if (!data || Object.keys(data).length === 0 || !data.fableRateLimitEndAt) {
+        return {
+          isRateLimited: false,
+          rateLimitedAt: null,
+          resetAt: null,
+          minutesRemaining: 0
+        }
+      }
+
+      const resetAtMs = Date.parse(data.fableRateLimitEndAt)
+      if (Number.isNaN(resetAtMs)) {
+        return {
+          isRateLimited: false,
+          rateLimitedAt: data.fableRateLimitedAt || null,
+          resetAt: null,
+          minutesRemaining: 0
+        }
+      }
+
+      const nowMs = Date.now()
+      if (nowMs >= resetAtMs) {
+        // 自动清理过期标记，避免前端持续显示陈旧状态
+        await this.clearAccountFableRateLimit(accountId).catch(() => {})
+        return {
+          isRateLimited: false,
+          rateLimitedAt: data.fableRateLimitedAt || null,
+          resetAt: data.fableRateLimitEndAt,
+          minutesRemaining: 0
+        }
+      }
+
+      return {
+        isRateLimited: true,
+        rateLimitedAt: data.fableRateLimitedAt || null,
+        resetAt: data.fableRateLimitEndAt,
+        minutesRemaining: Math.max(0, Math.ceil((resetAtMs - nowMs) / (1000 * 60)))
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to get Fable rate limit info for account: ${accountId}`, error)
+      return {
+        isRateLimited: false,
+        rateLimitedAt: null,
+        resetAt: null,
+        minutesRemaining: 0
+      }
+    }
+  }
+
+  // 🔍 检查账号是否处于 Fable 限流状态（自动清理过期标记）
+  async isAccountFableRateLimited(accountId) {
+    try {
+      const accountData = await redis.getClaudeAccount(accountId)
+      if (!accountData || Object.keys(accountData).length === 0) {
+        return false
+      }
+
+      if (!accountData.fableRateLimitEndAt) {
+        return false
+      }
+
+      const resetTime = new Date(accountData.fableRateLimitEndAt)
+      if (Number.isNaN(resetTime.getTime())) {
+        await this.clearAccountFableRateLimit(accountId)
+        return false
+      }
+
+      const now = new Date()
+      if (now >= resetTime) {
+        await this.clearAccountFableRateLimit(accountId)
+        return false
+      }
+
+      return true
+    } catch (error) {
+      logger.error(`❌ Failed to check Fable rate limit status for account: ${accountId}`, error)
+      return false
+    }
+  }
+
+  // ♻️ 检查并清理已过期的 Fable 限流标记
+  async clearExpiredFableRateLimit(accountId) {
+    try {
+      const accountData = await redis.getClaudeAccount(accountId)
+      if (!accountData || Object.keys(accountData).length === 0) {
+        return { success: true }
+      }
+
+      if (!accountData.fableRateLimitEndAt) {
+        return { success: true }
+      }
+
+      const resetTime = new Date(accountData.fableRateLimitEndAt)
+      if (Number.isNaN(resetTime.getTime()) || new Date() >= resetTime) {
+        await this.clearAccountFableRateLimit(accountId)
+      }
+
+      return { success: true }
+    } catch (error) {
+      logger.error(`❌ Failed to clear expired Fable rate limit for account: ${accountId}`, error)
+      throw error
+    }
+  }
+
   // ✅ 移除账号的限流状态
   async removeAccountRateLimit(accountId) {
     try {
@@ -2610,6 +2785,8 @@ class ClaudeAccountService {
       delete updatedAccountData.sessionWindowEnd
       delete updatedAccountData.opusRateLimitedAt
       delete updatedAccountData.opusRateLimitEndAt
+      delete updatedAccountData.fableRateLimitedAt
+      delete updatedAccountData.fableRateLimitEndAt
       delete updatedAccountData.lastOverloadAt
 
       // 保存更新后的账户数据
@@ -2628,6 +2805,8 @@ class ClaudeAccountService {
         'sessionWindowEnd',
         'opusRateLimitedAt',
         'opusRateLimitEndAt',
+        'fableRateLimitedAt',
+        'fableRateLimitEndAt',
         'lastOverloadAt',
         // 新的独立标记
         'rateLimitAutoStopped',

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -474,6 +474,8 @@ class ClaudeRelayService {
 
       const isOpusModelRequest =
         typeof requestBody?.model === 'string' && requestBody.model.toLowerCase().includes('opus')
+      const isFableModelRequest =
+        typeof requestBody?.model === 'string' && requestBody.model.toLowerCase().includes('fable')
 
       // 生成会话哈希用于sticky会话
       const sessionHash = sessionHelper.generateSessionHash(requestBody)
@@ -848,6 +850,14 @@ class ClaudeRelayService {
                   accountId
                 }
               }
+            } else if (isFableModelRequest && !Number.isNaN(parsedResetTimestamp)) {
+              await claudeAccountService.markAccountFableRateLimited(
+                accountId,
+                parsedResetTimestamp
+              )
+              logger.warn(
+                `🚫 Account ${accountId} hit Fable limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
+              )
             } else {
               isRateLimited = true
               if (!Number.isNaN(parsedResetTimestamp)) {
@@ -2106,6 +2116,8 @@ class ClaudeRelayService {
 
     const isOpusModelRequest =
       typeof body?.model === 'string' && body.model.toLowerCase().includes('opus')
+    const isFableModelRequest =
+      typeof body?.model === 'string' && body.model.toLowerCase().includes('fable')
 
     // 使用公共方法准备请求头和 payload
     const prepared = await this._prepareRequestHeadersAndPayload(
@@ -2237,6 +2249,16 @@ class ClaudeRelayService {
                 responseStream.end()
                 resolve()
                 return
+              }
+            } else if (isFableModelRequest) {
+              if (!Number.isNaN(parsedResetTimestamp)) {
+                await claudeAccountService.markAccountFableRateLimited(
+                  accountId,
+                  parsedResetTimestamp
+                )
+                logger.warn(
+                  `🚫 [Stream] Account ${accountId} hit Fable limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
+                )
               }
             } else {
               const rateLimitResetTimestamp = Number.isNaN(parsedResetTimestamp)
@@ -2915,6 +2937,14 @@ class ClaudeRelayService {
               await claudeAccountService.markAccountOpusRateLimited(accountId, parsedResetTimestamp)
               logger.warn(
                 `🚫 [Stream] Account ${accountId} hit Opus limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
+              )
+            } else if (isFableModelRequest && !Number.isNaN(parsedResetTimestamp)) {
+              await claudeAccountService.markAccountFableRateLimited(
+                accountId,
+                parsedResetTimestamp
+              )
+              logger.warn(
+                `🚫 [Stream] Account ${accountId} hit Fable limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
               )
             } else if (this._isAgentViewAuxiliaryRequest(body, clientHeaders)) {
               logger.warn(

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -233,6 +233,10 @@ class UnifiedClaudeScheduler {
         effectiveModel && typeof effectiveModel === 'string'
           ? effectiveModel.toLowerCase().includes('opus')
           : false
+      const isFableRequest =
+        effectiveModel && typeof effectiveModel === 'string'
+          ? effectiveModel.toLowerCase().includes('fable')
+          : false
 
       // 如果是 CCR 前缀，只在 CCR 账户池中选择
       if (vendor === 'ccr') {
@@ -285,6 +289,9 @@ class UnifiedClaudeScheduler {
             } else {
               if (isOpusRequest) {
                 await claudeAccountService.clearExpiredOpusRateLimit(boundAccount.id)
+              }
+              if (isFableRequest) {
+                await claudeAccountService.clearExpiredFableRateLimit(boundAccount.id)
               }
               logger.info(
                 `🎯 Using bound dedicated Claude OAuth account: ${boundAccount.name} (${apiKeyData.claudeAccountId}) for API key ${apiKeyData.name}`
@@ -465,6 +472,10 @@ class UnifiedClaudeScheduler {
     const isOpusRequest =
       requestedModel && typeof requestedModel === 'string'
         ? requestedModel.toLowerCase().includes('opus')
+        : false
+    const isFableRequest =
+      requestedModel && typeof requestedModel === 'string'
+        ? requestedModel.toLowerCase().includes('fable')
         : false
 
     // 如果API Key绑定了专属账户，优先返回
@@ -653,6 +664,18 @@ class UnifiedClaudeScheduler {
           if (isOpusRateLimited) {
             logger.info(
               `🚫 Skipping account ${account.name} (${account.id}) due to active Opus limit`
+            )
+            continue
+          }
+        }
+
+        if (isFableRequest) {
+          const isFableRateLimited = await claudeAccountService.isAccountFableRateLimited(
+            account.id
+          )
+          if (isFableRateLimited) {
+            logger.info(
+              `🚫 Skipping account ${account.name} (${account.id}) due to active Fable limit`
             )
             continue
           }
@@ -1029,6 +1052,18 @@ class UnifiedClaudeScheduler {
           const isOpusRateLimited = await claudeAccountService.isAccountOpusRateLimited(accountId)
           if (isOpusRateLimited) {
             logger.info(`🚫 Account ${accountId} skipped due to active Opus limit (session check)`)
+            return false
+          }
+        }
+
+        if (
+          requestedModel &&
+          typeof requestedModel === 'string' &&
+          requestedModel.toLowerCase().includes('fable')
+        ) {
+          const isFableRateLimited = await claudeAccountService.isAccountFableRateLimited(accountId)
+          if (isFableRateLimited) {
+            logger.info(`🚫 Account ${accountId} skipped due to active Fable limit (session check)`)
             return false
           }
         }
@@ -1516,6 +1551,10 @@ class UnifiedClaudeScheduler {
         requestedModel && typeof requestedModel === 'string'
           ? requestedModel.toLowerCase().includes('opus')
           : false
+      const isFableRequest =
+        requestedModel && typeof requestedModel === 'string'
+          ? requestedModel.toLowerCase().includes('fable')
+          : false
 
       // 获取所有成员账户的详细信息
       for (const memberId of memberIds) {
@@ -1591,6 +1630,18 @@ class UnifiedClaudeScheduler {
             if (isOpusRateLimited) {
               logger.info(
                 `🚫 Skipping group member ${account.name} (${account.id}) due to active Opus limit`
+              )
+              continue
+            }
+          }
+
+          if (accountType === 'claude-official' && isFableRequest) {
+            const isFableRateLimited = await claudeAccountService.isAccountFableRateLimited(
+              account.id
+            )
+            if (isFableRateLimited) {
+              logger.info(
+                `🚫 Skipping group member ${account.name} (${account.id}) due to active Fable limit`
               )
               continue
             }

--- a/tests/claudeAccountFableRateLimit.test.js
+++ b/tests/claudeAccountFableRateLimit.test.js
@@ -1,0 +1,123 @@
+// Regression test for Fable-5 rate-limit isolation.
+//
+// Bug: a `claude-fable-5` 429 (a separate, weekly-scale limit) was routed into the
+// account-wide rate-limit bucket (markAccountRateLimited → schedulable='false'),
+// taking the whole OAuth account offline. Subsequent `claude-opus-4-8` requests then
+// failed with "No available Claude accounts support the requested model".
+//
+// Fix: Fable limits get their own model-scoped bucket (markAccountFableRateLimited),
+// mirroring the Opus bucket, that does NOT disable account-wide scheduling and does
+// NOT set the general rate-limit state that gates every other model.
+
+const mockStore = new Map()
+
+jest.mock('../src/models/redis', () => ({
+  getClaudeAccount: jest.fn(async (id) => mockStore.get(id) || {}),
+  setClaudeAccount: jest.fn(async (id, data) => {
+    mockStore.set(id, { ...data })
+  }),
+  client: {
+    hdel: jest.fn(async () => 1)
+  }
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn()
+}))
+
+// Side-effectful deps the Fable rate-limit methods never touch.
+jest.mock('../src/services/tokenRefreshService', () => ({}))
+jest.mock('../src/utils/tokenRefreshLogger', () => ({}))
+jest.mock('../src/utils/webhookNotifier', () => ({
+  sendAccountAnomalyNotification: jest.fn()
+}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({
+  recordErrorHistory: jest.fn(() => ({ catch: jest.fn() })),
+  markTempUnavailable: jest.fn(() => ({ catch: jest.fn() })),
+  parseRetryAfter: jest.fn(() => null)
+}))
+jest.mock('../src/utils/proxyHelper', () => ({}))
+jest.mock('axios', () => ({}))
+
+// The service constructor starts a cache-cleanup setInterval at load. Unref it so the
+// timer never keeps the Jest process alive (avoids needing --forceExit for this file).
+const _realSetInterval = global.setInterval
+global.setInterval = (fn, ms, ...args) => {
+  const timer = _realSetInterval(fn, ms, ...args)
+  if (timer && typeof timer.unref === 'function') {
+    timer.unref()
+  }
+  return timer
+}
+const claudeAccountService = require('../src/services/account/claudeAccountService')
+global.setInterval = _realSetInterval
+
+const ACCOUNT_ID = 'acct-fable-test'
+const DAY = 24 * 60 * 60 * 1000
+
+const seedActiveAccount = () => {
+  mockStore.clear()
+  mockStore.set(ACCOUNT_ID, {
+    id: ACCOUNT_ID,
+    name: 'test-account',
+    isActive: 'true',
+    status: 'active',
+    schedulable: 'true'
+  })
+}
+
+describe('Fable rate-limit isolation (claudeAccountService)', () => {
+  beforeEach(() => {
+    seedActiveAccount()
+  })
+
+  it('records the Fable bucket without flipping the account-wide kill switch', async () => {
+    // ~3 days out — a weekly-scale limit, exactly the shape that regressed opus.
+    const resetTs = Math.floor((Date.now() + 3 * DAY) / 1000)
+
+    await claudeAccountService.markAccountFableRateLimited(ACCOUNT_ID, resetTs)
+
+    const stored = mockStore.get(ACCOUNT_ID)
+    expect(stored.fableRateLimitedAt).toBeTruthy()
+    expect(stored.fableRateLimitEndAt).toBeTruthy()
+    // The heart of the bug: a Fable limit must NOT disable scheduling account-wide,
+    // and must NOT write the general rate-limit state that blocks every other model.
+    expect(stored.schedulable).not.toBe('false')
+    expect(stored.rateLimitStatus).toBeUndefined()
+    expect(stored.rateLimitAutoStopped).toBeUndefined()
+    expect(stored.rateLimitEndAt).toBeUndefined()
+  })
+
+  it('is fable-limited but NOT general (account-wide) rate-limited', async () => {
+    const resetTs = Math.floor((Date.now() + 3 * DAY) / 1000)
+    await claudeAccountService.markAccountFableRateLimited(ACCOUNT_ID, resetTs)
+
+    expect(await claudeAccountService.isAccountFableRateLimited(ACCOUNT_ID)).toBe(true)
+    // Opus (and every non-fable model) is gated by the GENERAL bucket; a fable limit
+    // must leave it false so opus-4-8 keeps scheduling on this account.
+    expect(await claudeAccountService.isAccountRateLimited(ACCOUNT_ID)).toBe(false)
+    // And it must not leak into the Opus bucket either.
+    expect(await claudeAccountService.isAccountOpusRateLimited(ACCOUNT_ID)).toBe(false)
+  })
+
+  it('auto-clears an expired Fable limit', async () => {
+    const pastTs = Math.floor((Date.now() - 60 * 60 * 1000) / 1000)
+    await claudeAccountService.markAccountFableRateLimited(ACCOUNT_ID, pastTs)
+
+    expect(await claudeAccountService.isAccountFableRateLimited(ACCOUNT_ID)).toBe(false)
+    expect(mockStore.get(ACCOUNT_ID).fableRateLimitEndAt).toBeUndefined()
+  })
+
+  it('surfaces fable status via getAccountFableRateLimitInfo', async () => {
+    const resetTs = Math.floor((Date.now() + 3 * DAY) / 1000)
+    await claudeAccountService.markAccountFableRateLimited(ACCOUNT_ID, resetTs)
+
+    const info = await claudeAccountService.getAccountFableRateLimitInfo(ACCOUNT_ID)
+    expect(info.isRateLimited).toBe(true)
+    expect(info.minutesRemaining).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## 问题

当账号命中 **Fable-5（`claude-fable-5`）** 的限流后，同一账号上的 `claude-opus-4-8`（以及其它所有模型）请求随即全部失败：

```
500 No available Claude accounts support the requested model: claude-opus-4-8
```

## 根因

`claudeRelayService` 处理上游 429 时，只按 `isOpusModelRequest` 把限流分成两类：

- Opus 请求 → `markAccountOpusRateLimited`（仅影响 Opus 路由）
- 其余所有模型 → 账号级 `markAccountRateLimited`，会把 `schedulable` 置为 `false`，停用**整个账号**直到 reset。

Fable-5 拥有**独立的周级限流额度**，其 429 的 reset 往往在数天之后。命中后由于落入账号级分支，整个账号被停用数天，导致 `claude-opus-4-8` 等其它模型在调度阶段找不到可用账号（`_getAllAvailableAccounts` 返回空）而报错。

线上日志印证：某账号因 `claude-fable-5` 的 429 被标记限流，reset 为约 3.7 天之后（周级窗口，而非 5 小时会话窗口），随后 `claude-opus-4-8` 请求即 500。此处 “support the requested model” 的报错文案有一定误导性——实际是账号被整体停用，并非缺少支持该模型的账号。

## 改动

参照 Opus 已有的「独立限流桶」做法，为 Fable 增加对称实现：

- **claudeAccountService**：新增 `markAccountFableRateLimited` / `isAccountFableRateLimited` / `getAccountFableRateLimitInfo` / `clearAccountFableRateLimit` / `clearExpiredFableRateLimit`。仅写入 `fableRateLimitedAt` / `fableRateLimitEndAt`，**不再置 `schedulable=false`**；账号列表接口补充 `fableRateLimitStatus`，重置账号状态时一并清理 fable 字段。
- **unifiedClaudeScheduler**：共享池、粘性会话、分组、专属账号四条路径中，Fable 请求会跳过处于 Fable 限流的账号（与 Opus 对称）。
- **claudeRelayService**：非流式 / 流式中途 / 流式末尾三处 429 分支中，Fable 模型请求改为写入 Fable 专属限流桶，不再改写为账号级限流。

## 效果

Fable-5 限流后：该账号对 Fable 请求会被跳过，但对 `claude-opus-4-8` 等其它模型仍可正常调度，不再出现 “No available Claude accounts” 误报。

## 测试

- 新增 `tests/claudeAccountFableRateLimit.test.js`：验证 Fable 限流仅写入 fable 桶、不置 `schedulable=false`、不触发账号级 `isAccountRateLimited`、过期后自动清除。
- `npm test`：21 个测试套件，253 通过、8 跳过、0 失败。
- ESLint 无告警。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
