### PR TITLE
fix(relay): auto 模式 Bash 安全分类器请求被错误判定为真实 Claude Code 请求，剥离 billing header 后触发 429

### DIFF
--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -29,6 +29,13 @@ const {
 const safeClone =
   typeof structuredClone === 'function' ? structuredClone : (obj) => JSON.parse(JSON.stringify(obj))
 
+// 🏷️ 判断某个 system 元素是否是 Claude Code 的 billing header 标识
+const isBillingHeaderSystemBlock = (item) =>
+  !!item &&
+  item.type === 'text' &&
+  typeof item.text === 'string' &&
+  item.text.trim().startsWith('x-anthropic-billing-header')
+
 class ClaudeRelayService {
   constructor() {
     this.claudeApiUrl = 'https://api.anthropic.com/v1/messages?beta=true'
@@ -154,7 +161,21 @@ class ClaudeRelayService {
   }
 
   // 🔍 判断是否是真实的 Claude Code 请求
+  // 注意：判定前必须先剔除 billing header 元素。它在模板库中有对应条目
+  // （contents.js 的 claudeOtherSystemPrompt5），单独就能让判定通过；但转发前
+  // _removeBillingHeaderFromSystem 又会把它删掉。若不在此处对齐，Claude Code 的辅助请求
+  // （如 auto 模式的 Bash 安全分类器，system 为 [billing header, 分类器提示词]）会被判成
+  // 真实 Claude Code 而跳过身份提示词注入，剥离 billing header 后上游收到的 system 里
+  // 不含任何 Claude Code 标识，被 Anthropic 拒绝并返回无 reset 头的 429。
   isRealClaudeCodeRequest(requestBody) {
+    const system = requestBody?.system
+    if (Array.isArray(system) && system.some(isBillingHeaderSystemBlock)) {
+      const withoutBillingHeader = system.filter((item) => !isBillingHeaderSystemBlock(item))
+      return ClaudeCodeValidator.includesClaudeCodeSystemPrompt(
+        { ...requestBody, system: withoutBillingHeader },
+        1
+      )
+    }
     return ClaudeCodeValidator.includesClaudeCodeSystemPrompt(requestBody, 1)
   }
 
@@ -1333,13 +1354,7 @@ class ClaudeRelayService {
     if (Array.isArray(processedBody.system)) {
       const originalLength = processedBody.system.length
       processedBody.system = processedBody.system.filter(
-        (item) =>
-          !(
-            item &&
-            item.type === 'text' &&
-            typeof item.text === 'string' &&
-            item.text.trim().startsWith('x-anthropic-billing-header')
-          )
+        (item) => !isBillingHeaderSystemBlock(item)
       )
       if (processedBody.system.length < originalLength) {
         logger.debug(

--- a/tests/claudeRelayBillingHeaderDetection.test.js
+++ b/tests/claudeRelayBillingHeaderDetection.test.js
@@ -1,0 +1,103 @@
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn(),
+  api: jest.fn()
+}))
+
+jest.mock('../src/models/redis', () => ({}))
+
+// 这些依赖在 require 阶段会建连接/起定时器，测试只关心请求体处理，全部置空
+jest.mock('../src/utils/proxyHelper', () => ({}))
+jest.mock('../src/utils/sessionHelper', () => ({}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({}))
+jest.mock('../src/utils/testPayloadHelper', () => ({ createClaudeTestPayload: jest.fn() }))
+jest.mock('../src/services/account/claudeAccountService', () => ({}))
+jest.mock('../src/services/scheduler/unifiedClaudeScheduler', () => ({}))
+jest.mock('../src/services/claudeCodeHeadersService', () => ({}))
+jest.mock('../src/services/requestIdentityService', () => ({}))
+jest.mock('../src/services/userMessageQueueService', () => ({}))
+
+const claudeRelayService = require('../src/services/relay/claudeRelayService')
+
+const BILLING_HEADER = {
+  type: 'text',
+  text: 'x-anthropic-billing-header: cc_version=2.1.233.931; cc_entrypoint=sdk-ts;'
+}
+const CLAUDE_CODE_IDENTITY = {
+  type: 'text',
+  text: "You are Claude Code, Anthropic's official CLI for Claude."
+}
+const AUXILIARY_PROMPT = {
+  type: 'text',
+  text: 'You are a security monitor for autonomous AI coding agents.'
+}
+
+const bodyWithSystem = (system) => ({
+  model: 'claude-opus-5',
+  max_tokens: 64,
+  system,
+  messages: [{ role: 'user', content: 'hi' }]
+})
+
+describe('claudeRelayService.isRealClaudeCodeRequest with billing header', () => {
+  it('ignores a lone billing header block', () => {
+    expect(claudeRelayService.isRealClaudeCodeRequest(bodyWithSystem([BILLING_HEADER]))).toBe(false)
+  })
+
+  it('rejects auxiliary requests whose only recognized block is the billing header', () => {
+    const body = bodyWithSystem([BILLING_HEADER, AUXILIARY_PROMPT])
+    expect(claudeRelayService.isRealClaudeCodeRequest(body)).toBe(false)
+  })
+
+  it('still accepts real Claude Code requests carrying a billing header', () => {
+    const body = bodyWithSystem([BILLING_HEADER, CLAUDE_CODE_IDENTITY])
+    expect(claudeRelayService.isRealClaudeCodeRequest(body)).toBe(true)
+  })
+
+  it('still accepts real Claude Code requests without a billing header', () => {
+    expect(claudeRelayService.isRealClaudeCodeRequest(bodyWithSystem([CLAUDE_CODE_IDENTITY]))).toBe(
+      true
+    )
+  })
+
+  it('does not mutate the caller request body', () => {
+    const body = bodyWithSystem([BILLING_HEADER, AUXILIARY_PROMPT])
+    claudeRelayService.isRealClaudeCodeRequest(body)
+    expect(body.system).toHaveLength(2)
+    expect(body.system[0]).toBe(BILLING_HEADER)
+  })
+})
+
+describe('claudeRelayService._processRequestBody keeps a Claude Code identity upstream', () => {
+  const identityText = (system) => {
+    if (typeof system === 'string') {
+      return system
+    }
+    return Array.isArray(system) ? system.map((item) => item && item.text).join('\n') : ''
+  }
+
+  it('injects the Claude Code prompt for billing-header-only auxiliary requests', () => {
+    const body = bodyWithSystem([BILLING_HEADER, AUXILIARY_PROMPT])
+    const isRealClaudeCode = claudeRelayService.isRealClaudeCodeRequest(body)
+    const processed = claudeRelayService._processRequestBody(body, null, isRealClaudeCode)
+
+    expect(identityText(processed.system)).toContain(
+      "You are Claude Code, Anthropic's official CLI"
+    )
+    expect(identityText(processed.system)).not.toContain('x-anthropic-billing-header')
+    // 原始 system 指令被迁移到 messages，模型仍能收到完整指令
+    expect(JSON.stringify(processed.messages)).toContain('security monitor for autonomous')
+  })
+
+  it('leaves real Claude Code requests with their own identity block', () => {
+    const body = bodyWithSystem([BILLING_HEADER, CLAUDE_CODE_IDENTITY, AUXILIARY_PROMPT])
+    const isRealClaudeCode = claudeRelayService.isRealClaudeCodeRequest(body)
+    const processed = claudeRelayService._processRequestBody(body, null, isRealClaudeCode)
+
+    expect(processed.system[0].text).toBe(CLAUDE_CODE_IDENTITY.text)
+    expect(identityText(processed.system)).not.toContain('x-anthropic-billing-header')
+  })
+})


### PR DESCRIPTION
## 问题

开启 Claude Code auto 模式后，Bash 安全分类器（用于判断 Bash 命令是否安全的辅助请求）频繁报错：

```
claude-opus-4-8[1m] is temporarily unavailable, so auto mode cannot determine the safety of
Bash right now. Wait briefly and then try this action again. If it keeps failing, continue
with other tasks that don't require this action and come back to it later.
```

对应 #1153 #1199 中反馈的 "auto mode 触发 429" —— 两个 issue 里都贴出了完全相同的报错文案，且都提到"正常对话请求没问题，只有 auto mode 会 429"，与本 PR 定位到的根因症状一致。

## 根因

Claude Code 的辅助请求（如 auto 模式的 Bash 安全分类器）发送的 `system` 数组形如：

```json
[
  { "type": "text", "text": "x-anthropic-billing-header: cc_version=..." },
  { "type": "text", "text": "You are a security monitor for autonomous AI coding agents..." }
]
```

**它不包含 "You are Claude Code..." 身份声明。**

`claudeRelayService.isRealClaudeCodeRequest()` 用请求体去匹配 `contents.js` 里的模板库判断"是否真实 Claude Code 请求"。billing header 这块文本恰好精确命中模板 `claudeOtherSystemPrompt5`（相似度 1.0），于是**仅凭 billing header 这一块就被判定为"真实 Claude Code 请求"**，从而跳过了后续的身份提示词注入改写逻辑（`_processRequestBody` 里 `if (!isRealClaudeCode)` 分支）。

紧接着 `_removeBillingHeaderFromSystem()` 为了不把客户端 billing 标识透传给上游，把这块内容删掉了。

两步叠加的结果：**最终发给 Anthropic 的请求，system 里唯一能证明"这是 Claude Code"的内容被删掉了，且没有走注入身份提示词的兜底路径**。上游收到"OAuth token + claude-cli 请求头 + 但 system 里没有任何 Claude Code 身份声明"的组合，直接拒绝，返回：

```json
{"type":"error","error":{"type":"rate_limit_error","message":"Error"}}
```

（响应头没有任何 `anthropic-ratelimit-*` / `retry-after`，说明这不是真实的用量限流，是身份校验失败被包装成了 429 的壳。）中转服务把这个 429 原样透传给客户端，Claude Code SDK 重试耗尽后报出上面那条 "temporarily unavailable" 错误。

## 复现（本地起服务，直连中转 API 验证）

| 客户端发送的 system | 判定 | 实际发给上游的 system | 结果 |
|---|---|---|---|
| `[billing header]` | 真实 CC | （空） | **429** |
| `[billing header, 分类器提示词]` ← auto 模式分类器的真实形状 | 真实 CC | `[分类器提示词]` | **429** |
| `[billing header, Claude Code 身份]` | 真实 CC | `[Claude Code 身份]` | 200 |
| `[billing header, Claude Code 身份, 分类器提示词]` | 真实 CC | `[Claude Code 身份, 分类器提示词]` | 200 |

前两行和后两行走的是完全相同的代码路径，唯一变量是"剥掉 billing header 后 system 里还剩不剩 Claude Code 身份声明"——这就是触发条件。

## 修复

判定"是否真实 Claude Code 请求"之前，先把 billing header 元素过滤掉再比对，让判定逻辑与转发前的剥离逻辑保持一致：

```js
isRealClaudeCodeRequest(requestBody) {
  const system = requestBody?.system
  if (Array.isArray(system) && system.some(isBillingHeaderSystemBlock)) {
    const withoutBillingHeader = system.filter((item) => !isBillingHeaderSystemBlock(item))
    return ClaudeCodeValidator.includesClaudeCodeSystemPrompt(
      { ...requestBody, system: withoutBillingHeader }, 1)
  }
  return ClaudeCodeValidator.includesClaudeCodeSystemPrompt(requestBody, 1)
}
```

效果：
- `[billing header, 分类器提示词]` → 过滤后只剩 `[分类器提示词]` → 判定为**非**真实 Claude Code → 走现有的身份提示词注入改写路径（原 system 迁移到 messages，system 替换为标准 Claude Code 身份）→ 上游收到合法身份声明 → 200
- `[billing header, Claude Code 身份, ...]`（正常对话请求）→ 过滤后仍能匹配到身份声明 → 判定不变，原样透传 → **无回归**

顺带把 billing header 判断逻辑抽成 `isBillingHeaderSystemBlock`，`_removeBillingHeaderFromSystem` 里原本重复的内联判断改为复用同一个函数，避免两处判断标准以后再次漂移出同类 bug。

## 验证

- 新增 `tests/claudeRelayBillingHeaderDetection.test.js`，覆盖四种 system 组合的判定结果、请求体不可变性、`_processRequestBody` 最终吐出的 system/messages 内容，共 7 个用例，全部通过
- `npm test`：全量 28 个测试文件、288 个用例全部通过
- 已在自建部署上实测：修复前对 `[billing header, 分类器提示词]` 形状的请求稳定复现 429；部署修复后同一请求返回 200

## 关联 Issue

- #1153 关于claude code max会员的auto mode —— 评论区 `alongw` 贴出的报错文案与本 PR 定位的症状完全一致
- #1199 CRS 的请求好像被判定成了外部工具调用，触发了 extra usage，频繁触发 429 限流 —— 评论区 `xtr9496` 贴出相同报错文案，且提到切到 `--dangerously-skip-permissions`（跳过权限确认，不会触发 Bash 安全分类器）后问题消失，与"只有分类器请求会 429，正常请求不受影响"的根因吻合。注意：该 issue 楼中还夹杂了其他症状（如切换到 1M context 模型触发的 429、`extra usage` 相关的账户级限流），可能是不同成因，本 PR 只解决 auto 模式分类器请求这一条链路。