### PR TITLE
fix: prevent heap OOM in safeStringify when serializing huge error objects

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -18,8 +18,14 @@ const safeStringify = (obj, maxDepth = Infinity) => {
     // 处理字符串值，清理可能导致JSON解析错误的特殊字符
     if (typeof value === 'string') {
       try {
+        // 超长字符串（如 axios error 携带的完整请求体）必须在正则清洗/深拷贝之前截断，
+        // 否则错误高峰期多次全量复制会耗尽 V8 堆（heap OOM 崩溃循环，见 #1099）
+        const raw =
+          value.length > 100000
+            ? `${value.substring(0, 10000)}...[truncated ${value.length} chars]`
+            : value
         // 移除或转义可能导致JSON解析错误的字符
-        const cleanValue = value
+        const cleanValue = raw
           // eslint-disable-next-line no-control-regex
           .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '') // 移除控制字符
           .replace(/[\uD800-\uDFFF]/g, '') // 移除孤立的代理对字符
@@ -74,9 +80,12 @@ const safeStringify = (obj, maxDepth = Infinity) => {
     // 体积保护: 超过 50KB 时对大字段做截断，保留顶层结构
     if (result.length > 50000 && processed && typeof processed === 'object') {
       const truncated = { ...processed, _truncated: true, _totalChars: result.length }
+      // 只跳过 safeStringify 自身添加的元数据字段；不能按 `_` 前缀跳过，
+      // 否则 Node 内部对象（如 ClientRequest）的 `_` 开头属性会完全绕过截断（#1099 Bug 1）
+      const isMetaField = (k) => k === '_truncated' || k === '_totalChars'
       // 第一轮: 截断单个大字段
       for (const [k, v] of Object.entries(truncated)) {
-        if (k.startsWith('_')) {
+        if (isMetaField(k)) {
           continue
         }
         const fieldStr = typeof v === 'string' ? v : JSON.stringify(v)
@@ -88,7 +97,7 @@ const safeStringify = (obj, maxDepth = Infinity) => {
       let secondResult = JSON.stringify(truncated)
       if (secondResult.length > 50000) {
         for (const [k, v] of Object.entries(truncated)) {
-          if (k.startsWith('_')) {
+          if (isMetaField(k)) {
             continue
           }
           const fieldStr = typeof v === 'string' ? v : JSON.stringify(v)


### PR DESCRIPTION
## 问题

#1099 报告的缺陷在生产环境实际触发:上游 `chatgpt.com` 断连(ECONNRESET/ETIMEDOUT)时,错误日志序列化完整 axios error(内含多 MB 请求体),导致 V8 堆耗尽、GC 假死、进程 OOM 崩溃循环。我们一台 8GB 实例(`--max-old-space-size=4096`)一周内累计 33 次同指纹崩溃,平均约 2 小时一次:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
...
16: v8::internal::Runtime_ObjectEntries(...)
```

## 根因(两处,同 #1099 分析)

**Bug 1:体积保护跑得太晚。** `safeStringify` 的 50KB 截断发生在 `replacer` 完成整棵对象树的深拷贝**之后**——多 MB 的请求体字符串在截断前已被正则清洗和深拷贝复制了数次。错误高峰期(客户端重试风暴)瞬时分配打满堆。

**Bug 2:`_` 前缀跳过条件过宽。** 截断循环的 `if (k.startsWith('_')) continue` 本意是跳过自身添加的 `_truncated`/`_totalChars` 元数据,但 Node 内部对象(`ClientRequest` 等)几乎全部状态都是 `_` 前缀属性,恰好是序列化体积的主要来源——截断对它们完全失效。

## 修复

1. 在 `replacer` 内对超长叶子字符串(>100KB)先截断到 10KB 再做正则清洗,从源头避免多次全量复制
2. 截断循环只跳过 `_truncated`/`_totalChars` 两个元数据字段

## 验证

- 冒烟测试:构造含 3 个 5MB 字符串字段(含 `_` 前缀嵌套)的假 axios error,`logger.error` 9ms 完成,堆增量 4MB(修复前:秒级 + 数百 MB)
- 生产验证:补丁部署到上述实例后,同等 Codex 流量下堆从"单调爬升至 4GB 假死"变为稳定波动、GC 正常回收,健康检查毫秒级,未再复现崩溃

Fixes #1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)
