### PR TITLE
feat: 增加 GPT-5.6 系列模型支持（sol/terra/luna）

### DIFF
--- a/src/services/modelService.js
+++ b/src/services/modelService.js
@@ -56,7 +56,10 @@ class ModelService {
           'gpt-5.3-codex',
           'gpt-5.3-codex-spark',
           'gpt-5.4',
-          'gpt-5.4-pro'
+          'gpt-5.4-pro',
+          'gpt-5.6-sol',
+          'gpt-5.6-terra',
+          'gpt-5.6-luna'
         ]
       },
       gemini: {

--- a/src/services/pricingService.js
+++ b/src/services/pricingService.js
@@ -372,6 +372,15 @@ class PricingService {
       }
     }
 
+    // 特殊处理：gpt-5.6 系列（sol/terra/luna）在 LiteLLM 收录前回退到 gpt-5
+    if (modelName.startsWith('gpt-5.6') && !this.pricingData[modelName]) {
+      const fallbackPricing = this.pricingData['gpt-5']
+      if (fallbackPricing) {
+        logger.info(`💰 Using gpt-5 pricing as fallback for ${modelName}`)
+        return fallbackPricing
+      }
+    }
+
     // 对于Bedrock区域前缀模型（如 us.anthropic.claude-sonnet-4-20250514-v1:0），
     // 尝试去掉区域前缀进行匹配
     if (modelName.includes('.anthropic.') || modelName.includes('.claude')) {

--- a/src/utils/costCalculator.js
+++ b/src/utils/costCalculator.js
@@ -369,6 +369,14 @@ class CostCalculator {
         return gpt5Pricing
       }
     }
+    // 特殊处理：gpt-5.6 系列（sol/terra/luna）在收录专门定价前回退到 gpt-5
+    if (model.startsWith('gpt-5.6') && !MODEL_PRICING[model]) {
+      const gpt5Pricing = MODEL_PRICING['gpt-5']
+      if (gpt5Pricing) {
+        console.log(`Using gpt-5 pricing as fallback for ${model}`)
+        return gpt5Pricing
+      }
+    }
     return MODEL_PRICING[model] || MODEL_PRICING['unknown']
   }
 


### PR DESCRIPTION
## Summary

OpenAI 于 2026-07-09 发布了 GPT-5.6 系列（Sol / Terra / Luna），已通过 Codex 通道对所有 ChatGPT 档位开放（上游 `openai/codex` 的 `models-manager/models.json` 中三个模型的 `available_in_plans` 与 gpt-5.5 完全一致）。本 PR 为 CRS 补齐对应支持：

- `src/services/modelService.js`：OpenAI 模型清单新增 `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna`，使 `GET /v1/models` 能向客户端展示新模型
- `src/services/pricingService.js` / `src/utils/costCalculator.js`：新增 gpt-5.6 系列的价格回退特判——LiteLLM 上游尚未收录 5.6 条目（已实测确认），收录前回退到 gpt-5 计价，避免用量统计按未知/零计

## 与 #1200 的关系

本 PR 与 #1200（补 gpt-5.5）互补、零重叠：只新增行，不触碰 #1200 修改的任何行（gpt-5-codex 回退特判原样保留）。两个 PR 任意顺序合并均无冲突；若有需要我随时 rebase。

## Checks

- `npx jest tests/costCalculator.test.js tests/pricingService.test.js` → 2 suites, 19 tests passed
- 功能验证（本地 node 直调）：
  - `costCalculator.getModelPricing('gpt-5.6-sol')` 返回与 `gpt-5` 一致的回退定价 ✅
  - `modelService.getAllModels()` 包含 `gpt-5.6-sol,gpt-5.6-terra,gpt-5.6-luna` ✅
- 已确认上游 LiteLLM `model_prices_and_context_window.json` 当前无任何 `5.6` 条目，回退分支会实际生效；待 LiteLLM 收录后自动走精确定价，特判自然失效
