### PR TITLE
fix(bedrock): repair AWS Bedrock integration and Claude Code model routing

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -66,8 +66,6 @@ const config = {
     defaultRegion: process.env.AWS_REGION || 'us-east-1',
     smallFastModelRegion: process.env.ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION,
     defaultModel: process.env.ANTHROPIC_MODEL || 'us.anthropic.claude-sonnet-4-20250514-v1:0',
-    smallFastModel:
-      process.env.ANTHROPIC_SMALL_FAST_MODEL || 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
     maxOutputTokens: parseInt(process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS) || 4096,
     maxThinkingTokens: parseInt(process.env.MAX_THINKING_TOKENS) || 1024,
     enablePromptCaching: process.env.DISABLE_PROMPT_CACHING !== '1'

--- a/config/models.js
+++ b/config/models.js
@@ -6,6 +6,7 @@
 const CLAUDE_MODELS = [
   { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
   { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+  { value: 'claude-opus-5', label: 'Claude Opus 5' },
   { value: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5' },
   { value: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5' },
   { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
@@ -45,6 +46,7 @@ const BEDROCK_MODELS = [
     value: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
     label: 'Claude Haiku 4.5'
   },
+  { value: 'global.anthropic.claude-opus-5', label: 'Claude Opus 5' },
   { value: 'us.anthropic.claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   { value: 'global.anthropic.claude-opus-4-6-v1', label: 'Claude Opus 4.6' },
   { value: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', label: 'Claude Sonnet 4.5' },

--- a/config/models.js
+++ b/config/models.js
@@ -41,11 +41,17 @@ const OPENAI_MODELS = [
 ]
 
 const BEDROCK_MODELS = [
-  { value: 'us.anthropic.claude-opus-4-6-20250610-v1:0', label: 'Claude Opus 4.6' },
+  {
+    value: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    label: 'Claude Haiku 4.5'
+  },
+  { value: 'us.anthropic.claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+  { value: 'global.anthropic.claude-opus-4-6-v1', label: 'Claude Opus 4.6' },
   { value: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', label: 'Claude Sonnet 4.5' },
-  { value: 'us.anthropic.claude-sonnet-4-20250514-v1:0', label: 'Claude Sonnet 4' },
-  { value: 'us.anthropic.claude-3-5-haiku-20241022-v1:0', label: 'Claude 3.5 Haiku' }
+  { value: 'us.anthropic.claude-sonnet-4-20250514-v1:0', label: 'Claude Sonnet 4' }
 ]
+
+const BEDROCK_TEST_MODEL = 'us.anthropic.claude-haiku-4-5-20251001-v1:0'
 
 // 其他模型（用于账户编辑的模型映射）
 const OTHER_MODELS = [
@@ -73,6 +79,7 @@ module.exports = {
   GEMINI_MODELS,
   OPENAI_MODELS,
   BEDROCK_MODELS,
+  BEDROCK_TEST_MODEL,
   OTHER_MODELS,
   PLATFORM_TEST_MODELS,
   // 按服务分组
@@ -84,6 +91,8 @@ module.exports = {
         return GEMINI_MODELS
       case 'openai':
         return OPENAI_MODELS
+      case 'bedrock':
+        return BEDROCK_MODELS
       default:
         return []
     }

--- a/config/models.js
+++ b/config/models.js
@@ -46,6 +46,7 @@ const BEDROCK_MODELS = [
     label: 'Claude Haiku 4.5'
   },
   { value: 'global.anthropic.claude-opus-5', label: 'Claude Opus 5' },
+  { value: 'global.anthropic.claude-sonnet-5', label: 'Claude Sonnet 5' },
   { value: 'us.anthropic.claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   { value: 'global.anthropic.claude-opus-4-6-v1', label: 'Claude Opus 4.6' },
   { value: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', label: 'Claude Sonnet 4.5' },

--- a/config/models.js
+++ b/config/models.js
@@ -6,7 +6,6 @@
 const CLAUDE_MODELS = [
   { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
   { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-  { value: 'claude-opus-5', label: 'Claude Opus 5' },
   { value: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5' },
   { value: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5' },
   { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@aws-sdk/client-bedrock": "^3.883.0",
         "@aws-sdk/client-bedrock-runtime": "^3.861.0",
-        "@aws-sdk/credential-providers": "^3.859.0",
         "axios": "^1.6.0",
         "bcryptjs": "^2.4.3",
         "chalk": "^4.1.2",
@@ -305,56 +304,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.883.0",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.883.0.tgz",
-      "integrity": "sha512-/uezRmLtkx7kZkC0o6B+hahCVBTij2ghCW+kXgbK0tz6Gl7WDYRIyszR9Vf0wDUqsj5S3hgBXKr6zR4V4ULTmw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.883.0",
-        "@aws-sdk/credential-provider-node": "3.883.0",
-        "@aws-sdk/middleware-host-header": "3.873.0",
-        "@aws-sdk/middleware-logger": "3.876.0",
-        "@aws-sdk/middleware-recursion-detection": "3.873.0",
-        "@aws-sdk/middleware-user-agent": "3.883.0",
-        "@aws-sdk/region-config-resolver": "3.873.0",
-        "@aws-sdk/types": "3.862.0",
-        "@aws-sdk/util-endpoints": "3.879.0",
-        "@aws-sdk/util-user-agent-browser": "3.873.0",
-        "@aws-sdk/util-user-agent-node": "3.883.0",
-        "@smithy/config-resolver": "^4.1.5",
-        "@smithy/core": "^3.9.2",
-        "@smithy/fetch-http-handler": "^5.1.1",
-        "@smithy/hash-node": "^4.0.5",
-        "@smithy/invalid-dependency": "^4.0.5",
-        "@smithy/middleware-content-length": "^4.0.5",
-        "@smithy/middleware-endpoint": "^4.1.21",
-        "@smithy/middleware-retry": "^4.1.22",
-        "@smithy/middleware-serde": "^4.0.9",
-        "@smithy/middleware-stack": "^4.0.5",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/node-http-handler": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/smithy-client": "^4.5.2",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.29",
-        "@smithy/util-defaults-mode-node": "^4.0.29",
-        "@smithy/util-endpoints": "^3.0.7",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-retry": "^4.0.7",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.883.0",
       "resolved": "https://registry.npmmirror.com/@aws-sdk/client-sso/-/client-sso-3.883.0.tgz",
@@ -424,22 +373,6 @@
         "@smithy/util-middleware": "^4.0.5",
         "@smithy/util-utf8": "^4.0.0",
         "fast-xml-parser": "5.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.883.0",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.883.0.tgz",
-      "integrity": "sha512-r5KQ1UP1LxtZ5PfBQr08zgn1fIgpDlyDSk59h3kpj91+xcuaQtn3241D61iTv0ICFTaurO5SqM25f87aQuAsDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.883.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -575,36 +508,6 @@
         "@aws-sdk/core": "3.883.0",
         "@aws-sdk/nested-clients": "3.883.0",
         "@aws-sdk/types": "3.862.0",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/types": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.883.0",
-      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-providers/-/credential-providers-3.883.0.tgz",
-      "integrity": "sha512-gIoGVbOTAaWm9muDo5QI42EAYW03RyNbtGb+Yhiy72EX15aZhRsW9v9Gs1YxC2d7dTW5Zs3qXMcenoMzas5aQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.883.0",
-        "@aws-sdk/core": "3.883.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.883.0",
-        "@aws-sdk/credential-provider-env": "3.883.0",
-        "@aws-sdk/credential-provider-http": "3.883.0",
-        "@aws-sdk/credential-provider-ini": "3.883.0",
-        "@aws-sdk/credential-provider-node": "3.883.0",
-        "@aws-sdk/credential-provider-process": "3.883.0",
-        "@aws-sdk/credential-provider-sso": "3.883.0",
-        "@aws-sdk/credential-provider-web-identity": "3.883.0",
-        "@aws-sdk/nested-clients": "3.883.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/config-resolver": "^4.1.5",
-        "@smithy/core": "^3.9.2",
-        "@smithy/credential-provider-imds": "^4.0.7",
-        "@smithy/node-config-provider": "^4.1.4",
         "@smithy/property-provider": "^4.0.5",
         "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-bedrock": "^3.883.0",
         "@aws-sdk/client-bedrock-runtime": "^3.861.0",
         "@aws-sdk/credential-providers": "^3.859.0",
         "axios": "^1.6.0",
@@ -189,6 +190,59 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock": {
+      "version": "3.883.0",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/client-bedrock/-/client-bedrock-3.883.0.tgz",
+      "integrity": "sha512-pIW6KdxK+efmFLES1U6am//A0+JT5po6+MKf5mx0PWZJ9rwEVGa9FalE+6Of5w4yXpwl4345+nWGrhcY52pjuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.883.0",
+        "@aws-sdk/credential-provider-node": "3.883.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.876.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.883.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/token-providers": "3.883.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.883.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.9.2",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.21",
+        "@smithy/middleware-retry": "^4.1.22",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.29",
+        "@smithy/util-defaults-mode-node": "^4.0.29",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "@aws-sdk/client-bedrock": "^3.883.0",
     "@aws-sdk/client-bedrock-runtime": "^3.861.0",
-    "@aws-sdk/credential-providers": "^3.859.0",
     "axios": "^1.6.0",
     "bcryptjs": "^2.4.3",
     "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:pricing-fallback": "node scripts/test-pricing-fallback.js"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock": "^3.883.0",
     "@aws-sdk/client-bedrock-runtime": "^3.861.0",
     "@aws-sdk/credential-providers": "^3.859.0",
     "axios": "^1.6.0",

--- a/src/models/redis.js
+++ b/src/models/redis.js
@@ -2188,6 +2188,15 @@ class RedisClient {
       accountData = await this.client.hgetall(`openai:account:${accountId}`)
     } else if (accountType === 'openai-responses') {
       accountData = await this.client.hgetall(`openai_responses_account:${accountId}`)
+    } else if (accountType === 'bedrock') {
+      const bedrockAccount = await this.client.get(`bedrock_account:${accountId}`)
+      if (bedrockAccount) {
+        try {
+          accountData = JSON.parse(bedrockAccount)
+        } catch (error) {
+          logger.warn(`Failed to parse Bedrock account ${accountId} for usage stats:`, error)
+        }
+      }
     } else {
       // 尝试多个前缀（优先 claude:account:）
       accountData = await this.client.hgetall(`claude:account:${accountId}`)

--- a/src/routes/admin/bedrockAccounts.js
+++ b/src/routes/admin/bedrockAccounts.js
@@ -58,7 +58,7 @@ router.get('/', authenticateAdmin, async (req, res) => {
     const accountsWithStats = await Promise.all(
       accounts.map(async (account) => {
         try {
-          const usageStats = await redis.getAccountUsageStats(account.id, 'openai')
+          const usageStats = await redis.getAccountUsageStats(account.id, 'bedrock')
           const groupInfos = await accountGroupService.getAccountGroups(account.id)
 
           const formattedAccount = formatAccountExpiry(account)
@@ -124,6 +124,8 @@ router.post('/', authenticateAdmin, async (req, res) => {
       awsCredentials,
       bearerToken,
       defaultModel,
+      expiresAt,
+      subscriptionExpiresAt,
       priority,
       accountType,
       credentialType
@@ -146,9 +148,9 @@ router.post('/', authenticateAdmin, async (req, res) => {
     }
 
     // 验证credentialType的有效性
-    if (credentialType && !['access_key', 'bearer_token'].includes(credentialType)) {
+    if (credentialType && !['access_key', 'bearer_token', 'default'].includes(credentialType)) {
       return res.status(400).json({
-        error: 'Invalid credential type. Must be "access_key" or "bearer_token"'
+        error: 'Invalid credential type. Must be "access_key", "bearer_token", or "default"'
       })
     }
 
@@ -159,6 +161,7 @@ router.post('/', authenticateAdmin, async (req, res) => {
       awsCredentials,
       bearerToken,
       defaultModel,
+      subscriptionExpiresAt: subscriptionExpiresAt ?? expiresAt ?? null,
       priority: priority || 50,
       accountType: accountType || 'shared',
       credentialType: credentialType || 'access_key'
@@ -166,7 +169,7 @@ router.post('/', authenticateAdmin, async (req, res) => {
 
     if (!result.success) {
       return res
-        .status(500)
+        .status(result.statusCode || 500)
         .json({ error: 'Failed to create Bedrock account', message: result.error })
     }
 
@@ -176,7 +179,7 @@ router.post('/', authenticateAdmin, async (req, res) => {
   } catch (error) {
     logger.error('❌ Failed to create Bedrock account:', error)
     return res
-      .status(500)
+      .status(error.statusCode || 500)
       .json({ error: 'Failed to create Bedrock account', message: error.message })
   }
 })
@@ -208,10 +211,10 @@ router.put('/:accountId', authenticateAdmin, async (req, res) => {
     // 验证credentialType的有效性
     if (
       mappedUpdates.credentialType &&
-      !['access_key', 'bearer_token'].includes(mappedUpdates.credentialType)
+      !['access_key', 'bearer_token', 'default'].includes(mappedUpdates.credentialType)
     ) {
       return res.status(400).json({
-        error: 'Invalid credential type. Must be "access_key" or "bearer_token"'
+        error: 'Invalid credential type. Must be "access_key", "bearer_token", or "default"'
       })
     }
 
@@ -219,7 +222,7 @@ router.put('/:accountId', authenticateAdmin, async (req, res) => {
 
     if (!result.success) {
       return res
-        .status(500)
+        .status(result.statusCode || 500)
         .json({ error: 'Failed to update Bedrock account', message: result.error })
     }
 
@@ -355,8 +358,9 @@ router.put('/:accountId/toggle-schedulable', authenticateAdmin, async (req, res)
 router.post('/:accountId/test', authenticateAdmin, async (req, res) => {
   try {
     const { accountId } = req.params
+    const { model } = req.body || {}
 
-    await bedrockAccountService.testAccountConnection(accountId, res)
+    await bedrockAccountService.testAccountConnection(accountId, res, model)
   } catch (error) {
     logger.error('❌ Failed to test Bedrock account:', error)
     // 错误已在服务层处理，这里仅做日志记录

--- a/src/routes/admin/bedrockAccounts.js
+++ b/src/routes/admin/bedrockAccounts.js
@@ -13,6 +13,7 @@ const { authenticateAdmin } = require('../../middleware/auth')
 const logger = require('../../utils/logger')
 const webhookNotifier = require('../../utils/webhookNotifier')
 const { formatAccountExpiry, mapExpiryField } = require('./utils')
+const { BEDROCK_CREDENTIAL_TYPES, normalizeBedrockRegion } = require('../../utils/bedrockConfig')
 
 // ☁️ Bedrock 账户管理
 
@@ -148,7 +149,7 @@ router.post('/', authenticateAdmin, async (req, res) => {
     }
 
     // 验证credentialType的有效性
-    if (credentialType && !['access_key', 'bearer_token', 'default'].includes(credentialType)) {
+    if (credentialType && !BEDROCK_CREDENTIAL_TYPES.includes(credentialType)) {
       return res.status(400).json({
         error: 'Invalid credential type. Must be "access_key", "bearer_token", or "default"'
       })
@@ -157,7 +158,7 @@ router.post('/', authenticateAdmin, async (req, res) => {
     const result = await bedrockAccountService.createAccount({
       name,
       description: description || '',
-      region: region || 'us-east-1',
+      region: normalizeBedrockRegion(region, 'us-east-1'),
       awsCredentials,
       bearerToken,
       defaultModel,
@@ -193,6 +194,10 @@ router.put('/:accountId', authenticateAdmin, async (req, res) => {
     // ✅ 【新增】映射字段名：前端的 expiresAt -> 后端的 subscriptionExpiresAt
     const mappedUpdates = mapExpiryField(updates, 'Bedrock', accountId)
 
+    if (mappedUpdates.region !== undefined) {
+      mappedUpdates.region = normalizeBedrockRegion(mappedUpdates.region)
+    }
+
     // 验证priority的有效性（1-100）
     if (
       mappedUpdates.priority !== undefined &&
@@ -211,7 +216,7 @@ router.put('/:accountId', authenticateAdmin, async (req, res) => {
     // 验证credentialType的有效性
     if (
       mappedUpdates.credentialType &&
-      !['access_key', 'bearer_token', 'default'].includes(mappedUpdates.credentialType)
+      !BEDROCK_CREDENTIAL_TYPES.includes(mappedUpdates.credentialType)
     ) {
       return res.status(400).json({
         error: 'Invalid credential type. Must be "access_key", "bearer_token", or "default"'
@@ -231,7 +236,7 @@ router.put('/:accountId', authenticateAdmin, async (req, res) => {
   } catch (error) {
     logger.error('❌ Failed to update Bedrock account:', error)
     return res
-      .status(500)
+      .status(error.statusCode || 500)
       .json({ error: 'Failed to update Bedrock account', message: error.message })
   }
 })

--- a/src/services/account/bedrockAccountService.js
+++ b/src/services/account/bedrockAccountService.js
@@ -3,9 +3,13 @@ const crypto = require('crypto')
 const redis = require('../../models/redis')
 const logger = require('../../utils/logger')
 const config = require('../../../config/config')
+const { BEDROCK_TEST_MODEL } = require('../../../config/models')
 const bedrockRelayService = require('../relay/bedrockRelayService')
 const LRUCache = require('../../utils/lruCache')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
+const { normalizeBedrockRegion, assertSupportedBedrockModel } = require('../../utils/bedrockConfig')
+
+const BEDROCK_CREDENTIAL_TYPES = ['access_key', 'bearer_token', 'default']
 
 class BedrockAccountService {
   constructor() {
@@ -29,6 +33,74 @@ class BedrockAccountService {
     )
   }
 
+  _createValidationError(message) {
+    const error = new Error(message)
+    error.code = 'BEDROCK_VALIDATION_ERROR'
+    error.statusCode = 400
+    return error
+  }
+
+  _resolveCredentialType(account = {}) {
+    if (BEDROCK_CREDENTIAL_TYPES.includes(account.credentialType)) {
+      return account.credentialType
+    }
+    if (account.awsCredentials) {
+      return 'access_key'
+    }
+    if (account.bearerToken) {
+      return 'bearer_token'
+    }
+    return 'default'
+  }
+
+  _assertCredentialType(credentialType) {
+    if (!BEDROCK_CREDENTIAL_TYPES.includes(credentialType)) {
+      throw this._createValidationError(
+        `Invalid credential type. Must be one of: ${BEDROCK_CREDENTIAL_TYPES.join(', ')}`
+      )
+    }
+    return credentialType
+  }
+
+  _normalizeAccessKeyCredentials(credentials) {
+    if (!credentials || typeof credentials !== 'object') {
+      return credentials
+    }
+    const normalized = {}
+    if (Object.prototype.hasOwnProperty.call(credentials, 'accessKeyId')) {
+      normalized.accessKeyId =
+        typeof credentials.accessKeyId === 'string'
+          ? credentials.accessKeyId.trim()
+          : credentials.accessKeyId
+    }
+    if (Object.prototype.hasOwnProperty.call(credentials, 'secretAccessKey')) {
+      normalized.secretAccessKey =
+        typeof credentials.secretAccessKey === 'string'
+          ? credentials.secretAccessKey.trim()
+          : credentials.secretAccessKey
+    }
+    if (Object.prototype.hasOwnProperty.call(credentials, 'sessionToken')) {
+      normalized.sessionToken =
+        typeof credentials.sessionToken === 'string'
+          ? credentials.sessionToken.trim() || null
+          : credentials.sessionToken
+    }
+    return normalized
+  }
+
+  _assertCompleteAccessKeyCredentials(credentials) {
+    if (
+      typeof credentials?.accessKeyId !== 'string' ||
+      !credentials.accessKeyId ||
+      typeof credentials?.secretAccessKey !== 'string' ||
+      !credentials.secretAccessKey
+    ) {
+      throw this._createValidationError(
+        'AWS Access Key ID and Secret Access Key are required for access_key credentials'
+      )
+    }
+  }
+
   // 🏢 创建Bedrock账户
   async createAccount(options = {}) {
     const {
@@ -42,27 +114,40 @@ class BedrockAccountService {
       accountType = 'shared', // 'dedicated' or 'shared'
       priority = 50, // 调度优先级 (1-100，数字越小优先级越高)
       schedulable = true, // 是否可被调度
-      credentialType = 'access_key', // 'access_key', 'bearer_token'（默认为 access_key）
+      credentialType = 'access_key',
       disableAutoProtection = false // 是否关闭自动防护（429/401/400/529 不自动禁用）
     } = options
 
     const accountId = uuidv4()
+    const normalizedRegion = normalizeBedrockRegion(region, 'us-east-1')
+    const normalizedCredentialType = this._assertCredentialType(credentialType)
+    const normalizedDefaultModel = defaultModel ? assertSupportedBedrockModel(defaultModel) : null
+    const normalizedCredentials = this._normalizeAccessKeyCredentials(awsCredentials)
+
+    if (normalizedCredentialType === 'access_key') {
+      this._assertCompleteAccessKeyCredentials(normalizedCredentials)
+    } else if (
+      normalizedCredentialType === 'bearer_token' &&
+      (typeof bearerToken !== 'string' || !bearerToken.trim())
+    ) {
+      throw this._createValidationError('Bearer Token is required for bearer_token credentials')
+    }
 
     const accountData = {
       id: accountId,
       name,
       description,
-      region,
-      defaultModel,
+      region: normalizedRegion,
+      defaultModel: normalizedDefaultModel,
       isActive,
       accountType,
       priority,
       schedulable,
-      credentialType,
+      credentialType: normalizedCredentialType,
 
       // ✅ 新增：账户订阅到期时间（业务字段，手动管理）
       // 注意：Bedrock 使用 AWS 凭证，没有 OAuth token，因此没有 expiresAt
-      subscriptionExpiresAt: options.subscriptionExpiresAt || null,
+      subscriptionExpiresAt: options.subscriptionExpiresAt || options.expiresAt || null,
 
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -71,20 +156,22 @@ class BedrockAccountService {
     }
 
     // 加密存储AWS凭证
-    if (awsCredentials) {
-      accountData.awsCredentials = this._encryptAwsCredentials(awsCredentials)
+    if (normalizedCredentialType === 'access_key') {
+      accountData.awsCredentials = this._encryptAwsCredentials(normalizedCredentials)
     }
 
     // 加密存储 Bearer Token
-    if (bearerToken) {
-      accountData.bearerToken = this._encryptAwsCredentials({ token: bearerToken })
+    if (normalizedCredentialType === 'bearer_token') {
+      accountData.bearerToken = this._encryptAwsCredentials({ token: bearerToken.trim() })
     }
 
     const client = redis.getClientSafe()
     await client.set(`bedrock_account:${accountId}`, JSON.stringify(accountData))
     await redis.addToIndex('bedrock_account:index', accountId)
 
-    logger.info(`✅ 创建Bedrock账户成功 - ID: ${accountId}, 名称: ${name}, 区域: ${region}`)
+    logger.info(
+      `✅ 创建Bedrock账户成功 - ID: ${accountId}, 名称: ${name}, 区域: ${normalizedRegion}`
+    )
 
     return {
       success: true,
@@ -92,13 +179,14 @@ class BedrockAccountService {
         id: accountId,
         name,
         description,
-        region,
-        defaultModel,
+        region: normalizedRegion,
+        defaultModel: normalizedDefaultModel,
         isActive,
         accountType,
         priority,
         schedulable,
-        credentialType,
+        credentialType: normalizedCredentialType,
+        expiresAt: accountData.subscriptionExpiresAt,
         createdAt: accountData.createdAt,
         type: 'bedrock'
       }
@@ -115,76 +203,31 @@ class BedrockAccountService {
       }
 
       const account = JSON.parse(accountData)
+      account.region = normalizeBedrockRegion(account.region, 'us-east-1')
+      account.credentialType = this._resolveCredentialType(account)
 
-      // 根据凭证类型解密对应的凭证
-      // 增强逻辑：优先按照 credentialType 解密，如果字段不存在则尝试解密实际存在的字段（兜底）
       try {
-        let accessKeyDecrypted = false
-        let bearerTokenDecrypted = false
-
-        // 第一步：按照 credentialType 尝试解密对应的凭证
-        if (account.credentialType === 'access_key' && account.awsCredentials) {
-          // Access Key 模式：解密 AWS 凭证
+        if (account.credentialType === 'access_key') {
+          if (!account.awsCredentials) {
+            throw new Error('AWS access key credentials are missing')
+          }
           account.awsCredentials = this._decryptAwsCredentials(account.awsCredentials)
-          accessKeyDecrypted = true
-          logger.debug(
-            `🔓 解密 Access Key 成功 - ID: ${accountId}, 类型: ${account.credentialType}`
-          )
-        } else if (account.credentialType === 'bearer_token' && account.bearerToken) {
-          // Bearer Token 模式：解密 Bearer Token
+          this._assertCompleteAccessKeyCredentials(account.awsCredentials)
+          delete account.bearerToken
+        } else if (account.credentialType === 'bearer_token') {
+          if (!account.bearerToken) {
+            throw new Error('AWS Bedrock bearer token is missing')
+          }
           const decrypted = this._decryptAwsCredentials(account.bearerToken)
           account.bearerToken = decrypted.token
-          bearerTokenDecrypted = true
-          logger.debug(
-            `🔓 解密 Bearer Token 成功 - ID: ${accountId}, 类型: ${account.credentialType}`
-          )
-        } else if (!account.credentialType || account.credentialType === 'default') {
-          // 向后兼容：旧版本账号可能没有 credentialType 字段，尝试解密所有存在的凭证
-          if (account.awsCredentials) {
-            account.awsCredentials = this._decryptAwsCredentials(account.awsCredentials)
-            accessKeyDecrypted = true
+          if (!account.bearerToken) {
+            throw new Error('AWS Bedrock bearer token is empty')
           }
-          if (account.bearerToken) {
-            const decrypted = this._decryptAwsCredentials(account.bearerToken)
-            account.bearerToken = decrypted.token
-            bearerTokenDecrypted = true
-          }
-          logger.debug(
-            `🔓 兼容模式解密 - ID: ${accountId}, Access Key: ${accessKeyDecrypted}, Bearer Token: ${bearerTokenDecrypted}`
-          )
-        }
-
-        // 第二步：兜底逻辑 - 如果按照 credentialType 没有解密到任何凭证，尝试解密实际存在的字段
-        if (!accessKeyDecrypted && !bearerTokenDecrypted) {
-          logger.warn(
-            `⚠️ credentialType="${account.credentialType}" 与实际字段不匹配，尝试兜底解密 - ID: ${accountId}`
-          )
-          if (account.awsCredentials) {
-            account.awsCredentials = this._decryptAwsCredentials(account.awsCredentials)
-            accessKeyDecrypted = true
-            logger.warn(
-              `🔓 兜底解密 Access Key 成功 - ID: ${accountId}, credentialType 应为 'access_key'`
-            )
-          }
-          if (account.bearerToken) {
-            const decrypted = this._decryptAwsCredentials(account.bearerToken)
-            account.bearerToken = decrypted.token
-            bearerTokenDecrypted = true
-            logger.warn(
-              `🔓 兜底解密 Bearer Token 成功 - ID: ${accountId}, credentialType 应为 'bearer_token'`
-            )
-          }
-        }
-
-        // 验证至少解密了一种凭证
-        if (!accessKeyDecrypted && !bearerTokenDecrypted) {
-          logger.error(
-            `❌ 未找到任何凭证可解密 - ID: ${accountId}, credentialType: ${account.credentialType}, hasAwsCredentials: ${!!account.awsCredentials}, hasBearerToken: ${!!account.bearerToken}`
-          )
-          return {
-            success: false,
-            error: 'No valid credentials found in account data'
-          }
+          delete account.awsCredentials
+        } else {
+          // Default provider-chain accounts must never accidentally use stale stored credentials.
+          delete account.awsCredentials
+          delete account.bearerToken
         }
       } catch (decryptError) {
         logger.error(
@@ -226,19 +269,28 @@ class BedrockAccountService {
         const accountData = dataList[i]
         if (accountData) {
           const account = JSON.parse(accountData)
+          const credentialType = this._resolveCredentialType(account)
+          let normalizedRegion
+          try {
+            normalizedRegion = normalizeBedrockRegion(account.region, 'us-east-1')
+          } catch (_error) {
+            normalizedRegion = String(account.region || '')
+              .trim()
+              .toLowerCase()
+          }
 
           // 返回给前端时，不包含敏感信息，只显示掩码
           accounts.push({
             id: account.id,
             name: account.name,
             description: account.description,
-            region: account.region,
+            region: normalizedRegion,
             defaultModel: account.defaultModel,
             isActive: account.isActive,
             accountType: account.accountType,
             priority: account.priority,
             schedulable: account.schedulable,
-            credentialType: account.credentialType,
+            credentialType,
 
             // ✅ 前端显示订阅过期时间（业务字段）
             expiresAt: account.subscriptionExpiresAt || null,
@@ -249,9 +301,11 @@ class BedrockAccountService {
             platform: 'bedrock',
             // 根据凭证类型判断是否有凭证
             hasCredentials:
-              account.credentialType === 'bearer_token'
-                ? !!account.bearerToken
-                : !!account.awsCredentials
+              credentialType === 'default'
+                ? true
+                : credentialType === 'bearer_token'
+                  ? !!account.bearerToken
+                  : !!account.awsCredentials
           })
         }
       }
@@ -287,6 +341,10 @@ class BedrockAccountService {
       }
 
       const account = JSON.parse(accountData)
+      const currentCredentialType = this._resolveCredentialType(account)
+      const targetCredentialType = this._assertCredentialType(
+        updates.credentialType === undefined ? currentCredentialType : updates.credentialType
+      )
 
       // 更新字段
       if (updates.name !== undefined) {
@@ -296,10 +354,14 @@ class BedrockAccountService {
         account.description = updates.description
       }
       if (updates.region !== undefined) {
-        account.region = updates.region
+        account.region = normalizeBedrockRegion(updates.region, account.region || 'us-east-1')
+      } else {
+        account.region = normalizeBedrockRegion(account.region, 'us-east-1')
       }
       if (updates.defaultModel !== undefined) {
         account.defaultModel = updates.defaultModel
+          ? assertSupportedBedrockModel(updates.defaultModel)
+          : null
       }
       if (updates.isActive !== undefined) {
         account.isActive = updates.isActive
@@ -313,32 +375,68 @@ class BedrockAccountService {
       if (updates.schedulable !== undefined) {
         account.schedulable = updates.schedulable
       }
-      if (updates.credentialType !== undefined) {
-        account.credentialType = updates.credentialType
-      }
+      if (targetCredentialType === 'access_key') {
+        if (targetCredentialType !== currentCredentialType && !updates.awsCredentials) {
+          throw this._createValidationError(
+            'Complete AWS access key credentials are required when switching credential type'
+          )
+        }
 
-      // 更新AWS凭证
-      if (updates.awsCredentials !== undefined) {
-        if (updates.awsCredentials) {
-          account.awsCredentials = this._encryptAwsCredentials(updates.awsCredentials)
-        } else {
+        if (updates.awsCredentials === null) {
           delete account.awsCredentials
-        }
-      } else if (account.awsCredentials && account.awsCredentials.accessKeyId) {
-        // 如果没有提供新凭证但现有凭证是明文格式，重新加密
-        const plainCredentials = account.awsCredentials
-        account.awsCredentials = this._encryptAwsCredentials(plainCredentials)
-        logger.info(`🔐 重新加密Bedrock账户凭证 - ID: ${accountId}`)
-      }
+        } else if (updates.awsCredentials !== undefined) {
+          const existingCredentials =
+            targetCredentialType === currentCredentialType && account.awsCredentials
+              ? this._decryptAwsCredentials(account.awsCredentials)
+              : {}
+          const patch = this._normalizeAccessKeyCredentials(updates.awsCredentials)
+          const mergedCredentials = { ...existingCredentials }
 
-      // 更新 Bearer Token
-      if (updates.bearerToken !== undefined) {
-        if (updates.bearerToken) {
-          account.bearerToken = this._encryptAwsCredentials({ token: updates.bearerToken })
-        } else {
-          delete account.bearerToken
+          if (Object.prototype.hasOwnProperty.call(patch, 'accessKeyId')) {
+            mergedCredentials.accessKeyId = patch.accessKeyId
+          }
+          if (Object.prototype.hasOwnProperty.call(patch, 'secretAccessKey')) {
+            mergedCredentials.secretAccessKey = patch.secretAccessKey
+          }
+          if (Object.prototype.hasOwnProperty.call(patch, 'sessionToken')) {
+            if (patch.sessionToken === null) {
+              delete mergedCredentials.sessionToken
+            } else {
+              mergedCredentials.sessionToken = patch.sessionToken
+            }
+          }
+
+          this._assertCompleteAccessKeyCredentials(mergedCredentials)
+          account.awsCredentials = this._encryptAwsCredentials(mergedCredentials)
+        } else if (account.awsCredentials?.accessKeyId) {
+          account.awsCredentials = this._encryptAwsCredentials(account.awsCredentials)
         }
+        delete account.bearerToken
+      } else if (targetCredentialType === 'bearer_token') {
+        if (
+          targetCredentialType !== currentCredentialType &&
+          (typeof updates.bearerToken !== 'string' || !updates.bearerToken.trim())
+        ) {
+          throw this._createValidationError(
+            'Bearer Token is required when switching credential type'
+          )
+        }
+
+        if (updates.bearerToken !== undefined) {
+          if (typeof updates.bearerToken === 'string' && updates.bearerToken.trim()) {
+            account.bearerToken = this._encryptAwsCredentials({
+              token: updates.bearerToken.trim()
+            })
+          } else {
+            delete account.bearerToken
+          }
+        }
+        delete account.awsCredentials
+      } else {
+        delete account.awsCredentials
+        delete account.bearerToken
       }
+      account.credentialType = targetCredentialType
 
       // ✅ 直接保存 subscriptionExpiresAt（如果提供）
       // Bedrock 没有 token 刷新逻辑，不会覆盖此字段
@@ -354,6 +452,7 @@ class BedrockAccountService {
       account.updatedAt = new Date().toISOString()
 
       await client.set(`bedrock_account:${accountId}`, JSON.stringify(account))
+      bedrockRelayService.invalidateAccountClients(accountId)
 
       logger.info(`✅ 更新Bedrock账户成功 - ID: ${accountId}, 名称: ${account.name}`)
 
@@ -370,13 +469,14 @@ class BedrockAccountService {
           priority: account.priority,
           schedulable: account.schedulable,
           credentialType: account.credentialType,
+          expiresAt: account.subscriptionExpiresAt || null,
           updatedAt: account.updatedAt,
           type: 'bedrock'
         }
       }
     } catch (error) {
       logger.error(`❌ 更新Bedrock账户失败 - ID: ${accountId}`, error)
-      return { success: false, error: error.message }
+      return { success: false, error: error.message, statusCode: error.statusCode }
     }
   }
 
@@ -391,6 +491,7 @@ class BedrockAccountService {
       const client = redis.getClientSafe()
       await client.del(`bedrock_account:${accountId}`)
       await redis.removeFromIndex('bedrock_account:index', accountId)
+      bedrockRelayService.invalidateAccountClients(accountId)
 
       logger.info(`✅ 删除Bedrock账户成功 - ID: ${accountId}`)
 
@@ -447,7 +548,7 @@ class BedrockAccountService {
   }
 
   // 🧪 测试账户连接
-  async testAccount(accountId) {
+  async testAccount(accountId, model = BEDROCK_TEST_MODEL) {
     try {
       const accountResult = await this.getAccount(accountId)
       if (!accountResult.success) {
@@ -456,58 +557,16 @@ class BedrockAccountService {
 
       const account = accountResult.data
 
-      logger.info(
-        `🧪 测试Bedrock账户连接 - ID: ${accountId}, 名称: ${account.name}, 凭证类型: ${account.credentialType}`
-      )
-
-      // 验证凭证是否已解密
-      const hasValidCredentials =
-        (account.credentialType === 'access_key' && account.awsCredentials) ||
-        (account.credentialType === 'bearer_token' && account.bearerToken) ||
-        (!account.credentialType && (account.awsCredentials || account.bearerToken))
-
-      if (!hasValidCredentials) {
-        logger.error(
-          `❌ 测试失败：账户没有有效凭证 - ID: ${accountId}, credentialType: ${account.credentialType}`
-        )
-        return {
-          success: false,
-          error: 'No valid credentials found after decryption'
-        }
-      }
-
-      // 尝试创建 Bedrock 客户端来验证凭证格式
-      try {
-        bedrockRelayService._getBedrockClient(account.region, account)
-        logger.debug(`✅ Bedrock客户端创建成功 - ID: ${accountId}`)
-      } catch (clientError) {
-        logger.error(`❌ 创建Bedrock客户端失败 - ID: ${accountId}`, clientError)
-        return {
-          success: false,
-          error: `Failed to create Bedrock client: ${clientError.message}`
-        }
-      }
-
-      // 获取可用模型列表（硬编码，但至少验证了凭证格式正确）
+      const connection = await bedrockRelayService.testConnection(account, model)
       const models = await bedrockRelayService.getAvailableModels(account)
 
-      if (models && models.length > 0) {
-        logger.info(
-          `✅ Bedrock账户测试成功 - ID: ${accountId}, 发现 ${models.length} 个模型, 凭证类型: ${account.credentialType}`
-        )
-        return {
-          success: true,
-          data: {
-            status: 'connected',
-            modelsCount: models.length,
-            region: account.region,
-            credentialType: account.credentialType
-          }
-        }
-      } else {
-        return {
-          success: false,
-          error: 'Unable to retrieve models from Bedrock'
+      logger.info(`✅ Bedrock账户真实连接测试成功 - ID: ${accountId}, 模型: ${connection.model}`)
+      return {
+        success: true,
+        data: {
+          ...connection,
+          modelsCount: models.length,
+          credentialType: account.credentialType
         }
       }
     } catch (error) {
@@ -526,8 +585,6 @@ class BedrockAccountService {
    * @param {string} model - 测试使用的模型
    */
   async testAccountConnection(accountId, res, model = null) {
-    const { InvokeModelWithResponseStreamCommand } = require('@aws-sdk/client-bedrock-runtime')
-
     try {
       // 获取账户信息
       const accountResult = await this.getAccount(accountId)
@@ -537,11 +594,7 @@ class BedrockAccountService {
 
       const account = accountResult.data
 
-      // 根据账户类型选择合适的测试模型
-      if (!model) {
-        // Access Key 模式使用 Haiku（更快更便宜）
-        model = account.defaultModel || 'us.anthropic.claude-3-5-haiku-20241022-v1:0'
-      }
+      model = model || BEDROCK_TEST_MODEL
 
       logger.info(
         `🧪 Testing Bedrock account connection: ${account.name} (${accountId}), model: ${model}, credentialType: ${account.credentialType}`
@@ -557,60 +610,12 @@ class BedrockAccountService {
       // 发送 test_start 事件
       res.write(`data: ${JSON.stringify({ type: 'test_start' })}\n\n`)
 
-      // 构造测试请求体（Bedrock 格式）
-      const bedrockPayload = {
-        anthropic_version: 'bedrock-2023-05-31',
-        max_tokens: 256,
-        messages: [
-          {
-            role: 'user',
-            content:
-              'Hello! Please respond with a simple greeting to confirm the connection is working. And tell me who are you?'
-          }
-        ]
-      }
-
-      // 获取 Bedrock 客户端
-      const region = account.region || bedrockRelayService.defaultRegion
-      const client = bedrockRelayService._getBedrockClient(region, account)
-
-      // 创建流式调用命令
-      const command = new InvokeModelWithResponseStreamCommand({
-        modelId: model,
-        body: JSON.stringify(bedrockPayload),
-        contentType: 'application/json',
-        accept: 'application/json'
+      const connection = await bedrockRelayService.testConnection(account, model, (text) => {
+        res.write(`data: ${JSON.stringify({ type: 'content', text })}\n\n`)
       })
-
-      logger.debug(`🌊 Bedrock test stream - model: ${model}, region: ${region}`)
-
-      const startTime = Date.now()
-      const response = await client.send(command)
-
-      // 处理流式响应
-      // let responseText = ''
-      for await (const chunk of response.body) {
-        if (chunk.chunk) {
-          const chunkData = JSON.parse(new TextDecoder().decode(chunk.chunk.bytes))
-
-          // 提取文本内容
-          if (chunkData.type === 'content_block_delta' && chunkData.delta?.text) {
-            const { text } = chunkData.delta
-            // responseText += text
-
-            // 发送 content 事件
-            res.write(`data: ${JSON.stringify({ type: 'content', text })}\n\n`)
-          }
-
-          // 检测错误
-          if (chunkData.type === 'error') {
-            throw new Error(chunkData.error?.message || 'Bedrock API error')
-          }
-        }
-      }
-
-      const duration = Date.now() - startTime
-      logger.info(`✅ Bedrock test completed - model: ${model}, duration: ${duration}ms`)
+      logger.info(
+        `✅ Bedrock test completed - model: ${connection.model}, duration: ${connection.duration}ms`
+      )
 
       // 发送 message_stop 事件（前端兼容）
       res.write(`data: ${JSON.stringify({ type: 'message_stop' })}\n\n`)
@@ -654,11 +659,12 @@ class BedrockAccountService {
    * @returns {boolean} - true: 已过期, false: 未过期
    */
   isSubscriptionExpired(account) {
-    if (!account.subscriptionExpiresAt) {
+    const expiresAt = account?.subscriptionExpiresAt || account?.expiresAt
+    if (!expiresAt) {
       return false // 未设置视为永不过期
     }
-    const expiryDate = new Date(account.subscriptionExpiresAt)
-    return expiryDate <= new Date()
+    const expiryTime = new Date(expiresAt).getTime()
+    return Number.isFinite(expiryTime) && expiryTime <= Date.now()
   }
 
   // 🔑 生成加密密钥（缓存优化）

--- a/src/services/account/bedrockAccountService.js
+++ b/src/services/account/bedrockAccountService.js
@@ -7,9 +7,11 @@ const { BEDROCK_TEST_MODEL } = require('../../../config/models')
 const bedrockRelayService = require('../relay/bedrockRelayService')
 const LRUCache = require('../../utils/lruCache')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
-const { normalizeBedrockRegion, assertSupportedBedrockModel } = require('../../utils/bedrockConfig')
-
-const BEDROCK_CREDENTIAL_TYPES = ['access_key', 'bearer_token', 'default']
+const {
+  BEDROCK_CREDENTIAL_TYPES,
+  normalizeBedrockRegion,
+  assertSupportedBedrockModel
+} = require('../../utils/bedrockConfig')
 
 class BedrockAccountService {
   constructor() {
@@ -60,6 +62,13 @@ class BedrockAccountService {
       )
     }
     return credentialType
+  }
+
+  _getSubscriptionExpiry(account = {}) {
+    if (Object.prototype.hasOwnProperty.call(account, 'subscriptionExpiresAt')) {
+      return account.subscriptionExpiresAt || null
+    }
+    return account.expiresAt || null
   }
 
   _normalizeAccessKeyCredentials(credentials) {
@@ -186,6 +195,8 @@ class BedrockAccountService {
         priority,
         schedulable,
         credentialType: normalizedCredentialType,
+        subscriptionExpiresAt: accountData.subscriptionExpiresAt,
+        tokenExpiresAt: null,
         expiresAt: accountData.subscriptionExpiresAt,
         createdAt: accountData.createdAt,
         type: 'bedrock'
@@ -205,6 +216,8 @@ class BedrockAccountService {
       const account = JSON.parse(accountData)
       account.region = normalizeBedrockRegion(account.region, 'us-east-1')
       account.credentialType = this._resolveCredentialType(account)
+      account.subscriptionExpiresAt = this._getSubscriptionExpiry(account)
+      account.expiresAt = account.subscriptionExpiresAt
 
       try {
         if (account.credentialType === 'access_key') {
@@ -270,6 +283,7 @@ class BedrockAccountService {
         if (accountData) {
           const account = JSON.parse(accountData)
           const credentialType = this._resolveCredentialType(account)
+          const subscriptionExpiresAt = this._getSubscriptionExpiry(account)
           let normalizedRegion
           try {
             normalizedRegion = normalizeBedrockRegion(account.region, 'us-east-1')
@@ -293,7 +307,9 @@ class BedrockAccountService {
             credentialType,
 
             // ✅ 前端显示订阅过期时间（业务字段）
-            expiresAt: account.subscriptionExpiresAt || null,
+            subscriptionExpiresAt,
+            tokenExpiresAt: null,
+            expiresAt: subscriptionExpiresAt,
 
             createdAt: account.createdAt,
             updatedAt: account.updatedAt,
@@ -354,7 +370,7 @@ class BedrockAccountService {
         account.description = updates.description
       }
       if (updates.region !== undefined) {
-        account.region = normalizeBedrockRegion(updates.region, account.region || 'us-east-1')
+        account.region = normalizeBedrockRegion(updates.region)
       } else {
         account.region = normalizeBedrockRegion(account.region, 'us-east-1')
       }
@@ -384,6 +400,8 @@ class BedrockAccountService {
 
         if (updates.awsCredentials === null) {
           delete account.awsCredentials
+          account.isActive = false
+          account.schedulable = false
         } else if (updates.awsCredentials !== undefined) {
           const existingCredentials =
             targetCredentialType === currentCredentialType && account.awsCredentials
@@ -429,6 +447,8 @@ class BedrockAccountService {
             })
           } else {
             delete account.bearerToken
+            account.isActive = false
+            account.schedulable = false
           }
         }
         delete account.awsCredentials
@@ -442,6 +462,7 @@ class BedrockAccountService {
       // Bedrock 没有 token 刷新逻辑，不会覆盖此字段
       if (updates.subscriptionExpiresAt !== undefined) {
         account.subscriptionExpiresAt = updates.subscriptionExpiresAt
+        delete account.expiresAt
       }
 
       // 自动防护开关
@@ -469,7 +490,9 @@ class BedrockAccountService {
           priority: account.priority,
           schedulable: account.schedulable,
           credentialType: account.credentialType,
-          expiresAt: account.subscriptionExpiresAt || null,
+          subscriptionExpiresAt: this._getSubscriptionExpiry(account),
+          tokenExpiresAt: null,
+          expiresAt: this._getSubscriptionExpiry(account),
           updatedAt: account.updatedAt,
           type: 'bedrock'
         }
@@ -483,12 +506,12 @@ class BedrockAccountService {
   // 🗑️ 删除账户
   async deleteAccount(accountId) {
     try {
-      const accountResult = await this.getAccount(accountId)
-      if (!accountResult.success) {
-        return accountResult
+      const client = redis.getClientSafe()
+      const accountData = await client.get(`bedrock_account:${accountId}`)
+      if (!accountData) {
+        return { success: false, error: 'Account not found' }
       }
 
-      const client = redis.getClientSafe()
       await client.del(`bedrock_account:${accountId}`)
       await redis.removeFromIndex('bedrock_account:index', accountId)
       bedrockRelayService.invalidateAccountClients(accountId)
@@ -519,7 +542,7 @@ class BedrockAccountService {
           return false
         }
 
-        return account.isActive && account.schedulable
+        return account.isActive && account.schedulable && account.hasCredentials !== false
       })
 
       if (availableAccounts.length === 0) {
@@ -659,7 +682,7 @@ class BedrockAccountService {
    * @returns {boolean} - true: 已过期, false: 未过期
    */
   isSubscriptionExpired(account) {
-    const expiresAt = account?.subscriptionExpiresAt || account?.expiresAt
+    const expiresAt = this._getSubscriptionExpiry(account)
     if (!expiresAt) {
       return false // 未设置视为永不过期
     }

--- a/src/services/relay/bedrockRelayService.js
+++ b/src/services/relay/bedrockRelayService.js
@@ -598,6 +598,9 @@ class BedrockRelayService {
       // Claude Opus 5
       'claude-opus-5': 'global.anthropic.claude-opus-5',
 
+      // Claude Sonnet 5
+      'claude-sonnet-5': 'global.anthropic.claude-sonnet-5',
+
       // Claude Opus 4.6
       'claude-opus-4-6': 'global.anthropic.claude-opus-4-6-v1',
 
@@ -713,13 +716,14 @@ class BedrockRelayService {
 
   _supportsAdaptiveThinking(modelId) {
     const normalizedModel = (modelId || '').replace(/\[1m\]$/, '')
-    return ['claude-opus-5', 'claude-opus-4-6', 'claude-sonnet-4-6'].some((model) =>
-      normalizedModel.includes(model)
+    return ['claude-opus-5', 'claude-sonnet-5', 'claude-opus-4-6', 'claude-sonnet-4-6'].some(
+      (model) => normalizedModel.includes(model)
     )
   }
 
   _requiresAdaptiveThinking(modelId) {
-    return (modelId || '').replace(/\[1m\]$/, '').includes('claude-opus-5')
+    const normalizedModel = (modelId || '').replace(/\[1m\]$/, '')
+    return ['claude-opus-5', 'claude-sonnet-5'].some((model) => normalizedModel.includes(model))
   }
 
   // 转换Claude格式请求到Bedrock格式

--- a/src/services/relay/bedrockRelayService.js
+++ b/src/services/relay/bedrockRelayService.js
@@ -8,7 +8,11 @@ const { BedrockClient, ListInferenceProfilesCommand } = require('@aws-sdk/client
 const logger = require('../../utils/logger')
 const config = require('../../../config/config')
 const { BEDROCK_MODELS, BEDROCK_TEST_MODEL } = require('../../../config/models')
-const { normalizeBedrockRegion, assertSupportedBedrockModel } = require('../../utils/bedrockConfig')
+const {
+  BEDROCK_CREDENTIAL_TYPES,
+  normalizeBedrockRegion,
+  assertSupportedBedrockModel
+} = require('../../utils/bedrockConfig')
 const userMessageQueueService = require('../userMessageQueueService')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
 
@@ -37,7 +41,7 @@ class BedrockRelayService {
     if (!bedrockAccount) {
       return 'default'
     }
-    if (['access_key', 'bearer_token', 'default'].includes(bedrockAccount.credentialType)) {
+    if (BEDROCK_CREDENTIAL_TYPES.includes(bedrockAccount.credentialType)) {
       return bedrockAccount.credentialType
     }
     if (bedrockAccount.awsCredentials) {
@@ -988,33 +992,37 @@ class BedrockRelayService {
       const client = new BedrockClient(
         this._createAwsClientConfig(region, bedrockAccount, credentialType)
       )
-      const profiles = []
-      let nextToken
+      try {
+        const profiles = []
+        let nextToken
 
-      do {
-        const response = await client.send(
-          new ListInferenceProfilesCommand({
-            typeEquals: 'SYSTEM_DEFINED',
-            maxResults: 100,
-            nextToken
-          })
-        )
-        profiles.push(...(response.inferenceProfileSummaries || []))
-        const { nextToken: responseNextToken } = response
-        nextToken = responseNextToken
-      } while (nextToken)
+        do {
+          const response = await client.send(
+            new ListInferenceProfilesCommand({
+              typeEquals: 'SYSTEM_DEFINED',
+              maxResults: 100,
+              nextToken
+            })
+          )
+          profiles.push(...(response.inferenceProfileSummaries || []))
+          const { nextToken: responseNextToken } = response
+          nextToken = responseNextToken
+        } while (nextToken)
 
-      const models = profiles
-        .filter((profile) => profile.inferenceProfileId?.includes('.anthropic.claude-'))
-        .map((profile) => ({
-          id: profile.inferenceProfileId,
-          name: profile.inferenceProfileName || profile.inferenceProfileId,
-          provider: 'anthropic',
-          type: 'bedrock'
-        }))
+        const models = profiles
+          .filter((profile) => profile.inferenceProfileId?.includes('.anthropic.claude-'))
+          .map((profile) => ({
+            id: profile.inferenceProfileId,
+            name: profile.inferenceProfileName || profile.inferenceProfileId,
+            provider: 'anthropic',
+            type: 'bedrock'
+          }))
 
-      logger.debug(`📋 发现Bedrock推理配置 ${models.length} 个, 区域: ${region}`)
-      return models.length > 0 ? models : fallbackModels
+        logger.debug(`📋 发现Bedrock推理配置 ${models.length} 个, 区域: ${region}`)
+        return models.length > 0 ? models : fallbackModels
+      } finally {
+        client.destroy()
+      }
     } catch (error) {
       logger.warn(`⚠️ 无法列出Bedrock推理配置，使用官方模型目录: ${error.message}`)
       return fallbackModels

--- a/src/services/relay/bedrockRelayService.js
+++ b/src/services/relay/bedrockRelayService.js
@@ -230,7 +230,7 @@ class BedrockRelayService {
       const client = this._getBedrockClient(region, bedrockAccount)
 
       // 转换请求格式为Bedrock格式
-      const bedrockPayload = this._convertToBedrockFormat(requestBody)
+      const bedrockPayload = this._convertToBedrockFormat(requestBody, modelId)
 
       const command = new InvokeModelCommand({
         modelId,
@@ -372,7 +372,7 @@ class BedrockRelayService {
       const client = this._getBedrockClient(region, bedrockAccount)
 
       // 转换请求格式为Bedrock格式
-      const bedrockPayload = this._convertToBedrockFormat(requestBody)
+      const bedrockPayload = this._convertToBedrockFormat(requestBody, modelId)
 
       const command = new InvokeModelWithResponseStreamCommand({
         modelId,
@@ -591,6 +591,9 @@ class BedrockRelayService {
 
     // 标准Claude模型名到Bedrock模型名的映射表
     const modelMapping = {
+      // Claude Opus 5
+      'claude-opus-5': 'global.anthropic.claude-opus-5',
+
       // Claude Opus 4.6
       'claude-opus-4-6': 'global.anthropic.claude-opus-4-6-v1',
 
@@ -704,8 +707,19 @@ class BedrockRelayService {
     return obj
   }
 
+  _supportsAdaptiveThinking(modelId) {
+    const normalizedModel = (modelId || '').replace(/\[1m\]$/, '')
+    return ['claude-opus-5', 'claude-opus-4-6', 'claude-sonnet-4-6'].some((model) =>
+      normalizedModel.includes(model)
+    )
+  }
+
+  _requiresAdaptiveThinking(modelId) {
+    return (modelId || '').replace(/\[1m\]$/, '').includes('claude-opus-5')
+  }
+
   // 转换Claude格式请求到Bedrock格式
-  _convertToBedrockFormat(requestBody) {
+  _convertToBedrockFormat(requestBody, modelId = null) {
     // 透传客户端的 max_tokens，仅在未指定时使用默认值作为回退
     const maxTokens = requestBody.max_tokens || this.maxOutputTokens
 
@@ -747,17 +761,49 @@ class BedrockRelayService {
       bedrockPayload.tool_choice = requestBody.tool_choice
     }
 
-    // Extended thinking 支持
-    // Bedrock 只支持 "enabled" / "disabled"，不支持 "adaptive"
-    // adaptive 模式不要求 budget_tokens，但 Bedrock enabled 必须有
+    const anthropicBetas = Array.isArray(requestBody.anthropic_beta)
+      ? [...requestBody.anthropic_beta]
+      : []
+    if (requestBody.context_management) {
+      bedrockPayload.context_management = requestBody.context_management
+      if (!anthropicBetas.includes('context-management-2025-06-27')) {
+        anthropicBetas.push('context-management-2025-06-27')
+      }
+    }
+    if (anthropicBetas.length > 0) {
+      bedrockPayload.anthropic_beta = anthropicBetas
+    }
+
+    // Newer Claude models use adaptive thinking; older Bedrock models still need a token budget.
+    const supportsAdaptiveThinking = this._supportsAdaptiveThinking(modelId || requestBody.model)
+    const requiresAdaptiveThinking = this._requiresAdaptiveThinking(modelId || requestBody.model)
+
     if (requestBody.thinking) {
       bedrockPayload.thinking = { ...requestBody.thinking }
-      if (bedrockPayload.thinking.type === 'adaptive') {
+
+      if (requiresAdaptiveThinking && bedrockPayload.thinking.type === 'enabled') {
+        bedrockPayload.thinking.type = 'adaptive'
+      }
+
+      if (bedrockPayload.thinking.type === 'adaptive' && supportsAdaptiveThinking) {
+        delete bedrockPayload.thinking.budget_tokens
+      } else if (bedrockPayload.thinking.type === 'adaptive') {
         bedrockPayload.thinking.type = 'enabled'
         if (!bedrockPayload.thinking.budget_tokens) {
           bedrockPayload.thinking.budget_tokens = maxTokens - 1
         }
       }
+    }
+
+    if (
+      supportsAdaptiveThinking &&
+      requestBody.output_config &&
+      typeof requestBody.output_config === 'object' &&
+      !Array.isArray(requestBody.output_config)
+    ) {
+      bedrockPayload.output_config = { ...requestBody.output_config }
+    } else if (requiresAdaptiveThinking && requestBody.thinking?.type === 'enabled') {
+      bedrockPayload.output_config = { effort: 'high' }
     }
 
     // metadata 透传
@@ -774,6 +820,7 @@ class BedrockRelayService {
   // 转换Bedrock响应到Claude格式
   _convertFromBedrockFormat(bedrockResponse) {
     return {
+      ...bedrockResponse,
       id: bedrockResponse.id || `msg_${Date.now()}_bedrock`,
       type: 'message',
       role: bedrockResponse.role || 'assistant',

--- a/src/services/relay/bedrockRelayService.js
+++ b/src/services/relay/bedrockRelayService.js
@@ -1,24 +1,30 @@
+const crypto = require('crypto')
 const {
   BedrockRuntimeClient,
   InvokeModelCommand,
   InvokeModelWithResponseStreamCommand
 } = require('@aws-sdk/client-bedrock-runtime')
-const { fromEnv } = require('@aws-sdk/credential-providers')
+const { BedrockClient, ListInferenceProfilesCommand } = require('@aws-sdk/client-bedrock')
 const logger = require('../../utils/logger')
 const config = require('../../../config/config')
+const { BEDROCK_MODELS, BEDROCK_TEST_MODEL } = require('../../../config/models')
+const { normalizeBedrockRegion, assertSupportedBedrockModel } = require('../../utils/bedrockConfig')
 const userMessageQueueService = require('../userMessageQueueService')
 const upstreamErrorHelper = require('../../utils/upstreamErrorHelper')
 
 class BedrockRelayService {
   constructor() {
-    this.defaultRegion = process.env.AWS_REGION || config.bedrock?.defaultRegion || 'us-east-1'
-    this.smallFastModelRegion =
-      process.env.ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION || this.defaultRegion
+    this.defaultRegion = normalizeBedrockRegion(
+      process.env.AWS_REGION || config.bedrock?.defaultRegion,
+      'us-east-1'
+    )
+    this.smallFastModelRegion = normalizeBedrockRegion(
+      process.env.ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION || config.bedrock?.smallFastModelRegion,
+      this.defaultRegion
+    )
 
     // 默认模型配置
     this.defaultModel = process.env.ANTHROPIC_MODEL || 'us.anthropic.claude-sonnet-4-20250514-v1:0'
-    this.defaultSmallModel =
-      process.env.ANTHROPIC_SMALL_FAST_MODEL || 'us.anthropic.claude-3-5-haiku-20241022-v1:0'
 
     // Token配置 — 仅作为客户端未指定 max_tokens 时的回退默认值，不用于截断
     this.maxOutputTokens = parseInt(process.env.BEDROCK_MAX_OUTPUT_TOKENS) || 128000
@@ -27,72 +33,107 @@ class BedrockRelayService {
     this.clients = new Map() // 缓存不同区域的客户端
   }
 
-  // 获取或创建Bedrock客户端
-  _getBedrockClient(region = null, bedrockAccount = null) {
-    const targetRegion = region || this.defaultRegion
-    const clientKey = `${targetRegion}-${bedrockAccount?.id || 'default'}`
+  _getCredentialType(bedrockAccount) {
+    if (!bedrockAccount) {
+      return 'default'
+    }
+    if (['access_key', 'bearer_token', 'default'].includes(bedrockAccount.credentialType)) {
+      return bedrockAccount.credentialType
+    }
+    if (bedrockAccount.awsCredentials) {
+      return 'access_key'
+    }
+    if (bedrockAccount.bearerToken) {
+      return 'bearer_token'
+    }
+    return 'default'
+  }
 
-    if (this.clients.has(clientKey)) {
-      return this.clients.get(clientKey)
+  _getCredentialFingerprint(bedrockAccount, credentialType) {
+    let credentialMaterial = 'default-provider-chain'
+
+    if (credentialType === 'access_key') {
+      const credentials = bedrockAccount?.awsCredentials
+      if (!credentials?.accessKeyId || !credentials?.secretAccessKey) {
+        throw new Error('AWS access key credentials are incomplete')
+      }
+      credentialMaterial = JSON.stringify([
+        credentials.accessKeyId,
+        credentials.secretAccessKey,
+        credentials.sessionToken || ''
+      ])
+    } else if (credentialType === 'bearer_token') {
+      if (!bedrockAccount?.bearerToken) {
+        throw new Error('AWS Bedrock bearer token is missing')
+      }
+      credentialMaterial = bedrockAccount.bearerToken
     }
 
+    return crypto.createHash('sha256').update(credentialMaterial).digest('hex')
+  }
+
+  _createAwsClientConfig(region, bedrockAccount, credentialType) {
     const clientConfig = {
-      region: targetRegion,
+      region,
       requestHandler: {
-        requestTimeout: config.requestTimeout || 600000, // 与其他 relay 服务保持一致
+        requestTimeout: config.requestTimeout || 600000,
         connectionTimeout: 10000
       }
     }
 
-    // 如果账户配置了特定的AWS凭证，使用它们
-    if (bedrockAccount?.awsCredentials) {
+    if (credentialType === 'access_key') {
       clientConfig.credentials = {
         accessKeyId: bedrockAccount.awsCredentials.accessKeyId,
         secretAccessKey: bedrockAccount.awsCredentials.secretAccessKey,
         sessionToken: bedrockAccount.awsCredentials.sessionToken
       }
-    } else if (bedrockAccount?.bearerToken) {
-      // Bedrock API Key (ABSK) 模式：需要通过 middleware 注入 Bearer Token，
-      // 因为 BedrockRuntimeClient 默认使用 SigV4 签名，不支持 token 配置
-      // 使用占位凭证防止 "Could not load credentials" 错误
-      // SigV4 签名会生成 Authorization header，但随后被 middleware 替换为 Bearer Token
+    } else if (credentialType === 'bearer_token') {
+      // The runtime client still runs SigV4 middleware before the bearer token replaces it.
       clientConfig.credentials = {
         accessKeyId: 'BEDROCK_API_KEY_PLACEHOLDER',
         secretAccessKey: 'BEDROCK_API_KEY_PLACEHOLDER'
       }
-      logger.debug(`🔑 使用 Bearer Token 认证 - 账户: ${bedrockAccount.name || 'unknown'}`)
-    } else {
-      // 检查是否有环境变量凭证
-      if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
-        clientConfig.credentials = fromEnv()
-      } else {
-        throw new Error(
-          'AWS凭证未配置。请在Bedrock账户中配置AWS访问密钥或Bearer Token，或设置环境变量AWS_ACCESS_KEY_ID、AWS_SECRET_ACCESS_KEY 或 AWS_BEARER_TOKEN_BEDROCK'
-        )
-      }
     }
+
+    return clientConfig
+  }
+
+  _addBearerTokenMiddleware(client, bearerToken) {
+    client.middlewareStack.add(
+      (next) => async (args) => {
+        for (const key of Object.keys(args.request.headers)) {
+          if (key.toLowerCase() === 'authorization') {
+            delete args.request.headers[key]
+          }
+        }
+        args.request.headers.Authorization = `Bearer ${bearerToken}`
+        delete args.request.headers['x-amz-date']
+        delete args.request.headers['x-amz-security-token']
+        delete args.request.headers['x-amz-content-sha256']
+        return next(args)
+      },
+      { step: 'finalizeRequest', name: 'bedrockBearerTokenAuth', override: true, priority: 'low' }
+    )
+  }
+
+  // 获取或创建Bedrock客户端
+  _getBedrockClient(region = null, bedrockAccount = null) {
+    const targetRegion = normalizeBedrockRegion(region, this.defaultRegion)
+    const credentialType = this._getCredentialType(bedrockAccount)
+    const credentialFingerprint = this._getCredentialFingerprint(bedrockAccount, credentialType)
+    const accountId = bedrockAccount?.id || 'default'
+    const clientKey = `${targetRegion}::${accountId}::${credentialType}::${credentialFingerprint}`
+
+    if (this.clients.has(clientKey)) {
+      return this.clients.get(clientKey)
+    }
+
+    const clientConfig = this._createAwsClientConfig(targetRegion, bedrockAccount, credentialType)
 
     const client = new BedrockRuntimeClient(clientConfig)
 
-    // Bedrock API Key (ABSK) 模式：注入 Bearer Token 到 Authorization header
-    if (bedrockAccount?.bearerToken) {
-      const { bearerToken } = bedrockAccount
-      client.middlewareStack.add(
-        (next) => async (args) => {
-          // 清除 SigV4 签名产生的所有 authorization header（大小写均删除）
-          for (const key of Object.keys(args.request.headers)) {
-            if (key.toLowerCase() === 'authorization') {
-              delete args.request.headers[key]
-            }
-          }
-          args.request.headers['Authorization'] = `Bearer ${bearerToken}`
-          delete args.request.headers['x-amz-date']
-          delete args.request.headers['x-amz-security-token']
-          delete args.request.headers['x-amz-content-sha256']
-          return next(args)
-        },
-        { step: 'finalizeRequest', name: 'bedrockBearerTokenAuth', override: true, priority: 'low' }
-      )
+    if (credentialType === 'bearer_token') {
+      this._addBearerTokenMiddleware(client, bedrockAccount.bearerToken)
       logger.debug(`🔑 Bearer Token middleware 已注入 - 账户: ${bedrockAccount.name || 'unknown'}`)
     }
 
@@ -102,6 +143,22 @@ class BedrockRelayService {
       `🔧 Created Bedrock client for region: ${targetRegion}, account: ${bedrockAccount?.name || 'default'}`
     )
     return client
+  }
+
+  invalidateAccountClients(accountId) {
+    if (!accountId) {
+      return 0
+    }
+
+    let removed = 0
+    for (const clientKey of this.clients.keys()) {
+      if (clientKey.split('::')[1] === accountId) {
+        this.clients.get(clientKey)?.destroy?.()
+        this.clients.delete(clientKey)
+        removed += 1
+      }
+    }
+    return removed
   }
 
   // 处理非流式请求
@@ -475,17 +532,15 @@ class BedrockRelayService {
   _selectModel(requestBody, bedrockAccount) {
     let selectedModel
 
-    // 优先使用账户配置的模型
-    if (bedrockAccount?.defaultModel) {
+    // The caller's explicit model must not be silently overridden by an account default.
+    if (requestBody?.model) {
+      selectedModel = requestBody.model
+      logger.info(`🎯 使用请求指定的模型: ${selectedModel}`, { metadata: { source: 'request' } })
+    } else if (bedrockAccount?.defaultModel) {
       selectedModel = bedrockAccount.defaultModel
       logger.info(`🎯 使用账户配置的模型: ${selectedModel}`, {
         metadata: { source: 'account', accountId: bedrockAccount.id }
       })
-    }
-    // 检查请求中指定的模型
-    else if (requestBody.model) {
-      selectedModel = requestBody.model
-      logger.info(`🎯 使用请求指定的模型: ${selectedModel}`, { metadata: { source: 'request' } })
     }
     // 使用默认模型
     else {
@@ -493,8 +548,8 @@ class BedrockRelayService {
       logger.info(`🎯 使用系统默认模型: ${selectedModel}`, { metadata: { source: 'default' } })
     }
 
-    // 如果是标准Claude模型名，需要映射为Bedrock格式
-    const bedrockModel = this._mapToBedrockModel(selectedModel)
+    const supportedModel = assertSupportedBedrockModel(selectedModel)
+    const bedrockModel = this._mapToBedrockModel(supportedModel)
     if (bedrockModel !== selectedModel) {
       logger.info(`🔄 模型映射: ${selectedModel} → ${bedrockModel}`, {
         metadata: { originalModel: selectedModel, bedrockModel }
@@ -539,8 +594,8 @@ class BedrockRelayService {
       // Claude Opus 4.6
       'claude-opus-4-6': 'global.anthropic.claude-opus-4-6-v1',
 
-      // Claude Sonnet 4.6 — Bedrock 暂未上线，回退到 Sonnet 4.5
-      'claude-sonnet-4-6': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+      // Claude Sonnet 4.6
+      'claude-sonnet-4-6': 'us.anthropic.claude-sonnet-4-6',
 
       // Claude 4.5 Opus
       'claude-opus-4-5': 'us.anthropic.claude-opus-4-5-20251101-v1:0',
@@ -572,10 +627,6 @@ class BedrockRelayService {
       // Claude 3.5 Sonnet v2
       'claude-3-5-sonnet': 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
       'claude-3-5-sonnet-20241022': 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
-
-      // Claude 3.5 Haiku
-      'claude-3-5-haiku': 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
-      'claude-3-5-haiku-20241022': 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
 
       // Claude 3 Sonnet
       'claude-3-sonnet': 'us.anthropic.claude-3-sonnet-20240229-v1:0',
@@ -613,15 +664,15 @@ class BedrockRelayService {
   _selectRegion(modelId, bedrockAccount) {
     // 优先使用账户配置的区域
     if (bedrockAccount?.region) {
-      return bedrockAccount.region
+      return normalizeBedrockRegion(bedrockAccount.region, this.defaultRegion)
     }
 
     // 对于小模型，使用专门的区域配置
     if (modelId.includes('haiku')) {
-      return this.smallFastModelRegion
+      return normalizeBedrockRegion(this.smallFastModelRegion, this.defaultRegion)
     }
 
-    return this.defaultRegion
+    return normalizeBedrockRegion(this.defaultRegion, 'us-east-1')
   }
 
   // Sanitize cache_control fields for Bedrock compatibility.
@@ -737,6 +788,76 @@ class BedrockRelayService {
     }
   }
 
+  async testConnection(bedrockAccount, model = BEDROCK_TEST_MODEL, onContent = null) {
+    const modelId = this._selectModel({ model }, bedrockAccount)
+    const region = this._selectRegion(modelId, bedrockAccount)
+    const client = this._getBedrockClient(region, bedrockAccount)
+    const command = new InvokeModelWithResponseStreamCommand({
+      modelId,
+      body: JSON.stringify({
+        anthropic_version: 'bedrock-2023-05-31',
+        max_tokens: 32,
+        messages: [{ role: 'user', content: 'Reply with OK.' }]
+      }),
+      contentType: 'application/json',
+      accept: 'application/json'
+    })
+
+    const startedAt = Date.now()
+    const response = await client.send(command)
+    if (!response?.body) {
+      throw new Error('Bedrock Runtime returned no response stream')
+    }
+
+    let responseText = ''
+    let eventCount = 0
+    let messageStopped = false
+
+    for await (const event of response.body) {
+      if (!event.chunk) {
+        const errorKey = [
+          'internalServerException',
+          'modelStreamErrorException',
+          'validationException',
+          'throttlingException',
+          'modelTimeoutException',
+          'serviceUnavailableException'
+        ].find((key) => event[key])
+        if (errorKey) {
+          throw new Error(event[errorKey].message || `Bedrock Runtime stream error: ${errorKey}`)
+        }
+        throw new Error('Bedrock Runtime returned an unknown stream event')
+      }
+      eventCount += 1
+      const chunkData = JSON.parse(new TextDecoder().decode(event.chunk.bytes))
+      if (chunkData.type === 'error') {
+        throw new Error(chunkData.error?.message || 'Bedrock API error')
+      }
+      if (chunkData.type === 'content_block_delta' && chunkData.delta?.text) {
+        responseText += chunkData.delta.text
+        if (onContent) {
+          onContent(chunkData.delta.text)
+        }
+      }
+      if (chunkData.type === 'message_stop') {
+        messageStopped = true
+      }
+    }
+
+    if (!messageStopped || !responseText.trim()) {
+      throw new Error('Bedrock Runtime returned an incomplete response stream')
+    }
+
+    return {
+      status: 'connected',
+      model: modelId,
+      region,
+      responseText,
+      eventCount,
+      duration: Date.now() - startedAt
+    }
+  }
+
   // 从 Bedrock 错误中提取 HTTP 状态码
   _getErrorStatusCode(error) {
     // AWS SDK v3 错误的 $metadata 包含 httpStatusCode
@@ -801,48 +922,55 @@ class BedrockRelayService {
 
   // 获取可用模型列表
   async getAvailableModels(bedrockAccount = null) {
+    const fallbackModels = BEDROCK_MODELS.map((model) => ({
+      id: model.value,
+      name: model.label,
+      provider: 'anthropic',
+      type: 'bedrock'
+    }))
+
     try {
-      const region = bedrockAccount?.region || this.defaultRegion
+      const region = normalizeBedrockRegion(bedrockAccount?.region, this.defaultRegion)
+      const credentialType = this._getCredentialType(bedrockAccount)
 
-      // Bedrock暂不支持列出推理配置文件的API，返回预定义的模型列表
-      const models = [
-        {
-          id: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
-          name: 'Claude Sonnet 4',
-          provider: 'anthropic',
-          type: 'bedrock'
-        },
-        {
-          id: 'us.anthropic.claude-opus-4-1-20250805-v1:0',
-          name: 'Claude Opus 4.1',
-          provider: 'anthropic',
-          type: 'bedrock'
-        },
-        {
-          id: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
-          name: 'Claude 3.7 Sonnet',
-          provider: 'anthropic',
-          type: 'bedrock'
-        },
-        {
-          id: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
-          name: 'Claude 3.5 Sonnet v2',
-          provider: 'anthropic',
-          type: 'bedrock'
-        },
-        {
-          id: 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
-          name: 'Claude 3.5 Haiku',
-          provider: 'anthropic',
-          type: 'bedrock'
-        }
-      ]
+      // Bedrock API keys authenticate runtime requests, not control-plane discovery.
+      if (credentialType === 'bearer_token') {
+        return fallbackModels
+      }
 
-      logger.debug(`📋 返回Bedrock可用模型 ${models.length} 个, 区域: ${region}`)
-      return models
+      const client = new BedrockClient(
+        this._createAwsClientConfig(region, bedrockAccount, credentialType)
+      )
+      const profiles = []
+      let nextToken
+
+      do {
+        const response = await client.send(
+          new ListInferenceProfilesCommand({
+            typeEquals: 'SYSTEM_DEFINED',
+            maxResults: 100,
+            nextToken
+          })
+        )
+        profiles.push(...(response.inferenceProfileSummaries || []))
+        const { nextToken: responseNextToken } = response
+        nextToken = responseNextToken
+      } while (nextToken)
+
+      const models = profiles
+        .filter((profile) => profile.inferenceProfileId?.includes('.anthropic.claude-'))
+        .map((profile) => ({
+          id: profile.inferenceProfileId,
+          name: profile.inferenceProfileName || profile.inferenceProfileId,
+          provider: 'anthropic',
+          type: 'bedrock'
+        }))
+
+      logger.debug(`📋 发现Bedrock推理配置 ${models.length} 个, 区域: ${region}`)
+      return models.length > 0 ? models : fallbackModels
     } catch (error) {
-      logger.error('❌ 获取Bedrock模型列表失败:', error)
-      return []
+      logger.warn(`⚠️ 无法列出Bedrock推理配置，使用官方模型目录: ${error.message}`)
+      return fallbackModels
     }
   }
 }

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -398,6 +398,7 @@ class UnifiedClaudeScheduler {
         if (
           boundBedrockAccountResult.success &&
           boundBedrockAccountResult.data.isActive === true &&
+          !bedrockAccountService.isSubscriptionExpired(boundBedrockAccountResult.data) &&
           isSchedulable(boundBedrockAccountResult.data.schedulable)
         ) {
           // 检查是否临时不可用
@@ -646,6 +647,7 @@ class UnifiedClaudeScheduler {
       if (
         boundBedrockAccountResult.success &&
         boundBedrockAccountResult.data.isActive === true &&
+        !bedrockAccountService.isSubscriptionExpired(boundBedrockAccountResult.data) &&
         isSchedulable(boundBedrockAccountResult.data.schedulable)
       ) {
         // 检查是否临时不可用
@@ -920,6 +922,7 @@ class UnifiedClaudeScheduler {
         if (
           account.isActive === true &&
           account.accountType === 'shared' &&
+          !bedrockAccountService.isSubscriptionExpired(account) &&
           isSchedulable(account.schedulable)
         ) {
           // 检查是否临时不可用
@@ -1181,6 +1184,10 @@ class UnifiedClaudeScheduler {
       } else if (accountType === 'bedrock') {
         const accountResult = await bedrockAccountService.getAccount(accountId)
         if (!accountResult.success || !accountResult.data.isActive) {
+          return false
+        }
+        if (bedrockAccountService.isSubscriptionExpired(accountResult.data)) {
+          logger.info(`🚫 Bedrock account ${accountId} subscription is expired`)
           return false
         }
         // 检查是否可调度

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -923,6 +923,7 @@ class UnifiedClaudeScheduler {
           account.isActive === true &&
           account.accountType === 'shared' &&
           !bedrockAccountService.isSubscriptionExpired(account) &&
+          account.hasCredentials !== false &&
           isSchedulable(account.schedulable)
         ) {
           // 检查是否临时不可用

--- a/src/utils/bedrockConfig.js
+++ b/src/utils/bedrockConfig.js
@@ -1,4 +1,5 @@
 const BEDROCK_REGION_PATTERN = /^[a-z]{2,8}(?:-[a-z0-9]+)+-\d+$/
+const BEDROCK_CREDENTIAL_TYPES = Object.freeze(['access_key', 'bearer_token', 'default'])
 
 const RETIRED_BEDROCK_MODEL_MARKERS = ['claude-3-5-haiku']
 
@@ -10,7 +11,7 @@ function createBedrockValidationError(message, code) {
 }
 
 function normalizeBedrockRegion(region, fallback = null) {
-  const value = region === undefined || region === null || region === '' ? fallback : region
+  const value = region === undefined || region === null ? fallback : region
   if (typeof value !== 'string' || value.trim() === '') {
     throw createBedrockValidationError('AWS Region is required', 'INVALID_BEDROCK_REGION')
   }
@@ -53,6 +54,7 @@ function assertSupportedBedrockModel(model) {
 
 module.exports = {
   BEDROCK_REGION_PATTERN,
+  BEDROCK_CREDENTIAL_TYPES,
   RETIRED_BEDROCK_MODEL_MARKERS,
   normalizeBedrockRegion,
   normalizeBedrockModel,

--- a/src/utils/bedrockConfig.js
+++ b/src/utils/bedrockConfig.js
@@ -1,0 +1,61 @@
+const BEDROCK_REGION_PATTERN = /^[a-z]{2,8}(?:-[a-z0-9]+)+-\d+$/
+
+const RETIRED_BEDROCK_MODEL_MARKERS = ['claude-3-5-haiku']
+
+function createBedrockValidationError(message, code) {
+  const error = new Error(message)
+  error.code = code
+  error.statusCode = 400
+  return error
+}
+
+function normalizeBedrockRegion(region, fallback = null) {
+  const value = region === undefined || region === null || region === '' ? fallback : region
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw createBedrockValidationError('AWS Region is required', 'INVALID_BEDROCK_REGION')
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (!BEDROCK_REGION_PATTERN.test(normalized)) {
+    throw createBedrockValidationError(
+      `Invalid AWS Region: ${normalized}`,
+      'INVALID_BEDROCK_REGION'
+    )
+  }
+
+  return normalized
+}
+
+function normalizeBedrockModel(model) {
+  if (typeof model !== 'string' || model.trim() === '') {
+    throw createBedrockValidationError('Bedrock model is required', 'INVALID_BEDROCK_MODEL')
+  }
+  return model.trim()
+}
+
+function isRetiredBedrockModel(model) {
+  if (typeof model !== 'string') {
+    return false
+  }
+  return RETIRED_BEDROCK_MODEL_MARKERS.some((marker) => model.includes(marker))
+}
+
+function assertSupportedBedrockModel(model) {
+  const normalized = normalizeBedrockModel(model)
+  if (isRetiredBedrockModel(normalized)) {
+    throw createBedrockValidationError(
+      `Bedrock model ${normalized} is retired; select a current model such as Claude Haiku 4.5`,
+      'RETIRED_BEDROCK_MODEL'
+    )
+  }
+  return normalized
+}
+
+module.exports = {
+  BEDROCK_REGION_PATTERN,
+  RETIRED_BEDROCK_MODEL_MARKERS,
+  normalizeBedrockRegion,
+  normalizeBedrockModel,
+  isRetiredBedrockModel,
+  assertSupportedBedrockModel
+}

--- a/tests/bedrockAccountService.test.js
+++ b/tests/bedrockAccountService.test.js
@@ -102,7 +102,7 @@ describe('bedrockAccountService', () => {
     expect(account.data.awsCredentials.accessKeyId).toBe('AKIA_ORIGINAL')
   })
 
-  test('removes the complete access key group only when null is explicit', async () => {
+  test('disables and remains deletable after the complete access key group is removed', async () => {
     const created = await createAccessKeyAccount()
 
     const updated = await service.updateAccount(created.data.id, { awsCredentials: null })
@@ -110,6 +110,17 @@ describe('bedrockAccountService', () => {
 
     expect(updated.success).toBe(true)
     expect(stored).not.toHaveProperty('awsCredentials')
+    expect(stored.isActive).toBe(false)
+    expect(stored.schedulable).toBe(false)
+    await expect(service.getAccount(created.data.id)).resolves.toEqual(
+      expect.objectContaining({ success: false })
+    )
+
+    relay.invalidateAccountClients.mockClear()
+    await expect(service.deleteAccount(created.data.id)).resolves.toEqual({ success: true })
+    expect(store.has(`bedrock_account:${created.data.id}`)).toBe(false)
+    expect(relay.invalidateAccountClients).toHaveBeenCalledTimes(1)
+    expect(relay.invalidateAccountClients).toHaveBeenCalledWith(created.data.id)
   })
 
   test('atomically clears stale access keys when switching to bearer token', async () => {
@@ -145,6 +156,23 @@ describe('bedrockAccountService', () => {
         data: expect.objectContaining({ credentialType: 'default' })
       })
     )
+  })
+
+  test('disables a bearer-token account when its token is explicitly removed', async () => {
+    const created = await service.createAccount({
+      name: 'Bearer account',
+      region: 'us-west-2',
+      credentialType: 'bearer_token',
+      bearerToken: 'bedrock-token'
+    })
+
+    const updated = await service.updateAccount(created.data.id, { bearerToken: null })
+    const stored = JSON.parse(store.get(`bedrock_account:${created.data.id}`))
+
+    expect(updated.success).toBe(true)
+    expect(stored).not.toHaveProperty('bearerToken')
+    expect(stored.isActive).toBe(false)
+    expect(stored.schedulable).toBe(false)
   })
 
   test('rejects non-string bearer tokens as validation errors', async () => {
@@ -220,5 +248,28 @@ describe('bedrockAccountService', () => {
     expect(service.isSubscriptionExpired({ subscriptionExpiresAt: past })).toBe(true)
     expect(service.isSubscriptionExpired({ expiresAt: past })).toBe(true)
     expect(service.isSubscriptionExpired({ expiresAt: future })).toBe(false)
+  })
+
+  test('preserves legacy expiresAt through the account-list DTO', async () => {
+    const created = await createAccessKeyAccount()
+    const key = `bedrock_account:${created.data.id}`
+    const legacy = JSON.parse(store.get(key))
+    const expiresAt = '2020-01-01T00:00:00.000Z'
+    delete legacy.subscriptionExpiresAt
+    legacy.expiresAt = expiresAt
+    store.set(key, JSON.stringify(legacy))
+    redis.getAllIdsByIndex.mockResolvedValue([created.data.id])
+    redis.batchGetChunked.mockImplementation(async (keys) => keys.map((item) => store.get(item)))
+
+    const result = await service.getAllAccounts()
+
+    expect(result.data[0]).toEqual(
+      expect.objectContaining({
+        subscriptionExpiresAt: expiresAt,
+        tokenExpiresAt: null,
+        expiresAt
+      })
+    )
+    expect(service.isSubscriptionExpired(result.data[0])).toBe(true)
   })
 })

--- a/tests/bedrockAccountService.test.js
+++ b/tests/bedrockAccountService.test.js
@@ -1,0 +1,224 @@
+jest.useFakeTimers()
+
+jest.mock('../config/config', () => ({ security: { encryptionKey: 'test-encryption-key' } }), {
+  virtual: true
+})
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({ clearTempUnavailable: jest.fn() }))
+jest.mock('../src/models/redis', () => ({
+  getClientSafe: jest.fn(),
+  addToIndex: jest.fn(),
+  removeFromIndex: jest.fn(),
+  getAllIdsByIndex: jest.fn(),
+  batchGetChunked: jest.fn()
+}))
+jest.mock('../src/services/relay/bedrockRelayService', () => ({
+  testConnection: jest.fn(),
+  getAvailableModels: jest.fn(),
+  invalidateAccountClients: jest.fn()
+}))
+
+const redis = require('../src/models/redis')
+const relay = require('../src/services/relay/bedrockRelayService')
+const service = require('../src/services/account/bedrockAccountService')
+const { BEDROCK_TEST_MODEL } = require('../config/models')
+
+describe('bedrockAccountService', () => {
+  let store
+  let client
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    store = new Map()
+    client = {
+      get: jest.fn(async (key) => store.get(key) || null),
+      set: jest.fn(async (key, value) => store.set(key, value)),
+      del: jest.fn(async (key) => store.delete(key))
+    }
+    redis.getClientSafe.mockReturnValue(client)
+    redis.addToIndex.mockResolvedValue(undefined)
+    redis.removeFromIndex.mockResolvedValue(undefined)
+    relay.testConnection.mockResolvedValue({
+      status: 'connected',
+      model: BEDROCK_TEST_MODEL,
+      region: 'us-west-2',
+      responseText: 'OK'
+    })
+    relay.getAvailableModels.mockResolvedValue([{ id: BEDROCK_TEST_MODEL }])
+  })
+
+  async function createAccessKeyAccount(overrides = {}) {
+    return service.createAccount({
+      name: 'Bedrock test',
+      region: 'us-west-2',
+      credentialType: 'access_key',
+      awsCredentials: {
+        accessKeyId: 'AKIA_ORIGINAL',
+        secretAccessKey: 'original-secret',
+        sessionToken: 'original-session'
+      },
+      ...overrides
+    })
+  }
+
+  test('normalizes Region when creating and reading accounts', async () => {
+    const created = await createAccessKeyAccount({ region: '  US-West-2 ' })
+    const account = await service.getAccount(created.data.id)
+
+    expect(created.data.region).toBe('us-west-2')
+    expect(account.data.region).toBe('us-west-2')
+  })
+
+  test('merges partial access key updates without deleting omitted fields', async () => {
+    const created = await createAccessKeyAccount()
+
+    await service.updateAccount(created.data.id, {
+      awsCredentials: { secretAccessKey: 'rotated-secret' }
+    })
+    const account = await service.getAccount(created.data.id)
+
+    expect(account.data.awsCredentials).toEqual({
+      accessKeyId: 'AKIA_ORIGINAL',
+      secretAccessKey: 'rotated-secret',
+      sessionToken: 'original-session'
+    })
+    expect(relay.invalidateAccountClients).toHaveBeenCalledWith(created.data.id)
+  })
+
+  test('removes a session token only when null is explicit', async () => {
+    const created = await createAccessKeyAccount()
+
+    await service.updateAccount(created.data.id, {
+      awsCredentials: { sessionToken: null }
+    })
+    const account = await service.getAccount(created.data.id)
+
+    expect(account.data.awsCredentials).not.toHaveProperty('sessionToken')
+    expect(account.data.awsCredentials.accessKeyId).toBe('AKIA_ORIGINAL')
+  })
+
+  test('removes the complete access key group only when null is explicit', async () => {
+    const created = await createAccessKeyAccount()
+
+    const updated = await service.updateAccount(created.data.id, { awsCredentials: null })
+    const stored = JSON.parse(store.get(`bedrock_account:${created.data.id}`))
+
+    expect(updated.success).toBe(true)
+    expect(stored).not.toHaveProperty('awsCredentials')
+  })
+
+  test('atomically clears stale access keys when switching to bearer token', async () => {
+    const created = await createAccessKeyAccount()
+
+    const updated = await service.updateAccount(created.data.id, {
+      credentialType: 'bearer_token',
+      bearerToken: 'new-bedrock-token'
+    })
+    const stored = JSON.parse(store.get(`bedrock_account:${created.data.id}`))
+    const account = await service.getAccount(created.data.id)
+
+    expect(updated.success).toBe(true)
+    expect(stored).not.toHaveProperty('awsCredentials')
+    expect(account.data.credentialType).toBe('bearer_token')
+    expect(account.data.bearerToken).toBe('new-bedrock-token')
+  })
+
+  test('supports the standard AWS default credential chain without stored secrets', async () => {
+    const created = await service.createAccount({
+      name: 'Role account',
+      region: 'us-west-2',
+      credentialType: 'default'
+    })
+    const stored = JSON.parse(store.get(`bedrock_account:${created.data.id}`))
+    const account = await service.getAccount(created.data.id)
+
+    expect(stored).not.toHaveProperty('awsCredentials')
+    expect(stored).not.toHaveProperty('bearerToken')
+    expect(account).toEqual(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ credentialType: 'default' })
+      })
+    )
+  })
+
+  test('rejects non-string bearer tokens as validation errors', async () => {
+    await expect(
+      service.createAccount({
+        name: 'Invalid bearer account',
+        region: 'us-west-2',
+        credentialType: 'bearer_token',
+        bearerToken: 123
+      })
+    ).rejects.toEqual(expect.objectContaining({ statusCode: 400 }))
+  })
+
+  test('clears stored credentials when switching to the default provider chain', async () => {
+    const created = await createAccessKeyAccount()
+
+    const updated = await service.updateAccount(created.data.id, { credentialType: 'default' })
+    const stored = JSON.parse(store.get(`bedrock_account:${created.data.id}`))
+
+    expect(updated.success).toBe(true)
+    expect(stored.credentialType).toBe('default')
+    expect(stored).not.toHaveProperty('awsCredentials')
+    expect(stored).not.toHaveProperty('bearerToken')
+  })
+
+  test('infers access key authentication for legacy accounts without credentialType', async () => {
+    const created = await createAccessKeyAccount()
+    const key = `bedrock_account:${created.data.id}`
+    const legacy = JSON.parse(store.get(key))
+    delete legacy.credentialType
+    legacy.region = ' US-West-2 '
+    store.set(key, JSON.stringify(legacy))
+
+    const account = await service.getAccount(created.data.id)
+
+    expect(account.success).toBe(true)
+    expect(account.data.credentialType).toBe('access_key')
+    expect(account.data.region).toBe('us-west-2')
+    expect(account.data.awsCredentials.accessKeyId).toBe('AKIA_ORIGINAL')
+  })
+
+  test('connection test succeeds only after a Runtime request succeeds', async () => {
+    const created = await createAccessKeyAccount()
+
+    const result = await service.testAccount(created.data.id)
+
+    expect(relay.testConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: created.data.id }),
+      BEDROCK_TEST_MODEL
+    )
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ status: 'connected', modelsCount: 1 })
+      })
+    )
+  })
+
+  test('propagates Runtime failures instead of treating the model catalog as connectivity', async () => {
+    const created = await createAccessKeyAccount()
+    relay.testConnection.mockRejectedValueOnce(new Error('Access denied'))
+
+    await expect(service.testAccount(created.data.id)).resolves.toEqual({
+      success: false,
+      error: 'Access denied'
+    })
+  })
+
+  test('recognizes both stored and DTO expiry field names', () => {
+    const past = new Date(Date.now() - 1000).toISOString()
+    const future = new Date(Date.now() + 60_000).toISOString()
+
+    expect(service.isSubscriptionExpired({ subscriptionExpiresAt: past })).toBe(true)
+    expect(service.isSubscriptionExpired({ expiresAt: past })).toBe(true)
+    expect(service.isSubscriptionExpired({ expiresAt: future })).toBe(false)
+  })
+})

--- a/tests/bedrockAccountsRoute.test.js
+++ b/tests/bedrockAccountsRoute.test.js
@@ -62,11 +62,18 @@ describe('Bedrock admin routes', () => {
   })
 
   test('maps create expiry and accepts the default credential chain', async () => {
+    const expiresAt = '2030-01-01T00:00:00.000Z'
     service.createAccount.mockResolvedValue({
       success: true,
-      data: { id: 'account-1', region: 'us-west-2', credentialType: 'default' }
+      data: {
+        id: 'account-1',
+        region: 'us-west-2',
+        credentialType: 'default',
+        subscriptionExpiresAt: expiresAt,
+        tokenExpiresAt: null,
+        expiresAt
+      }
     })
-    const expiresAt = '2030-01-01T00:00:00.000Z'
 
     const response = await request(app).post('/api/admin/bedrock-accounts').send({
       name: 'Role account',
@@ -79,17 +86,20 @@ describe('Bedrock admin routes', () => {
     expect(service.createAccount).toHaveBeenCalledWith(
       expect.objectContaining({
         credentialType: 'default',
-        region: ' us-west-2 ',
+        region: 'us-west-2',
         subscriptionExpiresAt: expiresAt
+      })
+    )
+    expect(response.body.data).toEqual(
+      expect.objectContaining({
+        subscriptionExpiresAt: expiresAt,
+        tokenExpiresAt: null,
+        expiresAt
       })
     )
   })
 
   test('propagates Bedrock validation failures as HTTP 400', async () => {
-    service.createAccount.mockRejectedValue(
-      Object.assign(new Error('Invalid AWS Region'), { statusCode: 400 })
-    )
-
     const response = await request(app).post('/api/admin/bedrock-accounts').send({
       name: 'Invalid account',
       region: 'not-a-region',
@@ -97,7 +107,20 @@ describe('Bedrock admin routes', () => {
     })
 
     expect(response.status).toBe(400)
-    expect(response.body.message).toBe('Invalid AWS Region')
+    expect(response.body.message).toMatch('Invalid AWS Region')
+    expect(service.createAccount).not.toHaveBeenCalled()
+  })
+
+  test('rejects an explicitly empty Region instead of applying the default', async () => {
+    const response = await request(app).post('/api/admin/bedrock-accounts').send({
+      name: 'Empty Region account',
+      region: '',
+      credentialType: 'default'
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.message).toBe('AWS Region is required')
+    expect(service.createAccount).not.toHaveBeenCalled()
   })
 
   test('passes access key patches through without synthesizing omitted fields', async () => {
@@ -114,24 +137,39 @@ describe('Bedrock admin routes', () => {
   })
 
   test('returns HTTP 400 for invalid Region updates', async () => {
-    service.updateAccount.mockResolvedValue({
-      success: false,
-      error: 'Invalid AWS Region',
-      statusCode: 400
-    })
-
     const response = await request(app)
       .put('/api/admin/bedrock-accounts/account-1')
       .send({ region: 'invalid' })
 
     expect(response.status).toBe(400)
-    expect(response.body.message).toBe('Invalid AWS Region')
+    expect(response.body.message).toMatch('Invalid AWS Region')
+    expect(service.updateAccount).not.toHaveBeenCalled()
+  })
+
+  test('returns HTTP 400 for empty Region updates', async () => {
+    const response = await request(app)
+      .put('/api/admin/bedrock-accounts/account-1')
+      .send({ region: '' })
+
+    expect(response.status).toBe(400)
+    expect(response.body.message).toBe('AWS Region is required')
+    expect(service.updateAccount).not.toHaveBeenCalled()
   })
 
   test('queries usage statistics with the bedrock platform key', async () => {
+    const expiresAt = '2030-01-01T00:00:00.000Z'
     service.getAllAccounts.mockResolvedValue({
       success: true,
-      data: [{ id: 'account-1', name: 'Bedrock', platform: 'bedrock' }]
+      data: [
+        {
+          id: 'account-1',
+          name: 'Bedrock',
+          platform: 'bedrock',
+          subscriptionExpiresAt: expiresAt,
+          tokenExpiresAt: null,
+          expiresAt
+        }
+      ]
     })
     redis.getAccountUsageStats.mockResolvedValue({
       daily: { tokens: 1 },
@@ -143,5 +181,12 @@ describe('Bedrock admin routes', () => {
 
     expect(response.status).toBe(200)
     expect(redis.getAccountUsageStats).toHaveBeenCalledWith('account-1', 'bedrock')
+    expect(response.body.data[0]).toEqual(
+      expect.objectContaining({
+        subscriptionExpiresAt: expiresAt,
+        tokenExpiresAt: null,
+        expiresAt
+      })
+    )
   })
 })

--- a/tests/bedrockAccountsRoute.test.js
+++ b/tests/bedrockAccountsRoute.test.js
@@ -1,0 +1,147 @@
+jest.mock('../src/middleware/auth', () => ({
+  authenticateAdmin: (_req, _res, next) => next()
+}))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn()
+}))
+jest.mock('../src/services/account/bedrockAccountService', () => ({
+  getAllAccounts: jest.fn(),
+  createAccount: jest.fn(),
+  updateAccount: jest.fn(),
+  testAccountConnection: jest.fn(),
+  deleteAccount: jest.fn(),
+  resetAccountStatus: jest.fn()
+}))
+jest.mock('../src/services/apiKeyService', () => ({}))
+jest.mock('../src/services/accountGroupService', () => ({
+  getAccountGroups: jest.fn()
+}))
+jest.mock('../src/models/redis', () => ({
+  getAccountUsageStats: jest.fn()
+}))
+jest.mock('../src/utils/webhookNotifier', () => ({}))
+
+const express = require('express')
+const request = require('supertest')
+const service = require('../src/services/account/bedrockAccountService')
+const redis = require('../src/models/redis')
+const accountGroupService = require('../src/services/accountGroupService')
+const router = require('../src/routes/admin/bedrockAccounts')
+const { BEDROCK_TEST_MODEL } = require('../config/models')
+
+describe('Bedrock admin routes', () => {
+  let app
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    app = express()
+    app.use(express.json())
+    app.use('/api/admin/bedrock-accounts', router)
+    accountGroupService.getAccountGroups.mockResolvedValue([])
+  })
+
+  test('passes the selected model to the real SSE connection test', async () => {
+    service.testAccountConnection.mockImplementation(async (accountId, res, model) => {
+      res.json({ accountId, model })
+    })
+
+    const response = await request(app)
+      .post('/api/admin/bedrock-accounts/account-1/test')
+      .send({ model: BEDROCK_TEST_MODEL })
+
+    expect(response.status).toBe(200)
+    expect(service.testAccountConnection).toHaveBeenCalledWith(
+      'account-1',
+      expect.anything(),
+      BEDROCK_TEST_MODEL
+    )
+  })
+
+  test('maps create expiry and accepts the default credential chain', async () => {
+    service.createAccount.mockResolvedValue({
+      success: true,
+      data: { id: 'account-1', region: 'us-west-2', credentialType: 'default' }
+    })
+    const expiresAt = '2030-01-01T00:00:00.000Z'
+
+    const response = await request(app).post('/api/admin/bedrock-accounts').send({
+      name: 'Role account',
+      region: ' us-west-2 ',
+      credentialType: 'default',
+      expiresAt
+    })
+
+    expect(response.status).toBe(200)
+    expect(service.createAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialType: 'default',
+        region: ' us-west-2 ',
+        subscriptionExpiresAt: expiresAt
+      })
+    )
+  })
+
+  test('propagates Bedrock validation failures as HTTP 400', async () => {
+    service.createAccount.mockRejectedValue(
+      Object.assign(new Error('Invalid AWS Region'), { statusCode: 400 })
+    )
+
+    const response = await request(app).post('/api/admin/bedrock-accounts').send({
+      name: 'Invalid account',
+      region: 'not-a-region',
+      credentialType: 'default'
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.message).toBe('Invalid AWS Region')
+  })
+
+  test('passes access key patches through without synthesizing omitted fields', async () => {
+    service.updateAccount.mockResolvedValue({ success: true, data: { id: 'account-1' } })
+
+    const response = await request(app)
+      .put('/api/admin/bedrock-accounts/account-1')
+      .send({ awsCredentials: { secretAccessKey: 'rotated-secret' } })
+
+    expect(response.status).toBe(200)
+    expect(service.updateAccount).toHaveBeenCalledWith('account-1', {
+      awsCredentials: { secretAccessKey: 'rotated-secret' }
+    })
+  })
+
+  test('returns HTTP 400 for invalid Region updates', async () => {
+    service.updateAccount.mockResolvedValue({
+      success: false,
+      error: 'Invalid AWS Region',
+      statusCode: 400
+    })
+
+    const response = await request(app)
+      .put('/api/admin/bedrock-accounts/account-1')
+      .send({ region: 'invalid' })
+
+    expect(response.status).toBe(400)
+    expect(response.body.message).toBe('Invalid AWS Region')
+  })
+
+  test('queries usage statistics with the bedrock platform key', async () => {
+    service.getAllAccounts.mockResolvedValue({
+      success: true,
+      data: [{ id: 'account-1', name: 'Bedrock', platform: 'bedrock' }]
+    })
+    redis.getAccountUsageStats.mockResolvedValue({
+      daily: { tokens: 1 },
+      total: { tokens: 2 },
+      averages: { rpm: 0, tpm: 0 }
+    })
+
+    const response = await request(app).get('/api/admin/bedrock-accounts')
+
+    expect(response.status).toBe(200)
+    expect(redis.getAccountUsageStats).toHaveBeenCalledWith('account-1', 'bedrock')
+  })
+})

--- a/tests/bedrockConfig.test.js
+++ b/tests/bedrockConfig.test.js
@@ -1,0 +1,33 @@
+const modelsConfig = require('../config/models')
+const {
+  normalizeBedrockRegion,
+  assertSupportedBedrockModel
+} = require('../src/utils/bedrockConfig')
+
+describe('Bedrock configuration', () => {
+  test('normalizes surrounding whitespace and case in AWS regions', () => {
+    expect(normalizeBedrockRegion('  US-West-2\r\n')).toBe('us-west-2')
+  })
+
+  test('rejects malformed AWS regions before endpoint resolution', () => {
+    expect(() => normalizeBedrockRegion('us-west-2.invalid')).toThrow('Invalid AWS Region')
+  })
+
+  test('publishes current Bedrock models and the Haiku 4.5 test default', () => {
+    const modelIds = modelsConfig.BEDROCK_MODELS.map((model) => model.value)
+
+    expect(modelsConfig.BEDROCK_TEST_MODEL).toBe('us.anthropic.claude-haiku-4-5-20251001-v1:0')
+    expect(modelsConfig.BEDROCK_MODELS[0].value).toBe(modelsConfig.BEDROCK_TEST_MODEL)
+    expect(modelIds).toContain(modelsConfig.BEDROCK_TEST_MODEL)
+    expect(modelIds).toContain('us.anthropic.claude-sonnet-4-6')
+    expect(modelIds.some((model) => model.includes('claude-3-5-haiku-20241022'))).toBe(false)
+    expect(modelsConfig.getModelsByService('bedrock')).toBe(modelsConfig.BEDROCK_MODELS)
+  })
+
+  test('rejects the retired Bedrock Claude 3.5 Haiku model', () => {
+    expect(() =>
+      assertSupportedBedrockModel('us.anthropic.claude-3-5-haiku-20241022-v1:0')
+    ).toThrow(/retired/)
+    expect(() => assertSupportedBedrockModel('claude-3-5-haiku')).toThrow(/retired/)
+  })
+})

--- a/tests/bedrockConfig.test.js
+++ b/tests/bedrockConfig.test.js
@@ -25,9 +25,11 @@ describe('Bedrock configuration', () => {
     expect(modelsConfig.BEDROCK_MODELS[0].value).toBe(modelsConfig.BEDROCK_TEST_MODEL)
     expect(modelIds).toContain(modelsConfig.BEDROCK_TEST_MODEL)
     expect(modelIds).toContain('global.anthropic.claude-opus-5')
+    expect(modelIds).toContain('global.anthropic.claude-sonnet-5')
     expect(modelIds).toContain('us.anthropic.claude-sonnet-4-6')
     expect(modelIds.some((model) => model.includes('claude-3-5-haiku-20241022'))).toBe(false)
     expect(modelsConfig.CLAUDE_MODELS.map((model) => model.value)).not.toContain('claude-opus-5')
+    expect(modelsConfig.CLAUDE_MODELS.map((model) => model.value)).not.toContain('claude-sonnet-5')
     expect(modelsConfig.getModelsByService('bedrock')).toBe(modelsConfig.BEDROCK_MODELS)
   })
 

--- a/tests/bedrockConfig.test.js
+++ b/tests/bedrockConfig.test.js
@@ -19,6 +19,7 @@ describe('Bedrock configuration', () => {
     expect(modelsConfig.BEDROCK_TEST_MODEL).toBe('us.anthropic.claude-haiku-4-5-20251001-v1:0')
     expect(modelsConfig.BEDROCK_MODELS[0].value).toBe(modelsConfig.BEDROCK_TEST_MODEL)
     expect(modelIds).toContain(modelsConfig.BEDROCK_TEST_MODEL)
+    expect(modelIds).toContain('global.anthropic.claude-opus-5')
     expect(modelIds).toContain('us.anthropic.claude-sonnet-4-6')
     expect(modelIds.some((model) => model.includes('claude-3-5-haiku-20241022'))).toBe(false)
     expect(modelsConfig.getModelsByService('bedrock')).toBe(modelsConfig.BEDROCK_MODELS)

--- a/tests/bedrockConfig.test.js
+++ b/tests/bedrockConfig.test.js
@@ -13,6 +13,11 @@ describe('Bedrock configuration', () => {
     expect(() => normalizeBedrockRegion('us-west-2.invalid')).toThrow('Invalid AWS Region')
   })
 
+  test('rejects an explicitly empty AWS region instead of applying a fallback', () => {
+    expect(() => normalizeBedrockRegion('', 'us-east-1')).toThrow('AWS Region is required')
+    expect(() => normalizeBedrockRegion('   ', 'us-east-1')).toThrow('AWS Region is required')
+  })
+
   test('publishes current Bedrock models and the Haiku 4.5 test default', () => {
     const modelIds = modelsConfig.BEDROCK_MODELS.map((model) => model.value)
 
@@ -22,6 +27,7 @@ describe('Bedrock configuration', () => {
     expect(modelIds).toContain('global.anthropic.claude-opus-5')
     expect(modelIds).toContain('us.anthropic.claude-sonnet-4-6')
     expect(modelIds.some((model) => model.includes('claude-3-5-haiku-20241022'))).toBe(false)
+    expect(modelsConfig.CLAUDE_MODELS.map((model) => model.value)).not.toContain('claude-opus-5')
     expect(modelsConfig.getModelsByService('bedrock')).toBe(modelsConfig.BEDROCK_MODELS)
   })
 

--- a/tests/bedrockRelayService.test.js
+++ b/tests/bedrockRelayService.test.js
@@ -168,6 +168,98 @@ describe('bedrockRelayService', () => {
     )
   })
 
+  test('maps the Claude Code Opus 5 alias to the official Bedrock profile', () => {
+    expect(relay._selectModel({ model: 'claude-opus-5' }, null)).toBe(
+      'global.anthropic.claude-opus-5'
+    )
+    expect(relay._selectModel({ model: 'claude-opus-5[1m]' }, null)).toBe(
+      'global.anthropic.claude-opus-5'
+    )
+  })
+
+  test('preserves adaptive thinking and effort for Opus 5', () => {
+    const payload = relay._convertToBedrockFormat(
+      {
+        model: 'claude-opus-5[1m]',
+        max_tokens: 64000,
+        messages: [{ role: 'user', content: 'Hello' }],
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'high' }
+      },
+      'global.anthropic.claude-opus-5'
+    )
+
+    expect(payload.thinking).toEqual({ type: 'adaptive' })
+    expect(payload.output_config).toEqual({ effort: 'high' })
+  })
+
+  test('upgrades legacy extended thinking requests for Opus 5', () => {
+    const request = {
+      model: 'claude-opus-5',
+      max_tokens: 32000,
+      messages: [{ role: 'user', content: 'Hello' }],
+      system: [{ type: 'text', text: "You are Claude Code, Anthropic's official CLI." }],
+      tools: [{ name: 'Read', description: 'Read a file', input_schema: { type: 'object' } }],
+      metadata: { user_id: 'session-1' },
+      thinking: { type: 'enabled', budget_tokens: 31999 },
+      context_management: {
+        edits: [{ type: 'clear_thinking_20251015', keep: 'all' }]
+      },
+      stream: true
+    }
+    const payload = relay._convertToBedrockFormat(request, 'global.anthropic.claude-opus-5')
+
+    expect(payload.thinking).toEqual({ type: 'adaptive' })
+    expect(payload.output_config).toEqual({ effort: 'high' })
+    expect(payload.context_management).toEqual(request.context_management)
+    expect(payload.anthropic_beta).toContain('context-management-2025-06-27')
+    expect(payload.messages).toEqual(request.messages)
+    expect(payload.system).toEqual(request.system)
+    expect(payload.tools).toEqual(request.tools)
+    expect(payload.metadata).toEqual(request.metadata)
+    expect(payload).not.toHaveProperty('model')
+    expect(payload).not.toHaveProperty('stream')
+    expect(request.thinking).toEqual({ type: 'enabled', budget_tokens: 31999 })
+  })
+
+  test('keeps fixed-budget thinking for models without adaptive thinking', () => {
+    const payload = relay._convertToBedrockFormat(
+      {
+        max_tokens: 4096,
+        messages: [{ role: 'user', content: 'Hello' }],
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'low' }
+      },
+      BEDROCK_TEST_MODEL
+    )
+
+    expect(payload.thinking).toEqual({ type: 'enabled', budget_tokens: 4095 })
+    expect(payload).not.toHaveProperty('output_config')
+  })
+
+  test('preserves Bedrock response extensions while normalizing the model name', () => {
+    const response = relay._convertFromBedrockFormat({
+      id: 'message-1',
+      type: 'message',
+      role: 'assistant',
+      model: 'global.anthropic.claude-opus-5',
+      content: [{ type: 'text', text: 'OK' }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      stop_details: { type: 'refusal', category: null },
+      context_management: {
+        applied_edits: [{ type: 'clear_thinking_20251015', cleared_thinking_turns: 1 }]
+      },
+      usage: { input_tokens: 2, output_tokens: 1 }
+    })
+
+    expect(response.model).toBe('claude-opus-5')
+    expect(response.stop_details).toEqual({ type: 'refusal', category: null })
+    expect(response.context_management).toEqual({
+      applied_edits: [{ type: 'clear_thinking_20251015', cleared_thinking_turns: 1 }]
+    })
+  })
+
   test('performs a real streaming Runtime request for connection tests', async () => {
     const account = {
       id: 'account-1',

--- a/tests/bedrockRelayService.test.js
+++ b/tests/bedrockRelayService.test.js
@@ -225,6 +225,15 @@ describe('bedrockRelayService', () => {
     )
   })
 
+  test('maps the Claude Code Sonnet 5 alias to the official Bedrock profile', () => {
+    expect(relay._selectModel({ model: 'claude-sonnet-5' }, null)).toBe(
+      'global.anthropic.claude-sonnet-5'
+    )
+    expect(relay._selectModel({ model: 'claude-sonnet-5[1m]' }, null)).toBe(
+      'global.anthropic.claude-sonnet-5'
+    )
+  })
+
   test('preserves adaptive thinking and effort for Opus 5', () => {
     const payload = relay._convertToBedrockFormat(
       {
@@ -268,6 +277,21 @@ describe('bedrockRelayService', () => {
     expect(payload).not.toHaveProperty('model')
     expect(payload).not.toHaveProperty('stream')
     expect(request.thinking).toEqual({ type: 'enabled', budget_tokens: 31999 })
+  })
+
+  test('upgrades legacy extended thinking requests for Sonnet 5', () => {
+    const payload = relay._convertToBedrockFormat(
+      {
+        model: 'claude-sonnet-5',
+        max_tokens: 32000,
+        messages: [{ role: 'user', content: 'Hello' }],
+        thinking: { type: 'enabled', budget_tokens: 31999 }
+      },
+      'global.anthropic.claude-sonnet-5'
+    )
+
+    expect(payload.thinking).toEqual({ type: 'adaptive' })
+    expect(payload.output_config).toEqual({ effort: 'high' })
   })
 
   test('keeps fixed-budget thinking for models without adaptive thinking', () => {

--- a/tests/bedrockRelayService.test.js
+++ b/tests/bedrockRelayService.test.js
@@ -1,0 +1,227 @@
+jest.mock('../config/config', () => ({ bedrock: {} }), { virtual: true })
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+jest.mock('../src/services/userMessageQueueService', () => ({}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({
+  markTempUnavailable: jest.fn().mockResolvedValue(undefined)
+}))
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn(),
+  InvokeModelCommand: jest.fn((input) => ({ input })),
+  InvokeModelWithResponseStreamCommand: jest.fn((input) => ({ input }))
+}))
+jest.mock('@aws-sdk/client-bedrock', () => ({
+  BedrockClient: jest.fn(),
+  ListInferenceProfilesCommand: jest.fn((input) => ({ input }))
+}))
+
+const runtimeSdk = require('@aws-sdk/client-bedrock-runtime')
+const controlSdk = require('@aws-sdk/client-bedrock')
+const relay = require('../src/services/relay/bedrockRelayService')
+const { BEDROCK_TEST_MODEL } = require('../config/models')
+
+function streamResponse(text = 'OK') {
+  return {
+    body: (async function* stream() {
+      yield {
+        chunk: {
+          bytes: Buffer.from(
+            JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text } })
+          )
+        }
+      }
+      yield { chunk: { bytes: Buffer.from(JSON.stringify({ type: 'message_stop' })) } }
+    })()
+  }
+}
+
+function emptyStreamResponse() {
+  return {
+    body: (async function* stream() {})()
+  }
+}
+
+describe('bedrockRelayService', () => {
+  let runtimeInstances
+  let runtimeSend
+  let middlewareAdd
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    relay.clients.clear()
+    runtimeInstances = []
+    runtimeSend = jest.fn().mockResolvedValue(streamResponse())
+    middlewareAdd = jest.fn()
+    runtimeSdk.BedrockRuntimeClient.mockImplementation((clientConfig) => {
+      const client = {
+        clientConfig,
+        send: runtimeSend,
+        middlewareStack: { add: middlewareAdd }
+      }
+      runtimeInstances.push(client)
+      return client
+    })
+    controlSdk.BedrockClient.mockImplementation(() => ({
+      send: jest.fn().mockResolvedValue({ inferenceProfileSummaries: [] })
+    }))
+  })
+
+  test('normalizes Region before constructing the SDK client', () => {
+    relay._getBedrockClient(' us-west-2 ', {
+      id: 'account-1',
+      credentialType: 'access_key',
+      awsCredentials: { accessKeyId: 'AKIA_TEST', secretAccessKey: 'secret' }
+    })
+
+    expect(runtimeInstances[0].clientConfig.region).toBe('us-west-2')
+    expect(runtimeInstances[0].clientConfig.requestHandler).toEqual({
+      requestTimeout: 600000,
+      connectionTimeout: 10000
+    })
+  })
+
+  test('rejects malformed Region instead of generating an invalid URL', () => {
+    expect(() =>
+      relay._getBedrockClient('us-west-2.invalid', {
+        id: 'account-1',
+        credentialType: 'access_key',
+        awsCredentials: { accessKeyId: 'AKIA_TEST', secretAccessKey: 'secret' }
+      })
+    ).toThrow('Invalid AWS Region')
+  })
+
+  test('uses a credential fingerprint so rotations create a fresh client', () => {
+    const first = relay._getBedrockClient('us-west-2', {
+      id: 'account-1',
+      credentialType: 'access_key',
+      awsCredentials: { accessKeyId: 'AKIA_ONE', secretAccessKey: 'secret-one' }
+    })
+    const second = relay._getBedrockClient('us-west-2', {
+      id: 'account-1',
+      credentialType: 'access_key',
+      awsCredentials: { accessKeyId: 'AKIA_TWO', secretAccessKey: 'secret-two' }
+    })
+
+    expect(second).not.toBe(first)
+    expect(runtimeSdk.BedrockRuntimeClient).toHaveBeenCalledTimes(2)
+    for (const cacheKey of relay.clients.keys()) {
+      expect(cacheKey).not.toContain('AKIA_ONE')
+      expect(cacheKey).not.toContain('AKIA_TWO')
+      expect(cacheKey).not.toContain('secret-one')
+      expect(cacheKey).not.toContain('secret-two')
+    }
+  })
+
+  test('destroys cached clients when an account is invalidated', () => {
+    const client = relay._getBedrockClient('us-west-2', {
+      id: 'account-1',
+      credentialType: 'access_key',
+      awsCredentials: { accessKeyId: 'AKIA_TEST', secretAccessKey: 'secret' }
+    })
+    client.destroy = jest.fn()
+
+    expect(relay.invalidateAccountClients('account-1')).toBe(1)
+    expect(client.destroy).toHaveBeenCalledTimes(1)
+    expect(relay.clients).toHaveProperty('size', 0)
+  })
+
+  test('strictly follows bearer_token even when stale access keys exist', () => {
+    relay._getBedrockClient('us-west-2', {
+      id: 'account-1',
+      credentialType: 'bearer_token',
+      bearerToken: 'bedrock-token',
+      awsCredentials: { accessKeyId: 'STALE', secretAccessKey: 'stale-secret' }
+    })
+
+    expect(runtimeInstances[0].clientConfig.credentials).toEqual({
+      accessKeyId: 'BEDROCK_API_KEY_PLACEHOLDER',
+      secretAccessKey: 'BEDROCK_API_KEY_PLACEHOLDER'
+    })
+    expect(middlewareAdd).toHaveBeenCalledTimes(1)
+  })
+
+  test('leaves credentials unset for the standard AWS provider chain', () => {
+    relay._getBedrockClient('us-west-2', {
+      id: 'account-default',
+      credentialType: 'default'
+    })
+
+    expect(runtimeInstances[0].clientConfig).not.toHaveProperty('credentials')
+  })
+
+  test('honors the requested model before the account default', () => {
+    expect(
+      relay._selectModel(
+        { model: 'claude-haiku-4-5' },
+        { id: 'account-1', defaultModel: 'us.anthropic.claude-sonnet-4-20250514-v1:0' }
+      )
+    ).toBe(BEDROCK_TEST_MODEL)
+  })
+
+  test('maps Sonnet 4.6 without silently downgrading it', () => {
+    expect(relay._selectModel({ model: 'claude-sonnet-4-6' }, null)).toBe(
+      'us.anthropic.claude-sonnet-4-6'
+    )
+  })
+
+  test('performs a real streaming Runtime request for connection tests', async () => {
+    const account = {
+      id: 'account-1',
+      region: 'us-west-2',
+      credentialType: 'access_key',
+      awsCredentials: { accessKeyId: 'AKIA_TEST', secretAccessKey: 'secret' }
+    }
+    const onContent = jest.fn()
+
+    await expect(relay.testConnection(account, BEDROCK_TEST_MODEL, onContent)).resolves.toEqual(
+      expect.objectContaining({
+        status: 'connected',
+        model: BEDROCK_TEST_MODEL,
+        region: 'us-west-2',
+        responseText: 'OK'
+      })
+    )
+    expect(runtimeSend).toHaveBeenCalledTimes(1)
+    expect(onContent).toHaveBeenCalledWith('OK')
+  })
+
+  test('does not report connected for an incomplete Runtime stream', async () => {
+    runtimeSend.mockResolvedValueOnce(emptyStreamResponse())
+
+    await expect(
+      relay.testConnection(
+        {
+          id: 'account-1',
+          region: 'us-west-2',
+          credentialType: 'access_key',
+          awsCredentials: { accessKeyId: 'AKIA_TEST', secretAccessKey: 'secret' }
+        },
+        BEDROCK_TEST_MODEL
+      )
+    ).rejects.toThrow('incomplete response stream')
+  })
+
+  test('surfaces Runtime exception events from the response stream', async () => {
+    runtimeSend.mockResolvedValueOnce({
+      body: (async function* stream() {
+        yield { validationException: { message: 'Model is unavailable' } }
+      })()
+    })
+
+    await expect(
+      relay.testConnection(
+        {
+          id: 'account-1',
+          region: 'us-west-2',
+          credentialType: 'access_key',
+          awsCredentials: { accessKeyId: 'AKIA_TEST', secretAccessKey: 'secret' }
+        },
+        BEDROCK_TEST_MODEL
+      )
+    ).rejects.toThrow('Model is unavailable')
+  })
+})

--- a/tests/bedrockRelayService.test.js
+++ b/tests/bedrockRelayService.test.js
@@ -49,6 +49,8 @@ describe('bedrockRelayService', () => {
   let runtimeInstances
   let runtimeSend
   let middlewareAdd
+  let controlSend
+  let controlDestroy
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -56,6 +58,8 @@ describe('bedrockRelayService', () => {
     runtimeInstances = []
     runtimeSend = jest.fn().mockResolvedValue(streamResponse())
     middlewareAdd = jest.fn()
+    controlSend = jest.fn().mockResolvedValue({ inferenceProfileSummaries: [] })
+    controlDestroy = jest.fn()
     runtimeSdk.BedrockRuntimeClient.mockImplementation((clientConfig) => {
       const client = {
         clientConfig,
@@ -66,7 +70,8 @@ describe('bedrockRelayService', () => {
       return client
     })
     controlSdk.BedrockClient.mockImplementation(() => ({
-      send: jest.fn().mockResolvedValue({ inferenceProfileSummaries: [] })
+      send: controlSend,
+      destroy: controlDestroy
     }))
   })
 
@@ -151,6 +156,49 @@ describe('bedrockRelayService', () => {
     })
 
     expect(runtimeInstances[0].clientConfig).not.toHaveProperty('credentials')
+  })
+
+  test('destroys the control-plane client after paginated model discovery', async () => {
+    controlSend
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: BEDROCK_TEST_MODEL,
+            inferenceProfileName: 'Claude Haiku 4.5'
+          }
+        ],
+        nextToken: 'next-page'
+      })
+      .mockResolvedValueOnce({ inferenceProfileSummaries: [] })
+
+    await expect(
+      relay.getAvailableModels({
+        id: 'account-1',
+        region: 'us-west-2',
+        credentialType: 'access_key',
+        awsCredentials: { accessKeyId: 'AKIA_TEST', secretAccessKey: 'secret' }
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({ id: BEDROCK_TEST_MODEL, name: 'Claude Haiku 4.5' })
+    ])
+    expect(controlSend).toHaveBeenCalledTimes(2)
+    expect(controlDestroy).toHaveBeenCalledTimes(1)
+  })
+
+  test('destroys the control-plane client when discovery falls back', async () => {
+    controlSend.mockRejectedValueOnce(new Error('Access denied'))
+
+    const models = await relay.getAvailableModels({
+      id: 'account-1',
+      region: 'us-west-2',
+      credentialType: 'access_key',
+      awsCredentials: { accessKeyId: 'AKIA_TEST', secretAccessKey: 'secret' }
+    })
+
+    expect(models).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: BEDROCK_TEST_MODEL })])
+    )
+    expect(controlDestroy).toHaveBeenCalledTimes(1)
   })
 
   test('honors the requested model before the account default', () => {

--- a/tests/redisBedrockUsageStats.test.js
+++ b/tests/redisBedrockUsageStats.test.js
@@ -1,0 +1,48 @@
+jest.mock(
+  '../config/config',
+  () => ({
+    system: { timezoneOffset: 8 }
+  }),
+  { virtual: true }
+)
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+  debug: jest.fn()
+}))
+
+const redis = require('../src/models/redis')
+
+describe('Redis Bedrock usage stats', () => {
+  test('loads Bedrock creation time from its JSON account key', async () => {
+    const originalClient = redis.client
+    const originalDailyCost = redis.getAccountDailyCost
+    const createdAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString()
+    const client = {
+      hgetall: jest.fn(async (key) => {
+        if (key === 'account_usage:bedrock-1') {
+          return { totalTokens: '1000', totalRequests: '100' }
+        }
+        return {}
+      }),
+      get: jest.fn(async (key) =>
+        key === 'bedrock_account:bedrock-1' ? JSON.stringify({ createdAt }) : null
+      )
+    }
+    redis.client = client
+    redis.getAccountDailyCost = jest.fn().mockResolvedValue(0)
+
+    try {
+      const result = await redis.getAccountUsageStats('bedrock-1', 'bedrock')
+
+      expect(client.get).toHaveBeenCalledWith('bedrock_account:bedrock-1')
+      expect(result.total.requests).toBe(100)
+      expect(result.averages.dailyRequests).toBeLessThan(100)
+    } finally {
+      redis.client = originalClient
+      redis.getAccountDailyCost = originalDailyCost
+    }
+  })
+})

--- a/tests/unifiedClaudeSchedulerBedrockExpiry.test.js
+++ b/tests/unifiedClaudeSchedulerBedrockExpiry.test.js
@@ -84,4 +84,20 @@ describe('UnifiedClaudeScheduler Bedrock expiry', () => {
     await expect(scheduler._getAllAvailableAccounts({})).resolves.toEqual([])
     expect(tempSpy).not.toHaveBeenCalledWith(expiredAccount.id, 'bedrock')
   })
+
+  test('excludes shared Bedrock accounts whose stored credentials were removed', async () => {
+    const accountWithoutCredentials = {
+      ...expiredAccount,
+      id: 'bedrock-no-credentials',
+      expiresAt: null,
+      hasCredentials: false
+    }
+    bedrockAccountService.getAllAccounts.mockResolvedValue({
+      success: true,
+      data: [accountWithoutCredentials]
+    })
+
+    await expect(scheduler._getAllAvailableAccounts({})).resolves.toEqual([])
+    expect(tempSpy).not.toHaveBeenCalledWith(accountWithoutCredentials.id, 'bedrock')
+  })
 })

--- a/tests/unifiedClaudeSchedulerBedrockExpiry.test.js
+++ b/tests/unifiedClaudeSchedulerBedrockExpiry.test.js
@@ -1,0 +1,87 @@
+jest.mock('../config/config', () => ({ claude: {} }), { virtual: true })
+jest.mock('../src/services/account/claudeAccountService', () => ({}))
+jest.mock('../src/services/account/claudeConsoleAccountService', () => ({
+  getAllAccounts: jest.fn().mockResolvedValue([])
+}))
+jest.mock('../src/services/account/bedrockAccountService', () => ({
+  getAccount: jest.fn(),
+  getAllAccounts: jest.fn(),
+  isSubscriptionExpired: jest.fn()
+}))
+jest.mock('../src/services/account/ccrAccountService', () => ({
+  getAllAccounts: jest.fn().mockResolvedValue({ success: true, data: [] })
+}))
+jest.mock('../src/services/accountGroupService', () => ({}))
+jest.mock('../src/models/redis', () => ({
+  getAllClaudeAccounts: jest.fn().mockResolvedValue([])
+}))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+jest.mock('../src/utils/modelHelper', () => ({
+  parseVendorPrefixedModel: jest.fn((model) => ({ model })),
+  isOpus45OrNewer: jest.fn(() => true),
+  getRateLimitModelFamily: jest.fn(() => null)
+}))
+jest.mock('../src/utils/commonHelper', () => ({
+  isSchedulable: jest.fn((value) => value !== false && value !== 'false'),
+  sortAccountsByPriority: jest.fn((accounts) => accounts)
+}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({}))
+
+const bedrockAccountService = require('../src/services/account/bedrockAccountService')
+const scheduler = require('../src/services/scheduler/unifiedClaudeScheduler')
+
+const expiredAccount = {
+  id: 'bedrock-expired',
+  name: 'Expired Bedrock',
+  isActive: true,
+  schedulable: true,
+  accountType: 'shared',
+  expiresAt: '2020-01-01T00:00:00.000Z'
+}
+
+describe('UnifiedClaudeScheduler Bedrock expiry', () => {
+  let tempSpy
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    bedrockAccountService.getAllAccounts.mockResolvedValue({ success: true, data: [] })
+    bedrockAccountService.isSubscriptionExpired.mockImplementation(
+      (account) => account.id === expiredAccount.id
+    )
+    tempSpy = jest.spyOn(scheduler, 'isAccountTemporarilyUnavailable').mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    tempSpy.mockRestore()
+  })
+
+  test('rejects an expired Bedrock session binding', async () => {
+    bedrockAccountService.getAccount.mockResolvedValue({ success: true, data: expiredAccount })
+
+    await expect(scheduler._isAccountAvailable(expiredAccount.id, 'bedrock')).resolves.toBe(false)
+  })
+
+  test('does not use an expired bound Bedrock account', async () => {
+    bedrockAccountService.getAccount.mockResolvedValue({ success: true, data: expiredAccount })
+
+    await expect(
+      scheduler._getAllAvailableAccounts({ bedrockAccountId: expiredAccount.id })
+    ).resolves.toEqual([])
+    expect(tempSpy).not.toHaveBeenCalledWith(expiredAccount.id, 'bedrock')
+  })
+
+  test('excludes expired Bedrock accounts from the shared pool', async () => {
+    bedrockAccountService.getAllAccounts.mockResolvedValue({
+      success: true,
+      data: [expiredAccount]
+    })
+
+    await expect(scheduler._getAllAvailableAccounts({})).resolves.toEqual([])
+    expect(tempSpy).not.toHaveBeenCalledWith(expiredAccount.id, 'bedrock')
+  })
+})

--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -1106,21 +1106,6 @@
                   </div>
                 </div>
               </div>
-
-              <div>
-                <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
-                  >小快速模型 (可选)</label
-                >
-                <input
-                  v-model="form.smallFastModel"
-                  class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400"
-                  placeholder="例如：us.anthropic.claude-3-5-haiku-20241022-v1:0"
-                  type="text"
-                />
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  用于快速响应的轻量级模型，留空将使用系统默认
-                </p>
-              </div>
             </div>
 
             <!-- Azure OpenAI 特定字段 -->
@@ -3676,19 +3661,6 @@
             </div>
 
             <div>
-              <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
-                >小快速模型 (可选)</label
-              >
-              <input
-                v-model="form.smallFastModel"
-                class="form-input w-full"
-                placeholder="例如：us.anthropic.claude-3-5-haiku-20241022-v1:0"
-                type="text"
-              />
-              <p class="mt-1 text-xs text-gray-500">用于快速响应的轻量级模型，留空将使用系统默认</p>
-            </div>
-
-            <div>
               <label class="mb-3 block text-sm font-semibold text-gray-700">限流机制</label>
               <div class="mb-3">
                 <label class="inline-flex cursor-pointer items-center">
@@ -4384,7 +4356,6 @@ const form = ref({
   sessionToken: props.account?.sessionToken || '',
   bearerToken: props.account?.bearerToken || '', // Bearer Token 字段
   defaultModel: props.account?.defaultModel || '',
-  smallFastModel: props.account?.smallFastModel || '',
   // Azure OpenAI 特定字段
   azureEndpoint: props.account?.azureEndpoint || '',
   apiVersion: props.account?.apiVersion || '',
@@ -5555,9 +5526,8 @@ const createAccount = async () => {
         data.bearerToken = form.value.bearerToken
       }
 
-      data.region = form.value.region
+      data.region = form.value.region.trim().toLowerCase()
       data.defaultModel = form.value.defaultModel || null
-      data.smallFastModel = form.value.smallFastModel || null
       data.priority = form.value.priority || 50
       // 如果不启用限流，传递 0 表示不限流
       data.rateLimitDuration = form.value.enableRateLimit ? form.value.rateLimitDuration || 60 : 0
@@ -5899,8 +5869,8 @@ const updateAccount = async () => {
           if (form.value.secretAccessKey) {
             data.awsCredentials.secretAccessKey = form.value.secretAccessKey
           }
-          if (form.value.sessionToken !== undefined) {
-            data.awsCredentials.sessionToken = form.value.sessionToken || null
+          if (form.value.sessionToken) {
+            data.awsCredentials.sessionToken = form.value.sessionToken
           }
         }
       } else if (form.value.credentialType === 'bearer_token') {
@@ -5911,11 +5881,10 @@ const updateAccount = async () => {
       }
 
       if (form.value.region) {
-        data.region = form.value.region
+        data.region = form.value.region.trim().toLowerCase()
       }
       // 模型配置（支持设置为空来使用系统默认）
       data.defaultModel = form.value.defaultModel || null
-      data.smallFastModel = form.value.smallFastModel || null
       data.priority = form.value.priority || 50
       // 如果不启用限流，传递 0 表示不限流
       data.rateLimitDuration = form.value.enableRateLimit ? form.value.rateLimitDuration || 60 : 0
@@ -6490,7 +6459,6 @@ watch(
         region: newAccount.region || '',
         sessionToken: '', // 编辑模式不显示现有的会话令牌
         defaultModel: newAccount.defaultModel || '',
-        smallFastModel: newAccount.smallFastModel || '',
         // Azure OpenAI 特定字段
         azureEndpoint: newAccount.azureEndpoint || '',
         apiVersion: newAccount.apiVersion || '',

--- a/web/admin-spa/src/components/common/UnifiedTestModal.vue
+++ b/web/admin-spa/src/components/common/UnifiedTestModal.vue
@@ -347,9 +347,7 @@ const defaultModel = computed(() => {
     if (platform === 'bedrock') {
       const models = availableModels.value
       if (models.length > 0) return models[0].value
-      if (props.account?.credentialType === 'bearer_token')
-        return 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
-      return 'us.anthropic.claude-3-5-haiku-20241022-v1:0'
+      return 'us.anthropic.claude-haiku-4-5-20251001-v1:0'
     }
     const models = availableModels.value
     if (models.length > 0) return models[0].value


### PR DESCRIPTION
## What changed

- Normalize and validate AWS Bedrock regions before account persistence and runtime use.
- Repair access-key, bearer-token, and default credential-chain lifecycle handling.
- Invalidate cached AWS SDK clients when credentials or accounts change.
- Use real `InvokeModelWithResponseStream` calls for Web and CLI connection tests.
- Discover inference profiles through the Bedrock control plane with a catalog fallback.
- Update the Bedrock model catalog and route Claude Code aliases to official inference profiles.
- Support Haiku 4.5, Sonnet 4.6, Opus 5, and Sonnet 5 without silent model downgrades.
- Convert Claude 5 legacy thinking payloads to Bedrock-compatible adaptive thinking.
- Exclude expired or unusable Bedrock accounts from all scheduler paths.
- Correct Bedrock expiry mapping and usage-statistics platform selection.

## Compatibility

- Existing Redis keys, account IDs, encryption format, and SSE event names are unchanged.
- Existing account regions are normalized when read; no bulk migration is required.
- The default connection-test model is Claude Haiku 4.5.
- Bedrock-only Claude 5 entries are not added to generic Claude account selectors.

## Validation

- `npm test -- --runInBand`: 31 suites passed, 328 tests passed, 8 skipped.
- `npm run lint:check`: passed.
- `npm run format:check`: passed.
- Admin SPA ESLint: 0 errors (90 pre-existing warnings).
- Admin SPA Prettier check: passed.
- Admin SPA Vite build: passed.
- Real Bedrock Runtime streaming calls succeeded in `us-west-2` for Claude Haiku 4.5 and Claude Sonnet 5.
- Sonnet 5 validation confirmed alias mapping, adaptive thinking conversion, complete response streaming, and usage reporting.
- `git diff --check` and credential-pattern scans passed.

## AWS references

- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html