### PR TITLE
fix: 仪表盘预设时间范围按系统时区取日期，修复浏览器时区非 UTC+8 时当天数据不可见

### DIFF
--- a/web/admin-spa/src/stores/dashboard.js
+++ b/web/admin-spa/src/stores/dashboard.js
@@ -175,6 +175,15 @@ export const useDashboardStore = defineStore('dashboard', () => {
     }
   }
 
+  // 辅助函数：把日期选择器的系统时区（UTC+8）墙钟字符串转换为 ISO 字符串
+  // 不能把无时区字符串原样发给后端——后端会按服务器本地时区解析，产生偏移
+  function systemTimeStringToISO(timeStr) {
+    const [datePart, timePart = '00:00:00'] = timeStr.split(' ')
+    const [year, month, day] = datePart.split('-').map(Number)
+    const [hours, minutes, seconds] = timePart.split(':').map(Number)
+    return new Date(Date.UTC(year, month - 1, day, hours - 8, minutes, seconds)).toISOString()
+  }
+
   // 公共函数：根据预设计算时间范围
   function getPresetTimeRange(preset) {
     const now = new Date()
@@ -323,13 +332,15 @@ export const useDashboardStore = defineStore('dashboard', () => {
       if (granularity === 'hour') {
         url += `granularity=hour`
 
-        if (dateFilter.value.customRange && dateFilter.value.customRange.length === 2) {
-          url += `&startDate=${encodeURIComponent(dateFilter.value.customRange[0])}`
-          url += `&endDate=${encodeURIComponent(dateFilter.value.customRange[1])}`
-        } else if (dateFilter.value.type === 'preset') {
+        // 预设模式优先于 customRange：customRange 里存的是用于展示的系统时区字符串，
+        // 预设范围必须由 getPresetTimeRange 重新计算并以 ISO 发送
+        if (dateFilter.value.type === 'preset') {
           const { start, end } = getPresetTimeRange(dateFilter.value.preset)
           url += `&startDate=${encodeURIComponent(start.toISOString())}`
           url += `&endDate=${encodeURIComponent(end.toISOString())}`
+        } else if (dateFilter.value.customRange && dateFilter.value.customRange.length === 2) {
+          url += `&startDate=${encodeURIComponent(systemTimeStringToISO(dateFilter.value.customRange[0]))}`
+          url += `&endDate=${encodeURIComponent(systemTimeStringToISO(dateFilter.value.customRange[1]))}`
         } else {
           const now = new Date()
           url += `&startDate=${encodeURIComponent(new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString())}`
@@ -353,15 +364,18 @@ export const useDashboardStore = defineStore('dashboard', () => {
     try {
       let url = `/admin/model-stats?period=${period}`
 
-      if (dateFilter.value.type === 'custom' || currentGranularity === 'hour') {
-        if (dateFilter.value.customRange && dateFilter.value.customRange.length === 2) {
-          url += `&startDate=${encodeURIComponent(dateFilter.value.customRange[0])}`
-          url += `&endDate=${encodeURIComponent(dateFilter.value.customRange[1])}`
-        } else if (currentGranularity === 'hour' && dateFilter.value.type === 'preset') {
-          const { start, end } = getPresetTimeRange(dateFilter.value.preset)
-          url += `&startDate=${encodeURIComponent(start.toISOString())}`
-          url += `&endDate=${encodeURIComponent(end.toISOString())}`
-        }
+      if (currentGranularity === 'hour' && dateFilter.value.type === 'preset') {
+        // 预设模式优先于 customRange：customRange 里存的是用于展示的系统时区字符串
+        const { start, end } = getPresetTimeRange(dateFilter.value.preset)
+        url += `&startDate=${encodeURIComponent(start.toISOString())}`
+        url += `&endDate=${encodeURIComponent(end.toISOString())}`
+      } else if (
+        dateFilter.value.type === 'custom' &&
+        dateFilter.value.customRange &&
+        dateFilter.value.customRange.length === 2
+      ) {
+        url += `&startDate=${encodeURIComponent(systemTimeStringToISO(dateFilter.value.customRange[0]))}`
+        url += `&endDate=${encodeURIComponent(systemTimeStringToISO(dateFilter.value.customRange[1]))}`
       } else if (dateFilter.value.type === 'preset' && currentGranularity === 'day') {
         const now = new Date()
         const option = dateFilter.value.presetOptions.find(
@@ -401,13 +415,14 @@ export const useDashboardStore = defineStore('dashboard', () => {
       if (currentGranularity === 'hour') {
         url += `granularity=hour`
 
-        if (dateFilter.value.customRange && dateFilter.value.customRange.length === 2) {
-          url += `&startDate=${encodeURIComponent(dateFilter.value.customRange[0])}`
-          url += `&endDate=${encodeURIComponent(dateFilter.value.customRange[1])}`
-        } else if (dateFilter.value.type === 'preset') {
+        // 预设模式优先于 customRange：customRange 里存的是用于展示的系统时区字符串
+        if (dateFilter.value.type === 'preset') {
           const { start, end } = getPresetTimeRange(dateFilter.value.preset)
           url += `&startDate=${encodeURIComponent(start.toISOString())}`
           url += `&endDate=${encodeURIComponent(end.toISOString())}`
+        } else if (dateFilter.value.customRange && dateFilter.value.customRange.length === 2) {
+          url += `&startDate=${encodeURIComponent(systemTimeStringToISO(dateFilter.value.customRange[0]))}`
+          url += `&endDate=${encodeURIComponent(systemTimeStringToISO(dateFilter.value.customRange[1]))}`
         } else {
           const now = new Date()
           url += `&startDate=${encodeURIComponent(new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString())}`
@@ -449,13 +464,14 @@ export const useDashboardStore = defineStore('dashboard', () => {
       if (currentGranularity === 'hour') {
         url += `granularity=hour`
 
-        if (dateFilter.value.customRange && dateFilter.value.customRange.length === 2) {
-          url += `&startDate=${encodeURIComponent(dateFilter.value.customRange[0])}`
-          url += `&endDate=${encodeURIComponent(dateFilter.value.customRange[1])}`
-        } else if (dateFilter.value.type === 'preset') {
+        // 预设模式优先于 customRange：customRange 里存的是用于展示的系统时区字符串
+        if (dateFilter.value.type === 'preset') {
           const { start, end } = getPresetTimeRange(dateFilter.value.preset)
           url += `&startDate=${encodeURIComponent(start.toISOString())}`
           url += `&endDate=${encodeURIComponent(end.toISOString())}`
+        } else if (dateFilter.value.customRange && dateFilter.value.customRange.length === 2) {
+          url += `&startDate=${encodeURIComponent(systemTimeStringToISO(dateFilter.value.customRange[0]))}`
+          url += `&endDate=${encodeURIComponent(systemTimeStringToISO(dateFilter.value.customRange[1]))}`
         } else {
           const now = new Date()
           url += `&startDate=${encodeURIComponent(new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString())}`
@@ -507,33 +523,36 @@ export const useDashboardStore = defineStore('dashboard', () => {
       startDate = range.start
       endDate = range.end
     } else {
-      startDate = new Date(now)
-      endDate = new Date(now)
-
+      // 日界线按系统时区（UTC+8）计算，不能用浏览器本地的 setHours
       if (normalizedPreset === 'today') {
-        startDate.setHours(0, 0, 0, 0)
-        endDate.setHours(23, 59, 59, 999)
+        startDate = getSystemTimezoneDay(now, true)
+        endDate = getSystemTimezoneDay(now, false)
       } else if (option?.days) {
-        startDate.setDate(now.getDate() - (option.days - 1))
-        startDate.setHours(0, 0, 0, 0)
-        endDate.setHours(23, 59, 59, 999)
+        const daysAgo = new Date(now)
+        daysAgo.setDate(daysAgo.getDate() - (option.days - 1))
+        startDate = getSystemTimezoneDay(daysAgo, true)
+        endDate = getSystemTimezoneDay(now, false)
+      } else {
+        startDate = new Date(now)
+        endDate = new Date(now)
       }
     }
 
     const formatDateForDisplay = (date) => {
-      // 使用本地时间直接格式化，避免多余的时区偏移导致日期错位
-      const localTime = new Date(date)
-      const year = localTime.getFullYear()
-      const month = String(localTime.getMonth() + 1).padStart(2, '0')
-      const day = String(localTime.getDate()).padStart(2, '0')
-      const hours = String(localTime.getHours()).padStart(2, '0')
-      const minutes = String(localTime.getMinutes()).padStart(2, '0')
-      const seconds = String(localTime.getSeconds()).padStart(2, '0')
+      // 按系统时区（UTC+8）格式化显示，与查询范围的日期归属保持一致，
+      // 也保证 customRange 里的字符串能按系统时区语义回转（systemTimeStringToISO）
+      const systemTime = new Date(date.getTime() + 8 * 60 * 60 * 1000)
+      const year = systemTime.getUTCFullYear()
+      const month = String(systemTime.getUTCMonth() + 1).padStart(2, '0')
+      const day = String(systemTime.getUTCDate()).padStart(2, '0')
+      const hours = String(systemTime.getUTCHours()).padStart(2, '0')
+      const minutes = String(systemTime.getUTCMinutes()).padStart(2, '0')
+      const seconds = String(systemTime.getUTCSeconds()).padStart(2, '0')
       return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
     }
 
-    dateFilter.value.customStart = startDate ? startDate.toISOString().split('T')[0] : ''
-    dateFilter.value.customEnd = endDate ? endDate.toISOString().split('T')[0] : ''
+    dateFilter.value.customStart = startDate ? formatDateForDisplay(startDate).split(' ')[0] : ''
+    dateFilter.value.customEnd = endDate ? formatDateForDisplay(endDate).split(' ')[0] : ''
     dateFilter.value.customRange =
       startDate && endDate ? [formatDateForDisplay(startDate), formatDateForDisplay(endDate)] : null
 

--- a/web/admin-spa/src/stores/dashboard.js
+++ b/web/admin-spa/src/stores/dashboard.js
@@ -153,13 +153,16 @@ export const useDashboardStore = defineStore('dashboard', () => {
   })
 
   // 辅助函数：获取系统时区某一天的起止UTC时间
-  // 输入：一个本地时间的日期对象（如用户选择的日期）
-  // 输出：该日期在系统时区的0点/23:59对应的UTC时间
+  // 输入：一个时间点（Date 对象，通常由当前时刻推算而来）
+  // 输出：该时间点在系统时区（UTC+8）所属日期的0点/23:59对应的UTC时间
   function getSystemTimezoneDay(localDate, startOfDay = true) {
     // 固定使用UTC+8，因为后端系统时区是UTC+8
-    const year = localDate.getFullYear()
-    const month = localDate.getMonth()
-    const day = localDate.getDate()
+    // 通过时间戳偏移取 UTC+8 的日历日期，不能用 getFullYear/getDate（那是浏览器本地时区的日期，
+    // 浏览器时区 ≠ UTC+8 时会在系统时区已跨日、本地未跨日的窗口内漏掉整天数据）
+    const shifted = new Date(localDate.getTime() + 8 * 60 * 60 * 1000)
+    const year = shifted.getUTCFullYear()
+    const month = shifted.getUTCMonth()
+    const day = shifted.getUTCDate()
 
     if (startOfDay) {
       // 系统时区（UTC+8）的 YYYY-MM-DD 00:00:00


### PR DESCRIPTION
## 问题

管理后台仪表盘的「今日 / 7天 / 30天」预设时间范围，是用**浏览器本地时区**的日历日期套上 UTC+8 日界线计算的（`getSystemTimezoneDay` 中的 `getFullYear()/getMonth()/getDate()`）。

当浏览器时区不是 UTC+8 时（美洲、欧洲等地的用户），在「系统时区已跨日、浏览器本地还没跨日」的时间窗口内：

- 预设范围的结束时间停留在系统时区**昨天** 23:59:59
- 当天（系统时区日）产生的所有模型用量在「模型使用分布 / 详细统计数据」里完全不可见
- 刷新页面无效，切「今日」也看不到（它的"今日"同样按浏览器日期算）

以太平洋时间的浏览器为例，这个盲区窗口每天长达 15 小时（北京 0:00 → 太平洋 0:00）。数据本身没有丢失，Redis 按 UTC+8 日期桶记录正常，纯前端查询范围问题。

## 复现

1. 系统 `TIMEZONE_OFFSET=8`（默认）
2. 浏览器所在机器设为 `America/Los_Angeles` 等西侧时区
3. 在北京时间 0:00 之后（浏览器本地日期仍是前一天）发起 API 调用
4. 打开仪表盘：30天/今日 预设均看不到这些调用，日期范围显示到前一天 23:59:59 为止

## 修复

`getSystemTimezoneDay` 改为对输入时间戳偏移 +8h 后取 `getUTC*` 分量，日期归属只由系统时区决定，与浏览器时区无关。浏览器本身在 UTC+8 时行为完全不变。

## 验证

对 2026-07-09T18:48:00Z（北京 07-10 02:48 / 太平洋 07-09 11:48）分别在 `TZ=America/Los_Angeles`、`TZ=UTC`、`TZ=Asia/Shanghai` 下对比新旧实现：

| 浏览器时区 | 旧：今日结束 | 新：今日结束 |
|---|---|---|
| America/Los_Angeles | 07-09T15:59:59Z（漏掉当天数据） | 07-10T15:59:59Z ✅ |
| UTC | 07-09T15:59:59Z（漏掉当天数据） | 07-10T15:59:59Z ✅ |
| Asia/Shanghai | 07-10T15:59:59Z | 07-10T15:59:59Z（不变） ✅ |

`prettier --check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
