### PR TITLE
fix(admin-spa): derive Codex quota window label from windowMinutes

### DIFF
--- a/web/admin-spa/src/components/apistats/StatsOverview.vue
+++ b/web/admin-spa/src/components/apistats/StatsOverview.vue
@@ -256,15 +256,18 @@
           </div>
 
           <div v-else-if="account.platform === 'openai'" class="mt-3">
-            <div v-if="account.codexUsage" class="space-y-2">
+            <div
+              v-if="account.codexUsage && codexWindowTypes(account.codexUsage).length"
+              class="space-y-2"
+            >
               <div
-                v-for="type in ['primary', 'secondary']"
+                v-for="type in codexWindowTypes(account.codexUsage)"
                 :key="`${account.key}-${type}`"
                 class="quota-row"
               >
                 <div class="quota-header">
                   <span class="quota-tag" :class="type === 'primary' ? 'tag-indigo' : 'tag-blue'">
-                    {{ getCodexWindowLabel(type) }}
+                    {{ getCodexWindowLabel(account.codexUsage?.[type], type) }}
                   </span>
                   <span class="quota-percent">
                     {{ formatCodexUsagePercent(account.codexUsage?.[type]) }}
@@ -535,7 +538,33 @@ const formatCodexRemaining = (usageItem) => {
   return `${secs}秒`
 }
 
-const getCodexWindowLabel = (type) => (type === 'secondary' ? '周限' : '5h')
+// 根据窗口时长（分钟）推导标签，避免写死槽位（OpenAI 已取消 5h，现仅下发周限）
+const formatCodexWindowMinutes = (windowMinutes) => {
+  const m = Number(windowMinutes)
+  if (!Number.isFinite(m) || m <= 0) return null
+  if (m === 10080) return '周限'
+  if (m % 10080 === 0) return `${m / 10080}周`
+  if (m % 1440 === 0) return `${m / 1440}天`
+  if (m % 60 === 0) return `${m / 60}h`
+  return `${m}分钟`
+}
+
+// 该额度窗口是否有真实数据（无 windowMinutes 视为空槽，不渲染）
+const hasCodexWindow = (usageItem) => {
+  if (!usageItem) return false
+  const m = Number(usageItem.windowMinutes)
+  return Number.isFinite(m) && m > 0
+}
+
+// 有真实数据的窗口类型列表（供模板 v-for 过滤空槽）
+const codexWindowTypes = (codexUsage) =>
+  ['primary', 'secondary'].filter((t) => hasCodexWindow(codexUsage?.[t]))
+
+const getCodexWindowLabel = (usageItem, type) => {
+  const dynamic = formatCodexWindowMinutes(usageItem?.windowMinutes)
+  if (dynamic) return dynamic
+  return type === 'secondary' ? '周限' : '5h'
+}
 </script>
 
 <style scoped>

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -1146,13 +1146,23 @@
                     </div>
                   </div>
                   <div v-else-if="account.platform === 'openai'" class="space-y-2">
-                    <div v-if="account.codexUsage" class="space-y-2">
-                      <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                    <div
+                      v-if="
+                        account.codexUsage &&
+                        (hasCodexWindow(account.codexUsage.primary) ||
+                          hasCodexWindow(account.codexUsage.secondary))
+                      "
+                      class="space-y-2"
+                    >
+                      <div
+                        v-if="hasCodexWindow(account.codexUsage.primary)"
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300"
                           >
