### PR TITLE
fix: add explicit id to Dockerfile cache mounts for RAILPACK builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # 🔽 安装依赖 (生产环境) - 使用 BuildKit 缓存加速
-RUN --mount=type=cache,id=backend-npm,target=/root/.npm \
+RUN --mount=type=cache,id=cacheKey=backend-npm,target=/root/.npm \
     npm ci --only=production
 
 # 🎯 前端构建阶段 (与后端依赖并行)
@@ -21,7 +21,7 @@ WORKDIR /app/web/admin-spa
 COPY web/admin-spa/package*.json ./
 
 # 🔽 安装前端依赖 - 使用 BuildKit 缓存加速
-RUN --mount=type=cache,id=frontend-npm,target=/root/.npm \
+RUN --mount=type=cache,id=cacheKey=frontend-npm,target=/root/.npm \
     npm ci
 
 # 📋 复制前端源代码

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # 🔽 安装依赖 (生产环境) - 使用 BuildKit 缓存加速
-RUN --mount=type=cache,target=/root/.npm \
+RUN --mount=type=cache,id=backend-npm,target=/root/.npm \
     npm ci --only=production
 
 # 🎯 前端构建阶段 (与后端依赖并行)
@@ -21,7 +21,7 @@ WORKDIR /app/web/admin-spa
 COPY web/admin-spa/package*.json ./
 
 # 🔽 安装前端依赖 - 使用 BuildKit 缓存加速
-RUN --mount=type=cache,target=/root/.npm \
+RUN --mount=type=cache,id=frontend-npm,target=/root/.npm \
     npm ci
 
 # 📋 复制前端源代码


### PR DESCRIPTION
RAILPACK's Dockerfile parser requires an id on all --mount=type=cache flags. Add distinct ids (backend-npm, frontend-npm) to keep BuildKit cache acceleration while fixing the Railway build failure.