### PR TITLE
fix: 按模型家族独立限流，并禁止专属账号静默回退到共享池

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -44,6 +44,10 @@ const config = {
   claude: {
     apiUrl: process.env.CLAUDE_API_URL || 'https://api.anthropic.com/v1/messages',
     apiVersion: process.env.CLAUDE_API_VERSION || '2023-06-01',
+    // 专属账号不可用时是否回退到共享池。
+    // 默认 false：API Key 绑定了专属账号就必须使用该账号，不可用时直接报错，
+    // 否则「限定账号」的语义会被破坏（请求会静默用到别的账号）。
+    dedicatedAccountFallback: process.env.CLAUDE_DEDICATED_ACCOUNT_FALLBACK === 'true',
     betaHeader:
       process.env.CLAUDE_BETA_HEADER ||
       'claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
@@ -238,7 +242,10 @@ const config = {
     serverErrorTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_5XX_TTL_SECONDS) || 300, // 5xx错误暂停秒数
     overloadTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_OVERLOAD_TTL_SECONDS) || 600, // 529过载暂停秒数
     authErrorTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_AUTH_TTL_SECONDS) || 1800, // 401/403认证错误暂停秒数
-    timeoutTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_TIMEOUT_TTL_SECONDS) || 300 // 504超时暂停秒数
+    timeoutTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_TIMEOUT_TTL_SECONDS) || 300, // 504超时暂停秒数
+    // 上游 retry-after 派生的暂停时长上限（秒）。周级限额的 retry-after 可达数天，
+    // 若不钳制会把账号整整下线数天。长时限额应由账号级/模型级限流桶承担。
+    maxCustomTtlSeconds: parseInt(process.env.UPSTREAM_ERROR_MAX_CUSTOM_TTL_SECONDS) || 1800
   }
 }
 