-                            {{ getCodexWindowLabel('primary') }}
+                            {{ getCodexWindowLabel(account.codexUsage.primary, 'primary') }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -1179,12 +1189,15 @@
                           重置剩余 {{ formatCodexRemaining(account.codexUsage.primary) }}
                         </div>
                       </div>
-                      <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                      <div
+                        v-if="hasCodexWindow(account.codexUsage.secondary)"
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:bg-blue-500/20 dark:text-blue-300"
                           >
-                            {{ getCodexWindowLabel('secondary') }}
+                            {{ getCodexWindowLabel(account.codexUsage.secondary, 'secondary') }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -1746,13 +1759,23 @@
               <div v-else class="text-xs text-gray-400">暂无统计</div>
             </div>
             <div v-else-if="account.platform === 'openai'" class="space-y-2">
-              <div v-if="account.codexUsage" class="space-y-2">
-                <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700">
+              <div
+                v-if="
+                  account.codexUsage &&
+                  (hasCodexWindow(account.codexUsage.primary) ||
+                    hasCodexWindow(account.codexUsage.secondary))
+                "
+                class="space-y-2"
+              >
+                <div
+                  v-if="hasCodexWindow(account.codexUsage.primary)"
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700"
+                >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300"
                     >
-                      {{ getCodexWindowLabel('primary') }}
+                      {{ getCodexWindowLabel(account.codexUsage.primary, 'primary') }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -1779,12 +1802,15 @@
                     重置剩余 {{ formatCodexRemaining(account.codexUsage.primary) }}
                   </div>
                 </div>
-                <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700">
+                <div
+                  v-if="hasCodexWindow(account.codexUsage.secondary)"
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700"
+                >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:bg-blue-500/20 dark:text-blue-300"
                     >
-                      {{ getCodexWindowLabel('secondary') }}
+                      {{ getCodexWindowLabel(account.codexUsage.secondary, 'secondary') }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -1812,7 +1838,7 @@
                   </div>
                 </div>
               </div>
-              <div v-if="!account.codexUsage" class="text-xs text-gray-400">暂无统计</div>
+              <div v-else class="text-xs text-gray-400">暂无统计</div>
             </div>
 
             <!-- 最后使用时间 -->
@@ -4949,12 +4975,43 @@ const getCodexUsageWidth = (usageItem) => {
   return `${percent}%`
 }
 
-// 时间窗口标签
-const getCodexWindowLabel = (type) => {
-  if (type === 'secondary') {
+// 根据窗口时长（分钟）推导标签，避免写死槽位（OpenAI 已取消 5h，现仅下发周限）
+const formatCodexWindowMinutes = (windowMinutes) => {
+  const m = Number(windowMinutes)
+  if (!Number.isFinite(m) || m <= 0) {
+    return null
+  }
+  if (m === 10080) {
     return '周限'
   }
-  return '5h'
+  if (m % 10080 === 0) {
+    return `${m / 10080}周`
+  }
+  if (m % 1440 === 0) {
+    return `${m / 1440}天`
+  }
+  if (m % 60 === 0) {
+    return `${m / 60}h`
+  }
+  return `${m}分钟`
+}
+
+// 该额度窗口是否有真实数据（无 windowMinutes 视为空槽，不渲染）
+const hasCodexWindow = (usageItem) => {
+  if (!usageItem) {
+    return false
+  }
+  const m = Number(usageItem.windowMinutes)
+  return Number.isFinite(m) && m > 0
+}
+
+// 时间窗口标签：优先按实际 windowMinutes 动态推导，取不到时退回位置标签
+const getCodexWindowLabel = (usageItem, type) => {
+  const dynamic = formatCodexWindowMinutes(usageItem?.windowMinutes)
+  if (dynamic) {
+    return dynamic
+  }
+  return type === 'secondary' ? '周限' : '5h'
 }
 
 // 格式化剩余时间


### PR DESCRIPTION
## Problem

OpenAI removed the Codex **5h rolling window**. The rate-limit response headers now carry only the **weekly** window in the `x-codex-primary-*` slot (`window_minutes=10080`, resets in ~6d23h) and leave the `x-codex-secondary-*` slot empty (all zeros).

The account dashboard hard-codes the window label by slot position:

```js
const getCodexWindowLabel = (type) => (type === 'secondary' ? '周限' : '5h')
```

So after OpenAI's change the weekly window is mislabeled **"5h"** (showing "重置剩余 6天23小时"), and the now-empty secondary slot renders as **"周限 · 重置剩余 0秒"**.

Confirmed against a live account: `codexPrimaryWindowMinutes=10080`, `codexPrimaryResetAfterSeconds≈601199` (~6d23h), `codexSecondaryWindowMinutes=0`.

## Before / After

| Before (bug) | After (fixed) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/wanpidan1234-design/claude-relay-service/pr-assets/codex-window-before.jpg) | ![after](https://raw.githubusercontent.com/wanpidan1234-design/claude-relay-service/pr-assets/codex-window-after.jpg) |
| Weekly window mislabeled `5h` (6天23小时); empty secondary shows `周限 · 0秒` | Single correctly-labeled `周限` window; empty slot hidden |

## Fix (display layer only, no backend change)

- Derive the label from the actual `windowMinutes` instead of the slot position: `300 → 5h`, `10080 → 周限`, with day/hour/minute fallbacks. Falls back to the legacy positional label when `windowMinutes` is missing (backward compatible if OpenAI restores the 5h window).
- Hide windows that have no data (`windowMinutes <= 0`) so the empty "周限 0秒" bar disappears; show "暂无统计" / "暂无额度使用数据" only when no window has data.

Applied consistently in both `AccountsView.vue` (two render blocks) and `StatsOverview.vue` (the `v-for` block).

## Testing

- `npm run build` (admin-spa) passes, 0 errors.
- Verified on a live account: dashboard now shows a single **周限** meter with the correct reset time; the empty slot is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