--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -17,7 +17,7 @@ const {
 const tokenRefreshService = require('../tokenRefreshService')
 const LRUCache = require('../../utils/lruCache')
 const { formatDateWithTimezone, getISOStringWithTimezone } = require('../../utils/dateHelper')
-const { isOpus45OrNewer } = require('../../utils/modelHelper')
+const { isOpus45OrNewer, RATE_LIMITED_MODEL_FAMILIES } = require('../../utils/modelHelper')
 const {
   parseBooleanLike,
   normalizeOptionalNonNegativeInteger,
@@ -550,19 +550,23 @@ class ClaudeAccountService {
       // 处理返回数据，移除敏感信息并添加限流状态和会话窗口信息
       const processedAccounts = await Promise.all(
         accounts.map(async (account) => {
-          const [
-            rateLimitInfo,
-            sessionWindowInfo,
-            opusRateLimitStatus,
-            fableRateLimitStatus,
-            isOverloaded
-          ] = await Promise.all([
-            this.getAccountRateLimitInfo(account.id),
-            this.getSessionWindowInfo(account.id),
-            this.getAccountOpusRateLimitInfo(account.id, account),
-            this.getAccountFableRateLimitInfo(account.id, account),
-            this.isAccountOverloaded(account.id)
-          ])
+          const [rateLimitInfo, sessionWindowInfo, modelRateLimitEntries, isOverloaded] =
+            await Promise.all([
+              this.getAccountRateLimitInfo(account.id),
+              this.getSessionWindowInfo(account.id),
+              Promise.all(
+                RATE_LIMITED_MODEL_FAMILIES.map(async (family) => [
+                  family,
+                  await this.getAccountModelRateLimitInfo(account.id, family, account)
+                ])
+              ),
+              this.isAccountOverloaded(account.id)
+            ])
+
+          // 各模型家族的独立限流状态（opus/sonnet/haiku/fable）
+          const modelRateLimitStatus = Object.fromEntries(modelRateLimitEntries)
+          const opusRateLimitStatus = modelRateLimitStatus.opus
+          const fableRateLimitStatus = modelRateLimitStatus.fable
 
           // 构建 Claude Usage 快照（从 Redis 读取）
           const claudeUsage = this.buildClaudeUsageSnapshot(account)
@@ -624,6 +628,8 @@ class ClaudeAccountService {
             opusRateLimitStatus,
             // Fable 专属限流状态（仅影响 Fable 模型路由）
             fableRateLimitStatus,
+            // 各模型家族的独立限流状态（opus/sonnet/haiku/fable）
+            modelRateLimitStatus,
             // 过载状态（429/529 自动保护）
             overloadStatus: {
               isOverloaded,
@@ -1496,338 +1502,217 @@ class ClaudeAccountService {
     }
   }
 
-  // 🚫 标记账号的 Opus 限流状态（不影响其他模型调度）
-  async markAccountOpusRateLimited(accountId, rateLimitResetTimestamp = null) {
+  // 🧩 按模型家族存储的限流字段名（沿用既有 opus/fable 字段名，向后兼容旧数据）
+  _modelRateLimitFields(family) {
+    return {
+      atField: `${family}RateLimitedAt`,
+      endField: `${family}RateLimitEndAt`
+    }
+  }
+
+  // 🚫 标记账号在某个模型家族上的限流（仅影响该模型路由，不停用整个账号）
+  async markAccountModelRateLimited(accountId, family, rateLimitResetTimestamp = null) {
     try {
       const accountData = await redis.getClaudeAccount(accountId)
       if (!accountData || Object.keys(accountData).length === 0) {
         throw new Error('Account not found')
       }
 
+      const { atField, endField } = this._modelRateLimitFields(family)
       const updatedAccountData = { ...accountData }
-      const now = new Date()
-      updatedAccountData.opusRateLimitedAt = now.toISOString()
+      updatedAccountData[atField] = new Date().toISOString()
 
       if (rateLimitResetTimestamp) {
         const resetTime = new Date(rateLimitResetTimestamp * 1000)
-        updatedAccountData.opusRateLimitEndAt = resetTime.toISOString()
+        updatedAccountData[endField] = resetTime.toISOString()
         logger.warn(
-          `🚫 Account ${accountData.name} (${accountId}) reached Opus weekly cap, resets at ${resetTime.toISOString()}`
+          `🚫 Account ${accountData.name} (${accountId}) reached ${family} model cap, resets at ${resetTime.toISOString()}`
         )
       } else {
         // 如果缺少准确时间戳，保留现有值但记录警告，便于后续人工干预
         logger.warn(
-          `⚠️ Account ${accountData.name} (${accountId}) reported Opus limit without reset timestamp`
+          `⚠️ Account ${accountData.name} (${accountId}) reported ${family} limit without reset timestamp`
         )
       }
 
       await redis.setClaudeAccount(accountId, updatedAccountData)
       return { success: true }
     } catch (error) {
-      logger.error(`❌ Failed to mark Opus rate limit for account: ${accountId}`, error)
+      logger.error(`❌ Failed to mark ${family} rate limit for account: ${accountId}`, error)
       throw error
     }
+  }
+
+  // ✅ 清除账号在某个模型家族上的限流状态
+  async clearAccountModelRateLimit(accountId, family) {
+    try {
+      const accountData = await redis.getClaudeAccount(accountId)
+      if (!accountData || Object.keys(accountData).length === 0) {
+        return { success: true }
+      }
+
+      const { atField, endField } = this._modelRateLimitFields(family)
+      const updatedAccountData = { ...accountData }
+      delete updatedAccountData[atField]
+      delete updatedAccountData[endField]
+
+      await redis.setClaudeAccount(accountId, updatedAccountData)
+
+      const redisKey = `claude:account:${accountId}`
+      if (redis.client && typeof redis.client.hdel === 'function') {
+        await redis.client.hdel(redisKey, atField, endField)
+      }
+
+      logger.info(`✅ Cleared ${family} rate limit state for account ${accountId}`)
+      return { success: true }
+    } catch (error) {
+      logger.error(`❌ Failed to clear ${family} rate limit for account: ${accountId}`, error)
+      throw error
+    }
+  }
+
+  // 📊 获取账号在某个模型家族上的限流信息（自动清理过期状态）
+  async getAccountModelRateLimitInfo(accountId, family, accountData = null) {
+    try {
+      const { atField, endField } = this._modelRateLimitFields(family)
+      const data = accountData || (await redis.getClaudeAccount(accountId))
+      if (!data || Object.keys(data).length === 0 || !data[endField]) {
+        return { isRateLimited: false, rateLimitedAt: null, resetAt: null, minutesRemaining: 0 }
+      }
+
+      const resetAtMs = Date.parse(data[endField])
+      if (Number.isNaN(resetAtMs)) {
+        return {
+          isRateLimited: false,
+          rateLimitedAt: data[atField] || null,
+          resetAt: null,
+          minutesRemaining: 0
+        }
+      }
+
+      const nowMs = Date.now()
+      if (nowMs >= resetAtMs) {
+        // 自动清理过期标记，避免前端持续显示陈旧状态
+        await this.clearAccountModelRateLimit(accountId, family).catch(() => {})
+        return {
+          isRateLimited: false,
+          rateLimitedAt: data[atField] || null,
+          resetAt: data[endField],
+          minutesRemaining: 0
+        }
+      }
+
+      return {
+        isRateLimited: true,
+        rateLimitedAt: data[atField] || null,
+        resetAt: data[endField],
+        minutesRemaining: Math.max(0, Math.ceil((resetAtMs - nowMs) / (1000 * 60)))
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to get ${family} rate limit info for account: ${accountId}`, error)
+      return { isRateLimited: false, rateLimitedAt: null, resetAt: null, minutesRemaining: 0 }
+    }
+  }
+
+  // 🔍 检查账号在某个模型家族上是否处于限流状态（自动清理过期标记）
+  async isAccountModelRateLimited(accountId, family) {
+    try {
+      const { endField } = this._modelRateLimitFields(family)
+      const accountData = await redis.getClaudeAccount(accountId)
+      if (!accountData || Object.keys(accountData).length === 0 || !accountData[endField]) {
+        return false
+      }
+
+      const resetTime = new Date(accountData[endField])
+      if (Number.isNaN(resetTime.getTime()) || new Date() >= resetTime) {
+        await this.clearAccountModelRateLimit(accountId, family)
+        return false
+      }
+
+      return true
+    } catch (error) {
+      logger.error(
+        `❌ Failed to check ${family} rate limit status for account: ${accountId}`,
+        error
+      )
+      return false
+    }
+  }
+
+  // ♻️ 检查并清理已过期的模型家族限流标记
+  async clearExpiredModelRateLimit(accountId, family) {
+    try {
+      const { endField } = this._modelRateLimitFields(family)
+      const accountData = await redis.getClaudeAccount(accountId)
+      if (!accountData || Object.keys(accountData).length === 0 || !accountData[endField]) {
+        return { success: true }
+      }
+
+      const resetTime = new Date(accountData[endField])
+      if (Number.isNaN(resetTime.getTime()) || new Date() >= resetTime) {
+        await this.clearAccountModelRateLimit(accountId, family)
+      }
+
+      return { success: true }
+    } catch (error) {
+      logger.error(
+        `❌ Failed to clear expired ${family} rate limit for account: ${accountId}`,
+        error
+      )
+      throw error
+    }
+  }
+
+  // ---- 以下为按模型家族限流的兼容封装：保持既有调用方与 Redis 字段名不变 ----
+
+  // 🚫 标记账号的 Opus 限流状态（不影响其他模型调度）
+  async markAccountOpusRateLimited(accountId, rateLimitResetTimestamp = null) {
+    return this.markAccountModelRateLimited(accountId, 'opus', rateLimitResetTimestamp)
   }
 
   // ✅ 清除账号的 Opus 限流状态
   async clearAccountOpusRateLimit(accountId) {
-    try {
-      const accountData = await redis.getClaudeAccount(accountId)
-      if (!accountData || Object.keys(accountData).length === 0) {
-        return { success: true }
-      }
-
-      const updatedAccountData = { ...accountData }
-      delete updatedAccountData.opusRateLimitedAt
-      delete updatedAccountData.opusRateLimitEndAt
-
-      await redis.setClaudeAccount(accountId, updatedAccountData)
-
-      const redisKey = `claude:account:${accountId}`
-      if (redis.client && typeof redis.client.hdel === 'function') {
-        await redis.client.hdel(redisKey, 'opusRateLimitedAt', 'opusRateLimitEndAt')
-      }
-
-      logger.info(`✅ Cleared Opus rate limit state for account ${accountId}`)
-      return { success: true }
-    } catch (error) {
-      logger.error(`❌ Failed to clear Opus rate limit for account: ${accountId}`, error)
-      throw error
-    }
+    return this.clearAccountModelRateLimit(accountId, 'opus')
   }
 
   // 📊 获取账号 Opus 限流信息（自动清理过期状态）
   async getAccountOpusRateLimitInfo(accountId, accountData = null) {
-    try {
-      const data = accountData || (await redis.getClaudeAccount(accountId))
-      if (!data || Object.keys(data).length === 0 || !data.opusRateLimitEndAt) {
-        return {
-          isRateLimited: false,
-          rateLimitedAt: null,
-          resetAt: null,
-          minutesRemaining: 0
-        }
-      }
-
-      const resetAtMs = Date.parse(data.opusRateLimitEndAt)
-      if (Number.isNaN(resetAtMs)) {
-        return {
-          isRateLimited: false,
-          rateLimitedAt: data.opusRateLimitedAt || null,
-          resetAt: null,
-          minutesRemaining: 0
-        }
-      }
-
-      const nowMs = Date.now()
-      if (nowMs >= resetAtMs) {
-        // 自动清理过期标记，避免前端持续显示陈旧状态
-        await this.clearAccountOpusRateLimit(accountId).catch(() => {})
-        return {
-          isRateLimited: false,
-          rateLimitedAt: data.opusRateLimitedAt || null,
-          resetAt: data.opusRateLimitEndAt,
-          minutesRemaining: 0
-        }
-      }
-
-      return {
-        isRateLimited: true,
-        rateLimitedAt: data.opusRateLimitedAt || null,
-        resetAt: data.opusRateLimitEndAt,
-        minutesRemaining: Math.max(0, Math.ceil((resetAtMs - nowMs) / (1000 * 60)))
-      }
-    } catch (error) {
-      logger.error(`❌ Failed to get Opus rate limit info for account: ${accountId}`, error)
-      return {
-        isRateLimited: false,
-        rateLimitedAt: null,
-        resetAt: null,
-        minutesRemaining: 0
-      }
-    }
+    return this.getAccountModelRateLimitInfo(accountId, 'opus', accountData)
   }
 
   // 🔍 检查账号是否处于 Opus 限流状态（自动清理过期标记）
   async isAccountOpusRateLimited(accountId) {
-    try {
-      const accountData = await redis.getClaudeAccount(accountId)
-      if (!accountData || Object.keys(accountData).length === 0) {
-        return false
-      }
-
-      if (!accountData.opusRateLimitEndAt) {
-        return false
-      }
-
-      const resetTime = new Date(accountData.opusRateLimitEndAt)
-      if (Number.isNaN(resetTime.getTime())) {
-        await this.clearAccountOpusRateLimit(accountId)
-        return false
-      }
-
-      const now = new Date()
-      if (now >= resetTime) {
-        await this.clearAccountOpusRateLimit(accountId)
-        return false
-      }
-
-      return true
-    } catch (error) {
-      logger.error(`❌ Failed to check Opus rate limit status for account: ${accountId}`, error)
-      return false
-    }
+    return this.isAccountModelRateLimited(accountId, 'opus')
   }
 
   // ♻️ 检查并清理已过期的 Opus 限流标记
   async clearExpiredOpusRateLimit(accountId) {
-    try {
-      const accountData = await redis.getClaudeAccount(accountId)
-      if (!accountData || Object.keys(accountData).length === 0) {
-        return { success: true }
-      }
-
-      if (!accountData.opusRateLimitEndAt) {
-        return { success: true }
-      }
-
-      const resetTime = new Date(accountData.opusRateLimitEndAt)
-      if (Number.isNaN(resetTime.getTime()) || new Date() >= resetTime) {
-        await this.clearAccountOpusRateLimit(accountId)
-      }
-
-      return { success: true }
-    } catch (error) {
-      logger.error(`❌ Failed to clear expired Opus rate limit for account: ${accountId}`, error)
-      throw error
-    }
+    return this.clearExpiredModelRateLimit(accountId, 'opus')
   }
 
   // 🚫 标记账号的 Fable 限流状态（不影响其他模型调度）
   async markAccountFableRateLimited(accountId, rateLimitResetTimestamp = null) {
-    try {
-      const accountData = await redis.getClaudeAccount(accountId)
-      if (!accountData || Object.keys(accountData).length === 0) {
-        throw new Error('Account not found')
-      }
-
-      const updatedAccountData = { ...accountData }
-      const now = new Date()
-      updatedAccountData.fableRateLimitedAt = now.toISOString()
-
-      if (rateLimitResetTimestamp) {
-        const resetTime = new Date(rateLimitResetTimestamp * 1000)
-        updatedAccountData.fableRateLimitEndAt = resetTime.toISOString()
-        logger.warn(
-          `🚫 Account ${accountData.name} (${accountId}) reached Fable weekly cap, resets at ${resetTime.toISOString()}`
-        )
-      } else {
-        // 如果缺少准确时间戳，保留现有值但记录警告，便于后续人工干预
-        logger.warn(
-          `⚠️ Account ${accountData.name} (${accountId}) reported Fable limit without reset timestamp`
-        )
-      }
-
-      await redis.setClaudeAccount(accountId, updatedAccountData)
-      return { success: true }
-    } catch (error) {
-      logger.error(`❌ Failed to mark Fable rate limit for account: ${accountId}`, error)
-      throw error
-    }
+    return this.markAccountModelRateLimited(accountId, 'fable', rateLimitResetTimestamp)
   }
 
   // ✅ 清除账号的 Fable 限流状态
   async clearAccountFableRateLimit(accountId) {
-    try {
-      const accountData = await redis.getClaudeAccount(accountId)
-      if (!accountData || Object.keys(accountData).length === 0) {
-        return { success: true }
-      }
-
-      const updatedAccountData = { ...accountData }
-      delete updatedAccountData.fableRateLimitedAt
-      delete updatedAccountData.fableRateLimitEndAt
-
-      await redis.setClaudeAccount(accountId, updatedAccountData)
-
-      const redisKey = `claude:account:${accountId}`
-      if (redis.client && typeof redis.client.hdel === 'function') {
-        await redis.client.hdel(redisKey, 'fableRateLimitedAt', 'fableRateLimitEndAt')
-      }
-
-      logger.info(`✅ Cleared Fable rate limit state for account ${accountId}`)
-      return { success: true }
-    } catch (error) {
-      logger.error(`❌ Failed to clear Fable rate limit for account: ${accountId}`, error)
-      throw error
-    }
+    return this.clearAccountModelRateLimit(accountId, 'fable')
   }
 
   // 📊 获取账号 Fable 限流信息（自动清理过期状态）
   async getAccountFableRateLimitInfo(accountId, accountData = null) {
-    try {
-      const data = accountData || (await redis.getClaudeAccount(accountId))
-      if (!data || Object.keys(data).length === 0 || !data.fableRateLimitEndAt) {
-        return {
-          isRateLimited: false,
-          rateLimitedAt: null,
-          resetAt: null,
-          minutesRemaining: 0
-        }
-      }
-
-      const resetAtMs = Date.parse(data.fableRateLimitEndAt)
-      if (Number.isNaN(resetAtMs)) {
-        return {
-          isRateLimited: false,
-          rateLimitedAt: data.fableRateLimitedAt || null,
-          resetAt: null,
-          minutesRemaining: 0
-        }
-      }
-
-      const nowMs = Date.now()
-      if (nowMs >= resetAtMs) {
-        // 自动清理过期标记，避免前端持续显示陈旧状态
-        await this.clearAccountFableRateLimit(accountId).catch(() => {})
-        return {
-          isRateLimited: false,
-          rateLimitedAt: data.fableRateLimitedAt || null,
-          resetAt: data.fableRateLimitEndAt,
-          minutesRemaining: 0
-        }
-      }
-
-      return {
-        isRateLimited: true,
-        rateLimitedAt: data.fableRateLimitedAt || null,
-        resetAt: data.fableRateLimitEndAt,
-        minutesRemaining: Math.max(0, Math.ceil((resetAtMs - nowMs) / (1000 * 60)))
-      }
-    } catch (error) {
-      logger.error(`❌ Failed to get Fable rate limit info for account: ${accountId}`, error)
-      return {
-        isRateLimited: false,
-        rateLimitedAt: null,
-        resetAt: null,
-        minutesRemaining: 0
-      }
-    }
+    return this.getAccountModelRateLimitInfo(accountId, 'fable', accountData)
   }
 
   // 🔍 检查账号是否处于 Fable 限流状态（自动清理过期标记）
   async isAccountFableRateLimited(accountId) {
-    try {
-      const accountData = await redis.getClaudeAccount(accountId)
-      if (!accountData || Object.keys(accountData).length === 0) {
-        return false
-      }
-
-      if (!accountData.fableRateLimitEndAt) {
-        return false
-      }
-
-      const resetTime = new Date(accountData.fableRateLimitEndAt)
-      if (Number.isNaN(resetTime.getTime())) {
-        await this.clearAccountFableRateLimit(accountId)
-        return false
-      }
-
-      const now = new Date()
-      if (now >= resetTime) {
-        await this.clearAccountFableRateLimit(accountId)
-        return false
-      }
-
-      return true
-    } catch (error) {
-      logger.error(`❌ Failed to check Fable rate limit status for account: ${accountId}`, error)
-      return false
-    }
+    return this.isAccountModelRateLimited(accountId, 'fable')
   }
 
   // ♻️ 检查并清理已过期的 Fable 限流标记
   async clearExpiredFableRateLimit(accountId) {
-    try {
-      const accountData = await redis.getClaudeAccount(accountId)
-      if (!accountData || Object.keys(accountData).length === 0) {
-        return { success: true }
-      }
-
-      if (!accountData.fableRateLimitEndAt) {
-        return { success: true }
-      }
-
-      const resetTime = new Date(accountData.fableRateLimitEndAt)
-      if (Number.isNaN(resetTime.getTime()) || new Date() >= resetTime) {
-        await this.clearAccountFableRateLimit(accountId)
-      }
-
-      return { success: true }
-    } catch (error) {
-      logger.error(`❌ Failed to clear expired Fable rate limit for account: ${accountId}`, error)
-      throw error
-    }
+    return this.clearExpiredModelRateLimit(accountId, 'fable')
   }
 
   // ✅ 移除账号的限流状态
@@ -2783,10 +2668,11 @@ class ClaudeAccountService {
       delete updatedAccountData.tempErrorAt
       delete updatedAccountData.sessionWindowStart
       delete updatedAccountData.sessionWindowEnd
-      delete updatedAccountData.opusRateLimitedAt
-      delete updatedAccountData.opusRateLimitEndAt
-      delete updatedAccountData.fableRateLimitedAt
-      delete updatedAccountData.fableRateLimitEndAt
+      for (const family of RATE_LIMITED_MODEL_FAMILIES) {
+        const { atField, endField } = this._modelRateLimitFields(family)
+        delete updatedAccountData[atField]
+        delete updatedAccountData[endField]
+      }
       delete updatedAccountData.lastOverloadAt
 
       // 保存更新后的账户数据
@@ -2803,10 +2689,10 @@ class ClaudeAccountService {
         'tempErrorAt',
         'sessionWindowStart',
         'sessionWindowEnd',
-        'opusRateLimitedAt',
-        'opusRateLimitEndAt',
-        'fableRateLimitedAt',
-        'fableRateLimitEndAt',
+        ...RATE_LIMITED_MODEL_FAMILIES.flatMap((family) => [
+          `${family}RateLimitedAt`,
+          `${family}RateLimitEndAt`
+        ]),
         'lastOverloadAt',
         // 新的独立标记
         'rateLimitAutoStopped',

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -8,6 +8,7 @@ const unifiedClaudeScheduler = require('../scheduler/unifiedClaudeScheduler')
 const sessionHelper = require('../../utils/sessionHelper')
 const logger = require('../../utils/logger')
 const config = require('../../../config/config')
+const { getRateLimitModelFamily } = require('../../utils/modelHelper')
 const claudeCodeHeadersService = require('../claudeCodeHeadersService')
 const redis = require('../../models/redis')
 const ClaudeCodeValidator = require('../../validators/clients/claudeCodeValidator')
@@ -472,10 +473,9 @@ class ClaudeRelayService {
         requestedModel: requestBody.model
       })
 
-      const isOpusModelRequest =
-        typeof requestBody?.model === 'string' && requestBody.model.toLowerCase().includes('opus')
-      const isFableModelRequest =
-        typeof requestBody?.model === 'string' && requestBody.model.toLowerCase().includes('fable')
+      // 请求模型所属的限流家族（opus/sonnet/haiku/fable），决定 429 记入哪个限流桶
+      const requestModelFamily = getRateLimitModelFamily(requestBody?.model)
+      const isOpusModelRequest = requestModelFamily === 'opus'
 
       // 生成会话哈希用于sticky会话
       const sessionHash = sessionHelper.generateSessionHash(requestBody)
@@ -500,6 +500,20 @@ class ClaudeRelayService {
             body: JSON.stringify({
               error: 'upstream_rate_limited',
               message: limitMessage
+            }),
+            accountId: error.accountId
+          }
+        }
+        if (error.code === 'CLAUDE_DEDICATED_UNAVAILABLE') {
+          logger.warn(
+            `🚫 Dedicated account ${error.accountId} is unavailable (${error.reason}) for API key ${apiKeyData.name}, returning 503`
+          )
+          return {
+            statusCode: 503,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              error: 'dedicated_account_unavailable',
+              message: `该 API Key 绑定的专属账号当前不可用（${error.reason}），请稍后重试。`
             }),
             accountId: error.accountId
           }
@@ -832,13 +846,18 @@ class ClaudeRelayService {
               : null
             const parsedResetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN
 
-            if (isOpusModelRequest && !Number.isNaN(parsedResetTimestamp)) {
-              await claudeAccountService.markAccountOpusRateLimited(accountId, parsedResetTimestamp)
+            if (requestModelFamily && !Number.isNaN(parsedResetTimestamp)) {
+              // 模型级限额：只停用该模型家族，不改写为账号级限流
+              await claudeAccountService.markAccountModelRateLimited(
+                accountId,
+                requestModelFamily,
+                parsedResetTimestamp
+              )
               logger.warn(
-                `🚫 Account ${accountId} hit Opus limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
+                `🚫 Account ${accountId} hit ${requestModelFamily} limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
               )
 
-              if (isDedicatedOfficialAccount) {
+              if (isOpusModelRequest && isDedicatedOfficialAccount) {
                 const limitMessage = this._buildOpusLimitMessage(parsedResetTimestamp)
                 return {
                   statusCode: 403,
@@ -850,14 +869,6 @@ class ClaudeRelayService {
                   accountId
                 }
               }
-            } else if (isFableModelRequest && !Number.isNaN(parsedResetTimestamp)) {
-              await claudeAccountService.markAccountFableRateLimited(
-                accountId,
-                parsedResetTimestamp
-              )
-              logger.warn(
-                `🚫 Account ${accountId} hit Fable limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
-              )
             } else {
               isRateLimited = true
               if (!Number.isNaN(parsedResetTimestamp)) {
@@ -1892,6 +1903,23 @@ class ClaudeRelayService {
           responseStream.end()
           return
         }
+        if (error.code === 'CLAUDE_DEDICATED_UNAVAILABLE') {
+          logger.warn(
+            `🚫 [Stream] Dedicated account ${error.accountId} is unavailable (${error.reason}) for API key ${apiKeyData.name}, returning 503`
+          )
+          if (!responseStream.headersSent) {
+            responseStream.status(503)
+            responseStream.setHeader('Content-Type', 'application/json')
+          }
+          responseStream.write(
+            JSON.stringify({
+              error: 'dedicated_account_unavailable',
+              message: `该 API Key 绑定的专属账号当前不可用（${error.reason}），请稍后重试。`
+            })
+          )
+          responseStream.end()
+          return
+        }
         throw error
       }
       const { accountId } = accountSelection
@@ -2114,10 +2142,9 @@ class ClaudeRelayService {
     // 获取账户信息用于统一 User-Agent
     const account = await claudeAccountService.getAccount(accountId)
 
-    const isOpusModelRequest =
-      typeof body?.model === 'string' && body.model.toLowerCase().includes('opus')
-    const isFableModelRequest =
-      typeof body?.model === 'string' && body.model.toLowerCase().includes('fable')
+    // 请求模型所属的限流家族（opus/sonnet/haiku/fable），决定 429 记入哪个限流桶
+    const requestModelFamily = getRateLimitModelFamily(body?.model)
+    const isOpusModelRequest = requestModelFamily === 'opus'
 
     // 使用公共方法准备请求头和 payload
     const prepared = await this._prepareRequestHeadersAndPayload(
@@ -2223,18 +2250,20 @@ class ClaudeRelayService {
               : null
             const parsedResetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN
 
-            if (isOpusModelRequest) {
+            if (requestModelFamily) {
               if (!Number.isNaN(parsedResetTimestamp)) {
-                await claudeAccountService.markAccountOpusRateLimited(
+                // 模型级限额：只停用该模型家族，不改写为账号级限流
+                await claudeAccountService.markAccountModelRateLimited(
                   accountId,
+                  requestModelFamily,
                   parsedResetTimestamp
                 )
                 logger.warn(
-                  `🚫 [Stream] Account ${accountId} hit Opus limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
+                  `🚫 [Stream] Account ${accountId} hit ${requestModelFamily} limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
                 )
               }
 
-              if (isDedicatedOfficialAccount) {
+              if (isOpusModelRequest && isDedicatedOfficialAccount) {
                 const limitMessage = this._buildOpusLimitMessage(parsedResetTimestamp)
                 if (!responseStream.headersSent) {
                   responseStream.status(403)
@@ -2249,16 +2278,6 @@ class ClaudeRelayService {
                 responseStream.end()
                 resolve()
                 return
-              }
-            } else if (isFableModelRequest) {
-              if (!Number.isNaN(parsedResetTimestamp)) {
-                await claudeAccountService.markAccountFableRateLimited(
-                  accountId,
-                  parsedResetTimestamp
-                )
-                logger.warn(
-                  `🚫 [Stream] Account ${accountId} hit Fable limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
-                )
               }
             } else {
               const rateLimitResetTimestamp = Number.isNaN(parsedResetTimestamp)
@@ -2933,18 +2952,15 @@ class ClaudeRelayService {
               : null
             const parsedResetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN
 
-            if (isOpusModelRequest && !Number.isNaN(parsedResetTimestamp)) {
-              await claudeAccountService.markAccountOpusRateLimited(accountId, parsedResetTimestamp)
-              logger.warn(
-                `🚫 [Stream] Account ${accountId} hit Opus limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
-              )
-            } else if (isFableModelRequest && !Number.isNaN(parsedResetTimestamp)) {
-              await claudeAccountService.markAccountFableRateLimited(
+            if (requestModelFamily && !Number.isNaN(parsedResetTimestamp)) {
+              // 模型级限额：只停用该模型家族，不改写为账号级限流
+              await claudeAccountService.markAccountModelRateLimited(
                 accountId,
+                requestModelFamily,
                 parsedResetTimestamp
               )
               logger.warn(
-                `🚫 [Stream] Account ${accountId} hit Fable limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
+                `🚫 [Stream] Account ${accountId} hit ${requestModelFamily} limit, resets at ${new Date(parsedResetTimestamp * 1000).toISOString()}`
               )
             } else if (this._isAgentViewAuxiliaryRequest(body, clientHeaders)) {
               logger.warn(

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -5,9 +5,14 @@ const ccrAccountService = require('../account/ccrAccountService')
 const accountGroupService = require('../accountGroupService')
 const redis = require('../../models/redis')
 const logger = require('../../utils/logger')
-const { parseVendorPrefixedModel, isOpus45OrNewer } = require('../../utils/modelHelper')
+const {
+  parseVendorPrefixedModel,
+  isOpus45OrNewer,
+  getRateLimitModelFamily
+} = require('../../utils/modelHelper')
 const { isSchedulable, sortAccountsByPriority } = require('../../utils/commonHelper')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
+const config = require('../../../config/config')
 
 /**
  * Check if account is Pro (not Max)
@@ -229,14 +234,8 @@ class UnifiedClaudeScheduler {
       logger.debug(
         `🔍 Model parsing - Original: ${requestedModel}, Vendor: ${vendor}, Effective: ${effectiveModel}`
       )
-      const isOpusRequest =
-        effectiveModel && typeof effectiveModel === 'string'
-          ? effectiveModel.toLowerCase().includes('opus')
-          : false
-      const isFableRequest =
-        effectiveModel && typeof effectiveModel === 'string'
-          ? effectiveModel.toLowerCase().includes('fable')
-          : false
+      // 请求模型所属的限流家族（opus/sonnet/haiku/fable）；null 表示未知模型
+      const requestedModelFamily = getRateLimitModelFamily(effectiveModel)
 
       // 如果是 CCR 前缀，只在 CCR 账户池中选择
       if (vendor === 'ccr') {
@@ -260,52 +259,98 @@ class UnifiedClaudeScheduler {
         }
 
         // 普通专属账户
+        //
+        // 专属账号一旦不可用，必须显式报错，绝不能静默回退到共享池，否则
+        // 「把 API Key 限定到某个账号」的语义会被破坏（请求会用到别的账号）。
+        //
+        // 历史 bug：markAccountRateLimited 会同时置 schedulable=false 并写入 temp_unavailable，
+        // 而旧代码先判断 temp_unavailable 且仅打日志后继续向下执行，导致
+        // CLAUDE_DEDICATED_RATE_LIMITED 永远不会抛出，专属 Key 被静默回退到共享池。
         const boundAccount = await redis.getClaudeAccount(apiKeyData.claudeAccountId)
-        if (boundAccount && boundAccount.isActive === 'true' && boundAccount.status !== 'error') {
-          // 检查是否临时不可用
+        const allowDedicatedFallback = config.claude?.dedicatedAccountFallback === true
+
+        const dedicatedUnavailableError = (reason) => {
+          const error = new Error(`Dedicated Claude account is unavailable (${reason})`)
+          error.code = 'CLAUDE_DEDICATED_UNAVAILABLE'
+          error.accountId = apiKeyData.claudeAccountId
+          error.reason = reason
+          return error
+        }
+
+        if (!boundAccount || boundAccount.isActive !== 'true' || boundAccount.status === 'error') {
+          logger.warn(
+            `⚠️ Bound Claude OAuth account ${apiKeyData.claudeAccountId} is not available (isActive: ${boundAccount?.isActive}, status: ${boundAccount?.status})`
+          )
+          if (!allowDedicatedFallback) {
+            throw dedicatedUnavailableError('inactive_or_error')
+          }
+        } else {
+          // 1) 限流优先判断（必须早于 temp_unavailable / schedulable 判断）
+          const rateLimitAutoStopped = boundAccount.rateLimitAutoStopped === 'true'
+          const isRateLimited = await claudeAccountService.isAccountRateLimited(boundAccount.id)
+          if (isRateLimited || (rateLimitAutoStopped && !isSchedulable(boundAccount.schedulable))) {
+            const rateInfo = await claudeAccountService.getAccountRateLimitInfo(boundAccount.id)
+            const error = new Error('Dedicated Claude account is rate limited')
+            error.code = 'CLAUDE_DEDICATED_RATE_LIMITED'
+            error.accountId = boundAccount.id
+            error.rateLimitEndAt = rateInfo?.rateLimitEndAt || boundAccount.rateLimitEndAt || null
+            throw error
+          }
+
+          // 2) 请求模型所属家族的独立限流（opus/sonnet/haiku/fable）
+          if (requestedModelFamily) {
+            await claudeAccountService.clearExpiredModelRateLimit(
+              boundAccount.id,
+              requestedModelFamily
+            )
+            const isModelRateLimited = await claudeAccountService.isAccountModelRateLimited(
+              boundAccount.id,
+              requestedModelFamily
+            )
+            if (isModelRateLimited) {
+              const info = await claudeAccountService.getAccountModelRateLimitInfo(
+                boundAccount.id,
+                requestedModelFamily
+              )
+              const error = new Error(
+                `Dedicated Claude account reached its ${requestedModelFamily} model limit`
+              )
+              error.code = 'CLAUDE_DEDICATED_RATE_LIMITED'
+              error.accountId = boundAccount.id
+              error.rateLimitEndAt = info?.resetAt || null
+              error.modelFamily = requestedModelFamily
+              throw error
+            }
+          }
+
+          // 3) 临时不可用（5xx / 529 / 超时等短暂抖动）
           const isTempUnavailable = await this.isAccountTemporarilyUnavailable(
             boundAccount.id,
             'claude-official'
           )
           if (isTempUnavailable) {
             logger.warn(
-              `⏱️ Bound Claude OAuth account ${boundAccount.id} is temporarily unavailable, falling back to pool`
+              `⏱️ Bound Claude OAuth account ${boundAccount.id} is temporarily unavailable`
             )
-          } else {
-            const isRateLimited = await claudeAccountService.isAccountRateLimited(boundAccount.id)
-            if (isRateLimited) {
-              const rateInfo = await claudeAccountService.getAccountRateLimitInfo(boundAccount.id)
-              const error = new Error('Dedicated Claude account is rate limited')
-              error.code = 'CLAUDE_DEDICATED_RATE_LIMITED'
-              error.accountId = boundAccount.id
-              error.rateLimitEndAt = rateInfo?.rateLimitEndAt || boundAccount.rateLimitEndAt || null
-              throw error
+            if (!allowDedicatedFallback) {
+              throw dedicatedUnavailableError('temporarily_unavailable')
             }
-
-            if (!isSchedulable(boundAccount.schedulable)) {
-              logger.warn(
-                `⚠️ Bound Claude OAuth account ${apiKeyData.claudeAccountId} is not schedulable (schedulable: ${boundAccount?.schedulable}), falling back to pool`
-              )
-            } else {
-              if (isOpusRequest) {
-                await claudeAccountService.clearExpiredOpusRateLimit(boundAccount.id)
-              }
-              if (isFableRequest) {
-                await claudeAccountService.clearExpiredFableRateLimit(boundAccount.id)
-              }
-              logger.info(
-                `🎯 Using bound dedicated Claude OAuth account: ${boundAccount.name} (${apiKeyData.claudeAccountId}) for API key ${apiKeyData.name}`
-              )
-              return {
-                accountId: apiKeyData.claudeAccountId,
-                accountType: 'claude-official'
-              }
+          } else if (!isSchedulable(boundAccount.schedulable)) {
+            logger.warn(
+              `⚠️ Bound Claude OAuth account ${apiKeyData.claudeAccountId} is not schedulable (schedulable: ${boundAccount?.schedulable})`
+            )
+            if (!allowDedicatedFallback) {
+              throw dedicatedUnavailableError('not_schedulable')
+            }
+          } else {
+            logger.info(
+              `🎯 Using bound dedicated Claude OAuth account: ${boundAccount.name} (${apiKeyData.claudeAccountId}) for API key ${apiKeyData.name}`
+            )
+            return {
+              accountId: apiKeyData.claudeAccountId,
+              accountType: 'claude-official'
             }
           }
-        } else {
-          logger.warn(
-            `⚠️ Bound Claude OAuth account ${apiKeyData.claudeAccountId} is not available (isActive: ${boundAccount?.isActive}, status: ${boundAccount?.status}), falling back to pool`
-          )
         }
       }
 
@@ -469,14 +514,8 @@ class UnifiedClaudeScheduler {
   // 📋 获取所有可用账户（合并官方和Console）
   async _getAllAvailableAccounts(apiKeyData, requestedModel = null, includeCcr = false) {
     const availableAccounts = []
-    const isOpusRequest =
-      requestedModel && typeof requestedModel === 'string'
-        ? requestedModel.toLowerCase().includes('opus')
-        : false
-    const isFableRequest =
-      requestedModel && typeof requestedModel === 'string'
-        ? requestedModel.toLowerCase().includes('fable')
-        : false
+    // 请求模型所属的限流家族（opus/sonnet/haiku/fable）
+    const requestedModelFamily = getRateLimitModelFamily(requestedModel)
 
     // 如果API Key绑定了专属账户，优先返回
     // 1. 检查Claude OAuth账户绑定
@@ -505,7 +544,19 @@ class UnifiedClaudeScheduler {
             throw error
           }
 
-          if (!isSchedulable(boundAccount.schedulable)) {
+          // 请求模型所属家族的独立限流（opus/sonnet/haiku/fable）
+          const boundModelRateLimited = requestedModelFamily
+            ? await claudeAccountService.isAccountModelRateLimited(
+                boundAccount.id,
+                requestedModelFamily
+              )
+            : false
+
+          if (boundModelRateLimited) {
+            logger.warn(
+              `⏱️ Bound Claude OAuth account ${apiKeyData.claudeAccountId} hit its ${requestedModelFamily} limit in pool selection, falling back to shared pool`
+            )
+          } else if (!isSchedulable(boundAccount.schedulable)) {
             logger.warn(
               `⚠️ Bound Claude OAuth account ${apiKeyData.claudeAccountId} is not schedulable (schedulable: ${boundAccount?.schedulable})`
             )
@@ -659,23 +710,14 @@ class UnifiedClaudeScheduler {
           continue
         }
 
-        if (isOpusRequest) {
-          const isOpusRateLimited = await claudeAccountService.isAccountOpusRateLimited(account.id)
-          if (isOpusRateLimited) {
-            logger.info(
-              `🚫 Skipping account ${account.name} (${account.id}) due to active Opus limit`
-            )
-            continue
-          }
-        }
-
-        if (isFableRequest) {
-          const isFableRateLimited = await claudeAccountService.isAccountFableRateLimited(
-            account.id
+        if (requestedModelFamily) {
+          const isModelRateLimited = await claudeAccountService.isAccountModelRateLimited(
+            account.id,
+            requestedModelFamily
           )
-          if (isFableRateLimited) {
+          if (isModelRateLimited) {
             logger.info(
-              `🚫 Skipping account ${account.name} (${account.id}) due to active Fable limit`
+              `🚫 Skipping account ${account.name} (${account.id}) due to active ${requestedModelFamily} limit`
             )
             continue
           }
@@ -1044,26 +1086,16 @@ class UnifiedClaudeScheduler {
           return false
         }
 
-        if (
-          requestedModel &&
-          typeof requestedModel === 'string' &&
-          requestedModel.toLowerCase().includes('opus')
-        ) {
-          const isOpusRateLimited = await claudeAccountService.isAccountOpusRateLimited(accountId)
-          if (isOpusRateLimited) {
-            logger.info(`🚫 Account ${accountId} skipped due to active Opus limit (session check)`)
-            return false
-          }
-        }
-
-        if (
-          requestedModel &&
-          typeof requestedModel === 'string' &&
-          requestedModel.toLowerCase().includes('fable')
-        ) {
-          const isFableRateLimited = await claudeAccountService.isAccountFableRateLimited(accountId)
-          if (isFableRateLimited) {
-            logger.info(`🚫 Account ${accountId} skipped due to active Fable limit (session check)`)
+        const sessionModelFamily = getRateLimitModelFamily(requestedModel)
+        if (sessionModelFamily) {
+          const isModelRateLimited = await claudeAccountService.isAccountModelRateLimited(
+            accountId,
+            sessionModelFamily
+          )
+          if (isModelRateLimited) {
+            logger.info(
+              `🚫 Account ${accountId} skipped due to active ${sessionModelFamily} limit (session check)`
+            )
             return false
           }
         }
@@ -1547,14 +1579,8 @@ class UnifiedClaudeScheduler {
       }
 
       const availableAccounts = []
-      const isOpusRequest =
-        requestedModel && typeof requestedModel === 'string'
-          ? requestedModel.toLowerCase().includes('opus')
-          : false
-      const isFableRequest =
-        requestedModel && typeof requestedModel === 'string'
-          ? requestedModel.toLowerCase().includes('fable')
-          : false
+      // 请求模型所属的限流家族（opus/sonnet/haiku/fable）
+      const requestedModelFamily = getRateLimitModelFamily(requestedModel)
 
       // 获取所有成员账户的详细信息
       for (const memberId of memberIds) {
@@ -1623,25 +1649,14 @@ class UnifiedClaudeScheduler {
             continue
           }
 
-          if (accountType === 'claude-official' && isOpusRequest) {
-            const isOpusRateLimited = await claudeAccountService.isAccountOpusRateLimited(
-              account.id
+          if (accountType === 'claude-official' && requestedModelFamily) {
+            const isModelRateLimited = await claudeAccountService.isAccountModelRateLimited(
+              account.id,
+              requestedModelFamily
             )
-            if (isOpusRateLimited) {
+            if (isModelRateLimited) {
               logger.info(
-                `🚫 Skipping group member ${account.name} (${account.id}) due to active Opus limit`
-              )
-              continue
-            }
-          }
-
-          if (accountType === 'claude-official' && isFableRequest) {
-            const isFableRateLimited = await claudeAccountService.isAccountFableRateLimited(
-              account.id
-            )
-            if (isFableRateLimited) {
-              logger.info(
-                `🚫 Skipping group member ${account.name} (${account.id}) due to active Fable limit`
+                `🚫 Skipping group member ${account.name} (${account.id}) due to active ${requestedModelFamily} limit`
               )
               continue
             }

--- a/src/utils/modelHelper.js
+++ b/src/utils/modelHelper.js
@@ -231,11 +231,40 @@ function isClaudeFamilyModel(modelName) {
   return false
 }
 
+/**
+ * 参与「按模型独立限流」的模型家族。
+ *
+ * Anthropic 对这些模型分别下发独立的（通常是周级）限额：命中其中一个的 429，
+ * 只代表该模型不可用，不代表整个账号耗尽配额。因此必须记入该家族专属的限流桶，
+ * 而不能改写为账号级限流（那会把账号上的其它模型一并停掉）。
+ */
+const RATE_LIMITED_MODEL_FAMILIES = ['opus', 'sonnet', 'haiku', 'fable']
+
+/**
+ * 解析模型名所属的限流家族（会先去除 vendor 前缀）。
+ * @param {string} modelName - 模型名，如 claude-sonnet-4-5
+ * @returns {string|null} - 'opus' | 'sonnet' | 'haiku' | 'fable'，无法识别时返回 null
+ */
+function getRateLimitModelFamily(modelName) {
+  if (!modelName || typeof modelName !== 'string') {
+    return null
+  }
+
+  const baseModel = (getEffectiveModel(modelName) || '').toLowerCase()
+  if (!baseModel) {
+    return null
+  }
+
+  return RATE_LIMITED_MODEL_FAMILIES.find((family) => baseModel.includes(family)) || null
+}
+
 module.exports = {
   parseVendorPrefixedModel,
   hasVendorPrefix,
   getEffectiveModel,
   getVendorType,
   isOpus45OrNewer,
-  isClaudeFamilyModel
+  isClaudeFamilyModel,
+  RATE_LIMITED_MODEL_FAMILIES,
+  getRateLimitModelFamily
 }

--- a/src/utils/upstreamErrorHelper.js
+++ b/src/utils/upstreamErrorHelper.js
@@ -16,6 +16,12 @@ const DEFAULT_TTL = {
   rate_limit: 300 // 429: 5分钟（优先使用响应头解析值）
 }
 
+// 上游 retry-after 派生 TTL 的上限（秒）。
+// temp-unavailable 只用于「短暂抖动」的冷却；而周级限额的 retry-after 可达数天，
+// 直接采纳会把账号整整下线数天，且账号哈希看起来完全正常（该键是独立的 TTL 键），
+// 极难排查。真正的长时限额应由 markAccountRateLimited / 各模型家族限流桶承担。
+const DEFAULT_MAX_CUSTOM_TTL = 1800 // 30 分钟
+
 // 延迟加载配置，避免循环依赖
 let _configCache = null
 const getConfig = () => {
@@ -45,7 +51,11 @@ const getTtlConfig = () => {
     overload: config.upstreamError?.overloadTtlSeconds ?? DEFAULT_TTL.overload,
     auth_error: config.upstreamError?.authErrorTtlSeconds ?? DEFAULT_TTL.auth_error,
     timeout: config.upstreamError?.timeoutTtlSeconds ?? DEFAULT_TTL.timeout,
-    rate_limit: DEFAULT_TTL.rate_limit
+    rate_limit: DEFAULT_TTL.rate_limit,
+    max_custom:
+      config.upstreamError?.maxCustomTtlSeconds ??
+      parseEnvPositiveInt('UPSTREAM_ERROR_MAX_CUSTOM_TTL_SECONDS') ??
+      DEFAULT_MAX_CUSTOM_TTL
   }
 }
 
@@ -318,10 +328,19 @@ const markTempUnavailable = async (
 
     const ttlConfig = getTtlConfig()
     const parsedCustomTtl = Number(customTtl)
-    let ttlSeconds =
-      Number.isFinite(parsedCustomTtl) && parsedCustomTtl > 0
-        ? Math.ceil(parsedCustomTtl)
-        : ttlConfig[errorType]
+    let ttlSeconds
+    if (Number.isFinite(parsedCustomTtl) && parsedCustomTtl > 0) {
+      // 上游 retry-after 可能是周级限额（数天），必须钳制，否则账号会被长时间下线
+      const requestedTtl = Math.ceil(parsedCustomTtl)
+      ttlSeconds = Math.min(requestedTtl, ttlConfig.max_custom)
+      if (ttlSeconds < requestedTtl) {
+        logger.warn(
+          `⚠️ [UpstreamError] Upstream retry-after ${requestedTtl}s for account ${accountId} (${accountType}) exceeds temp-unavailable cap, clamping to ${ttlSeconds}s`
+        )
+      }
+    } else {
+      ttlSeconds = ttlConfig[errorType]
+    }
     if (
       Number.isFinite(policyDecision.ttlOverrideSeconds) &&
       policyDecision.ttlOverrideSeconds > 0

--- a/tests/claudeAccountModelRateLimit.test.js
+++ b/tests/claudeAccountModelRateLimit.test.js
@@ -1,0 +1,123 @@
+// Regression test for per-model rate-limit buckets.
+//
+// Bug: a model-specific (weekly) 429 — originally claude-fable-5, later claude-sonnet-4-5 —
+// was routed into the account-wide bucket (markAccountRateLimited -> schedulable='false'),
+// taking the whole OAuth account offline so claude-opus-4-8 failed with
+// "No available Claude accounts support the requested model".
+//
+// Fix: every model family (opus/sonnet/haiku/fable) gets its own bucket that never
+// disables account-wide scheduling and never sets the general rate-limit state.
+
+const mockStore = new Map()
+
+jest.mock('../src/models/redis', () => ({
+  getClaudeAccount: jest.fn(async (id) => mockStore.get(id) || {}),
+  setClaudeAccount: jest.fn(async (id, data) => {
+    mockStore.set(id, { ...data })
+  }),
+  client: { hdel: jest.fn(async () => 1) }
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn()
+}))
+
+jest.mock('../src/services/tokenRefreshService', () => ({}))
+jest.mock('../src/utils/tokenRefreshLogger', () => ({}))
+jest.mock('../src/utils/webhookNotifier', () => ({ sendAccountAnomalyNotification: jest.fn() }))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({
+  recordErrorHistory: jest.fn(() => ({ catch: jest.fn() })),
+  markTempUnavailable: jest.fn(() => ({ catch: jest.fn() })),
+  parseRetryAfter: jest.fn(() => null)
+}))
+jest.mock('../src/utils/proxyHelper', () => ({}))
+jest.mock('axios', () => ({}))
+
+// The service constructor starts a cache-cleanup setInterval at load; unref it so the
+// timer never keeps Jest alive.
+const _realSetInterval = global.setInterval
+global.setInterval = (fn, ms, ...args) => {
+  const timer = _realSetInterval(fn, ms, ...args)
+  if (timer && typeof timer.unref === 'function') {
+    timer.unref()
+  }
+  return timer
+}
+const claudeAccountService = require('../src/services/account/claudeAccountService')
+global.setInterval = _realSetInterval
+
+const ACCOUNT_ID = 'acct-model-test'
+const DAY = 24 * 60 * 60 * 1000
+const futureTs = () => Math.floor((Date.now() + 3 * DAY) / 1000)
+
+const seed = () => {
+  mockStore.clear()
+  mockStore.set(ACCOUNT_ID, {
+    id: ACCOUNT_ID,
+    name: 'test-account',
+    isActive: 'true',
+    status: 'active',
+    schedulable: 'true'
+  })
+}
+
+describe('per-model rate-limit buckets (claudeAccountService)', () => {
+  beforeEach(seed)
+
+  it.each(['opus', 'sonnet', 'haiku', 'fable'])(
+    'records a %s limit without flipping the account-wide kill switch',
+    async (family) => {
+      await claudeAccountService.markAccountModelRateLimited(ACCOUNT_ID, family, futureTs())
+
+      const stored = mockStore.get(ACCOUNT_ID)
+      expect(stored[`${family}RateLimitedAt`]).toBeTruthy()
+      expect(stored[`${family}RateLimitEndAt`]).toBeTruthy()
+      // The heart of the bug: a model limit must NOT disable account-wide scheduling,
+      // and must NOT write the general rate-limit state that blocks every other model.
+      expect(stored.schedulable).not.toBe('false')
+      expect(stored.rateLimitStatus).toBeUndefined()
+      expect(stored.rateLimitAutoStopped).toBeUndefined()
+      expect(stored.rateLimitEndAt).toBeUndefined()
+    }
+  )
+
+  it('a sonnet limit leaves opus schedulable and the general bucket untouched', async () => {
+    await claudeAccountService.markAccountModelRateLimited(ACCOUNT_ID, 'sonnet', futureTs())
+
+    expect(await claudeAccountService.isAccountModelRateLimited(ACCOUNT_ID, 'sonnet')).toBe(true)
+    // This is exactly what regressed opus in production.
+    expect(await claudeAccountService.isAccountModelRateLimited(ACCOUNT_ID, 'opus')).toBe(false)
+    expect(await claudeAccountService.isAccountRateLimited(ACCOUNT_ID)).toBe(false)
+  })
+
+  it('auto-clears an expired model limit', async () => {
+    const pastTs = Math.floor((Date.now() - 60 * 60 * 1000) / 1000)
+    await claudeAccountService.markAccountModelRateLimited(ACCOUNT_ID, 'sonnet', pastTs)
+
+    expect(await claudeAccountService.isAccountModelRateLimited(ACCOUNT_ID, 'sonnet')).toBe(false)
+    expect(mockStore.get(ACCOUNT_ID).sonnetRateLimitEndAt).toBeUndefined()
+  })
+
+  it('reports remaining minutes via getAccountModelRateLimitInfo', async () => {
+    await claudeAccountService.markAccountModelRateLimited(ACCOUNT_ID, 'haiku', futureTs())
+    const info = await claudeAccountService.getAccountModelRateLimitInfo(ACCOUNT_ID, 'haiku')
+    expect(info.isRateLimited).toBe(true)
+    expect(info.minutesRemaining).toBeGreaterThan(0)
+  })
+
+  it('keeps the legacy Opus/Fable wrappers writing the same Redis fields', async () => {
+    await claudeAccountService.markAccountOpusRateLimited(ACCOUNT_ID, futureTs())
+    await claudeAccountService.markAccountFableRateLimited(ACCOUNT_ID, futureTs())
+
+    const stored = mockStore.get(ACCOUNT_ID)
+    expect(stored.opusRateLimitEndAt).toBeTruthy()
+    expect(stored.fableRateLimitEndAt).toBeTruthy()
+    expect(await claudeAccountService.isAccountOpusRateLimited(ACCOUNT_ID)).toBe(true)
+    expect(await claudeAccountService.isAccountFableRateLimited(ACCOUNT_ID)).toBe(true)
+    expect(stored.schedulable).not.toBe('false')
+  })
+})

--- a/tests/modelRateLimitFamily.test.js
+++ b/tests/modelRateLimitFamily.test.js
@@ -1,0 +1,28 @@
+const { getRateLimitModelFamily, RATE_LIMITED_MODEL_FAMILIES } = require('../src/utils/modelHelper')
+
+describe('getRateLimitModelFamily', () => {
+  it('maps each Claude model to its independent rate-limit family', () => {
+    expect(getRateLimitModelFamily('claude-opus-4-8')).toBe('opus')
+    expect(getRateLimitModelFamily('claude-sonnet-4-5')).toBe('sonnet')
+    expect(getRateLimitModelFamily('claude-sonnet-4-6')).toBe('sonnet')
+    expect(getRateLimitModelFamily('claude-fable-5')).toBe('fable')
+    expect(getRateLimitModelFamily('claude-fable-5-mythos-5')).toBe('fable')
+    expect(getRateLimitModelFamily('claude-3-5-haiku-20241022')).toBe('haiku')
+  })
+
+  it('strips vendor prefixes before matching', () => {
+    expect(getRateLimitModelFamily('ccr,claude-sonnet-4-5')).toBe('sonnet')
+  })
+
+  it('returns null for unknown or invalid models', () => {
+    expect(getRateLimitModelFamily('deepseek-chat')).toBeNull()
+    expect(getRateLimitModelFamily('')).toBeNull()
+    expect(getRateLimitModelFamily(null)).toBeNull()
+    expect(getRateLimitModelFamily(undefined)).toBeNull()
+    expect(getRateLimitModelFamily(123)).toBeNull()
+  })
+
+  it('exposes the family list used for per-model rate-limit buckets', () => {
+    expect(RATE_LIMITED_MODEL_FAMILIES).toEqual(['opus', 'sonnet', 'haiku', 'fable'])
+  })
+})

--- a/tests/unifiedClaudeSchedulerDedicated.test.js
+++ b/tests/unifiedClaudeSchedulerDedicated.test.js
@@ -1,0 +1,153 @@
+// Regression test: an API key bound to a dedicated Claude account must NEVER be
+// silently routed to a different account.
+//
+// Bug: markAccountRateLimited sets schedulable='false' AND the relay writes a
+// temp_unavailable key. The bound-account path checked temp_unavailable FIRST and only
+// logged "falling back to pool", so the CLAUDE_DEDICATED_RATE_LIMITED throw was dead code
+// and the dedicated key quietly used other accounts from the shared pool.
+
+const mockConfig = { claude: {} }
+
+jest.mock('../config/config', () => mockConfig)
+jest.mock('../src/services/account/claudeAccountService', () => ({
+  isAccountRateLimited: jest.fn(),
+  getAccountRateLimitInfo: jest.fn(),
+  isAccountModelRateLimited: jest.fn(),
+  getAccountModelRateLimitInfo: jest.fn(),
+  clearExpiredModelRateLimit: jest.fn()
+}))
+jest.mock('../src/services/account/claudeConsoleAccountService', () => ({}))
+jest.mock('../src/services/account/bedrockAccountService', () => ({}))
+jest.mock('../src/services/account/ccrAccountService', () => ({}))
+jest.mock('../src/services/accountGroupService', () => ({}))
+jest.mock('../src/models/redis', () => ({ getClaudeAccount: jest.fn() }))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn()
+}))
+jest.mock('../src/utils/commonHelper', () => ({
+  isSchedulable: jest.fn((value) => value !== false && value !== 'false'),
+  sortAccountsByPriority: jest.fn((accounts) => accounts)
+}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({}))
+
+const claudeAccountService = require('../src/services/account/claudeAccountService')
+const redis = require('../src/models/redis')
+const scheduler = require('../src/services/scheduler/unifiedClaudeScheduler')
+
+const BOUND_ID = 'acct-0w'
+// mirrors production: API key "river" bound to account "0w"
+const apiKeyData = { id: 'key-river', name: 'river', claudeAccountId: BOUND_ID }
+
+const healthyAccount = {
+  id: BOUND_ID,
+  name: '0w',
+  isActive: 'true',
+  status: 'active',
+  schedulable: 'true'
+}
+
+describe('dedicated (bound) Claude account never silently falls back to the shared pool', () => {
+  let tempSpy
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockConfig.claude = {}
+    claudeAccountService.isAccountRateLimited.mockResolvedValue(false)
+    claudeAccountService.isAccountModelRateLimited.mockResolvedValue(false)
+    claudeAccountService.clearExpiredModelRateLimit.mockResolvedValue({ success: true })
+    claudeAccountService.getAccountRateLimitInfo.mockResolvedValue({
+      rateLimitEndAt: '2026-07-07T07:00:00.000Z'
+    })
+    claudeAccountService.getAccountModelRateLimitInfo.mockResolvedValue({ resetAt: null })
+    tempSpy = jest.spyOn(scheduler, 'isAccountTemporarilyUnavailable').mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    tempSpy.mockRestore()
+  })
+
+  it('uses the bound account when it is healthy', async () => {
+    redis.getClaudeAccount.mockResolvedValue(healthyAccount)
+
+    await expect(
+      scheduler.selectAccountForApiKey(apiKeyData, null, 'claude-opus-4-8')
+    ).resolves.toEqual({ accountId: BOUND_ID, accountType: 'claude-official' })
+  })
+
+  it('throws CLAUDE_DEDICATED_RATE_LIMITED when rate limited AND temp-unavailable (the production bug)', async () => {
+    // markAccountRateLimited sets schedulable=false + rateLimitAutoStopped,
+    // and the relay also writes temp_unavailable — the exact state of "0w".
+    redis.getClaudeAccount.mockResolvedValue({
+      ...healthyAccount,
+      schedulable: 'false',
+      rateLimitStatus: 'limited',
+      rateLimitAutoStopped: 'true'
+    })
+    claudeAccountService.isAccountRateLimited.mockResolvedValue(true)
+    tempSpy.mockResolvedValue(true)
+
+    await expect(
+      scheduler.selectAccountForApiKey(apiKeyData, null, 'claude-opus-4-8')
+    ).rejects.toMatchObject({ code: 'CLAUDE_DEDICATED_RATE_LIMITED', accountId: BOUND_ID })
+  })
+
+  it('throws CLAUDE_DEDICATED_RATE_LIMITED when only schedulable=false via rate-limit auto-stop', async () => {
+    redis.getClaudeAccount.mockResolvedValue({
+      ...healthyAccount,
+      schedulable: 'false',
+      rateLimitAutoStopped: 'true'
+    })
+
+    await expect(
+      scheduler.selectAccountForApiKey(apiKeyData, null, 'claude-opus-4-8')
+    ).rejects.toMatchObject({ code: 'CLAUDE_DEDICATED_RATE_LIMITED' })
+  })
+
+  it('throws CLAUDE_DEDICATED_RATE_LIMITED when the requested model family is limited', async () => {
+    redis.getClaudeAccount.mockResolvedValue(healthyAccount)
+    claudeAccountService.isAccountModelRateLimited.mockResolvedValue(true)
+    claudeAccountService.getAccountModelRateLimitInfo.mockResolvedValue({ resetAt: 'soon' })
+
+    await expect(
+      scheduler.selectAccountForApiKey(apiKeyData, null, 'claude-sonnet-4-5')
+    ).rejects.toMatchObject({ code: 'CLAUDE_DEDICATED_RATE_LIMITED', modelFamily: 'sonnet' })
+  })
+
+  it('throws CLAUDE_DEDICATED_UNAVAILABLE when only temporarily unavailable', async () => {
+    redis.getClaudeAccount.mockResolvedValue(healthyAccount)
+    tempSpy.mockResolvedValue(true)
+
+    await expect(
+      scheduler.selectAccountForApiKey(apiKeyData, null, 'claude-opus-4-8')
+    ).rejects.toMatchObject({
+      code: 'CLAUDE_DEDICATED_UNAVAILABLE',
+      reason: 'temporarily_unavailable'
+    })
+  })
+
+  it('throws CLAUDE_DEDICATED_UNAVAILABLE when the bound account is inactive', async () => {
+    redis.getClaudeAccount.mockResolvedValue({ ...healthyAccount, isActive: 'false' })
+
+    await expect(
+      scheduler.selectAccountForApiKey(apiKeyData, null, 'claude-opus-4-8')
+    ).rejects.toMatchObject({ code: 'CLAUDE_DEDICATED_UNAVAILABLE', reason: 'inactive_or_error' })
+  })
+
+  it('falls back to the shared pool ONLY when dedicatedAccountFallback is enabled', async () => {
+    mockConfig.claude = { dedicatedAccountFallback: true }
+    redis.getClaudeAccount.mockResolvedValue(healthyAccount)
+    tempSpy.mockResolvedValue(true)
+    const poolSpy = jest.spyOn(scheduler, '_getAllAvailableAccounts').mockResolvedValue([])
+
+    await expect(
+      scheduler.selectAccountForApiKey(apiKeyData, null, 'claude-opus-4-8')
+    ).rejects.toThrow(/No available Claude accounts/)
+    expect(poolSpy).toHaveBeenCalled()
+
+    poolSpy.mockRestore()
+  })
+})

--- a/tests/upstreamErrorTtlCap.test.js
+++ b/tests/upstreamErrorTtlCap.test.js
@@ -1,0 +1,59 @@
+// Regression test: temp-unavailable is a *transient* cooldown. A weekly-scale
+// upstream retry-after (observed: 443300s ≈ 5.1 days) must never sideline an account
+// for days — that key is a separate TTL'd Redis key and the account hash looks clean,
+// which made it nearly impossible to diagnose in production.
+
+const mockSetex = jest.fn(async () => 'OK')
+const mockDel = jest.fn(async () => 1)
+const mockHgetall = jest.fn(async () => ({}))
+
+jest.mock('../src/models/redis', () => ({
+  getClientSafe: () => ({
+    setex: mockSetex,
+    del: mockDel,
+    hgetall: mockHgetall,
+    zadd: jest.fn(async () => 1),
+    expire: jest.fn(async () => 1),
+    zremrangebyrank: jest.fn(async () => 1)
+  })
+}))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+jest.mock('../config/config', () => ({ upstreamError: {} }))
+
+const upstreamErrorHelper = require('../src/utils/upstreamErrorHelper')
+
+const ACCOUNT = 'acct-1'
+const TYPE = 'claude-official'
+const ttlPassedToSetex = () => mockSetex.mock.calls[0][1]
+
+describe('markTempUnavailable clamps upstream retry-after', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('clamps a weekly-scale retry-after (5.1 days) to the 30 minute cap', async () => {
+    await upstreamErrorHelper.markTempUnavailable(ACCOUNT, TYPE, 429, 443300)
+    expect(mockSetex).toHaveBeenCalledTimes(1)
+    expect(ttlPassedToSetex()).toBe(1800)
+  })
+
+  it('clamps the other observed value (4.2 days) too', async () => {
+    await upstreamErrorHelper.markTempUnavailable(ACCOUNT, TYPE, 429, 360117)
+    expect(ttlPassedToSetex()).toBe(1800)
+  })
+
+  it('leaves a short, sane retry-after untouched', async () => {
+    await upstreamErrorHelper.markTempUnavailable(ACCOUNT, TYPE, 429, 600)
+    expect(ttlPassedToSetex()).toBe(600)
+  })
+
+  it('falls back to the per-error-type default when no retry-after is given', async () => {
+    await upstreamErrorHelper.markTempUnavailable(ACCOUNT, TYPE, 429, null)
+    expect(ttlPassedToSetex()).toBe(300) // DEFAULT_TTL.rate_limit
+  })
+})


### PR DESCRIPTION
本 PR 修复两个独立但同源的问题，均来自线上事故排查（承接 #1228）。

---

## 问题一：把 #1228 的「模型级限流桶」推广到全部模型家族

> 这不是一个新 bug，而是 **#1228 的修复只覆盖了 4 个模型家族中的 2 个**（Opus、Fable），
> 且 #1228 完全没有涉及 temp-unavailable 的 TTL 上限。本 PR 将同一机制推广到 sonnet / haiku，
> 并把 Opus/Fable 的两套重复实现收敛为一套通用实现（原方法保留为薄封装）。

Anthropic 对 `opus` / `sonnet` / `haiku` / `fable` 分别下发独立的（周级）限额。#1228 只为 Opus、Fable 建立了专属限流桶，其余模型（线上主要是 `claude-sonnet-4-5`）的 429 仍会落入账号级分支，同时执行：

- `markAccountRateLimited(...)` → 置 `schedulable=false`，**停用整个账号**
- `markTempUnavailable(retry-after)` → 写入 `temp_unavailable` 键，而周级 `retry-after` 可达数天

线上实测 TTL：**443300s（≈5.1 天）**、**360117s（≈4.2 天）**。

> 上述数据是在 **#1228 合并、v1.1.310 已上线之后** 于生产环境采集的：日志中同时出现
> `hit Fable limit`（#1228 生效）与 `Account marked as rate limited: w2/0w`（sonnet 仍走账号级分支），
> 当日 `claude-sonnet-4-5` 请求量 1377。可见 #1228 并未覆盖该场景。

### #1228 的覆盖范围：只修好了一半

`v1.1.310`（即 #1228 合并后的发布版本）中，429 的分桶逻辑是：

```js
// src/services/relay/claudeRelayService.js @ v1.1.310
if (isOpusModelRequest && !Number.isNaN(parsedResetTimestamp)) {
  await claudeAccountService.markAccountOpusRateLimited(...)    // opus 专属桶
} else if (isFableModelRequest && !Number.isNaN(parsedResetTimestamp)) {
  await claudeAccountService.markAccountFableRateLimited(...)   // fable 专属桶（#1228 新增）
} else {
  isRateLimited = true                                          // ← sonnet / haiku 落在这里
  // → markAccountRateLimited(schedulable=false) + markTempUnavailable(retry-after)
}
```

| 模型家族 | v1.1.310（#1228 之后） | 说明 |
|---|---|---|
| `opus` | 专属限流桶 ✅ | #1228 之前已有 |
| `fable` | 专属限流桶 ✅ | **#1228 新增** |
| `sonnet` | **账号级限流 ❌** | 落入 `else` 分支 |
| `haiku` | **账号级限流 ❌** | 落入 `else` 分支 |

在 `v1.1.310` 中，`sonnet` / `haiku` 仅出现在与限流无关的位置（beta header 判断、账号连通性测试的默认模型、`_isModelSupportedByAccount` 里「是否为 Claude 系列模型」的判断），限流分桶逻辑中并不存在它们。

另外两点补充说明：

- #1228 **完全没有改动 `src/utils/upstreamErrorHelper.js`**，因此 temp-unavailable 的 TTL 仍直接采纳上游 `retry-after`（可达数天）。本 PR 中的 TTL 上限是全新的修复，与 #1228 无重叠。
- **问题二（专属账号被静默回退）与 #1228 无关**，该 bug 早于这两个 PR 就已存在（`CLAUDE_DEDICATED_RATE_LIMITED` 分支自始便是不可达的死代码）。

于是某个模型触顶后，整个账号连同 `claude-opus-4-8` 等其它模型一并被停用数天：

```
500 No available Claude accounts support the requested model: claude-opus-4-8
```

排查困难点：`temp_unavailable` 是**独立的 TTL 键**，账号哈希看起来完全正常（`schedulable=true`、无限流字段），且调度器跳过该账号时只打 debug 日志，生产日志中不可见。

### 改动

- **modelHelper**：新增 `RATE_LIMITED_MODEL_FAMILIES` 与 `getRateLimitModelFamily(model)`，统一从模型名解析限流家族。
- **claudeAccountService**：将 Opus / Fable 两套重复实现收敛为一套通用的按家族限流（`markAccountModelRateLimited` / `isAccountModelRateLimited` / `clearExpiredModelRateLimit` 等）。**沿用既有 `{family}RateLimitedAt` / `{family}RateLimitEndAt` 字段名，向后兼容旧数据**；原 Opus / Fable 方法保留为薄封装，现有调用方与前端字段无需改动。账号列表新增 `modelRateLimitStatus`。
- **claudeRelayService**：三处 429 分支（非流式 / 流式中途 / 流式末尾）统一改为「命中哪个模型家族，就只记入该家族的限流桶」，不再改写为账号级限流，也不再写 `temp_unavailable`。
- **unifiedClaudeScheduler**：共享池、粘性会话、分组、专属账号四条路径统一按家族判断。
- **upstreamErrorHelper**：对上游 `retry-after` 派生的 temp-unavailable TTL 增加上限（默认 `1800s`，可用 `upstreamError.maxCustomTtlSeconds` / `UPSTREAM_ERROR_MAX_CUSTOM_TTL_SECONDS` 配置）。temp-unavailable 只用于短暂抖动的冷却，长时限额应由账号级 / 模型级限流桶承担。

> 收益：新增模型（如未来的 sonnet-5、haiku-5）无需再改代码特判。

---

## 问题二：专属账号被静默回退到共享池

API Key 绑定专属账号后，一旦该账号被限流，请求会被**静默路由到其它账号**，「把 Key 限定到某个账号」的语义被破坏。

根因是**判断顺序错误**。`markAccountRateLimited` 会同时置 `schedulable=false` 并写 `temp_unavailable`，而 `selectAccountForApiKey` 先判断 `temp_unavailable`，且仅打印 `falling back to pool` 后继续向下执行：

```js
if (isTempUnavailable) {
  logger.warn(`... temporarily unavailable, falling back to pool`)   // 仅告警，继续向下
} else {
  const isRateLimited = await claudeAccountService.isAccountRateLimited(boundAccount.id)
  if (isRateLimited) { throw CLAUDE_DEDICATED_RATE_LIMITED }         // 永远走不到
  if (!isSchedulable(boundAccount.schedulable)) {
    logger.warn(`... not schedulable, falling back to pool`)          // 同样静默回退
  }
```

线上实测（单台，一天内）：

```
3280 × Bound account ... is not schedulable, falling back to pool
1852 × Bound account ... is temporarily unavailable, falling back to pool
   0 × CLAUDE_DEDICATED_RATE_LIMITED        ← 从未触发过
```

### 改动

- **unifiedClaudeScheduler**：专属账号路径改为「**限流优先判断**」，并新增所请求模型家族的限流判断；任何不可用情形都**显式抛错，不再静默回退**：
  - 限流 / 因限流自动停调度（`rateLimitAutoStopped`）/ 该模型家族触顶 → `CLAUDE_DEDICATED_RATE_LIMITED`（403）
  - 临时不可用 / 不可调度 / 账号失效 → `CLAUDE_DEDICATED_UNAVAILABLE`（503）
- **claudeRelayService**：流式与非流式路径均处理 `CLAUDE_DEDICATED_UNAVAILABLE`，返回 503。
- 新增配置 **`claude.dedicatedAccountFallback`（默认 `false`）**。

> 这是一处行为变更：默认改为「严格绑定」。考虑到 `CLAUDE_DEDICATED_RATE_LIMITED` 这个既有分支本就表明了「专属账号不可用时应报错而非回退」的设计意图，因此默认取严格语义；若有用户依赖旧的回退行为，可将该配置置为 `true`（或设置环境变量 `CLAUDE_DEDICATED_ACCOUNT_FALLBACK=true`）恢复。

---

## 测试

新增 4 个测试文件：

| 文件 | 覆盖内容 |
|---|---|
| `tests/modelRateLimitFamily.test.js` | 模型家族解析（含 vendor 前缀、未知模型） |
| `tests/claudeAccountModelRateLimit.test.js` | 按家族限流桶不置 `schedulable=false`、不触发账号级限流；opus/fable 兼容封装 |
| `tests/unifiedClaudeSchedulerDedicated.test.js` | 专属账号严格绑定（完整复现线上 bug 场景）、配置开关回退 |
| `tests/upstreamErrorTtlCap.test.js` | temp-unavailable TTL 钳制（443300s / 360117s → 1800s） |

- `npm test`：**25 个套件，276 通过、8 跳过、0 失败**
- ESLint 无告警，Prettier 已格式化

🤖 Generated with [Claude Code](https://claude.com/claude-code)
