### PR TITLE
fix(openai): mark invalid refresh tokens unauthorized

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -242,11 +242,31 @@ async function getOpenAIAuthToken(apiKeyData, sessionId = null, requestedModel =
             logger.info(`✅ Token refreshed successfully in route handler`)
           } catch (refreshError) {
             logger.error(`Failed to refresh token for ${account.name}:`, refreshError)
+            if (openaiAccountService.isTokenRefreshUnauthorizedError(refreshError)) {
+              const reason = `OpenAI账号认证失败（Refresh Token 无效）：${refreshError.message}`
+              await unifiedOpenAIScheduler
+                .markAccountUnauthorized(result.accountId, 'openai', sessionHash, reason)
+                .catch((markError) => {
+                  logger.error(
+                    '❌ Failed to mark OpenAI account unauthorized after refresh failure:',
+                    markError
+                  )
+                })
+            }
             const error = new Error(`Token expired and refresh failed: ${refreshError.message}`)
             error.statusCode = 403 // Forbidden - 认证失败
             throw error
           }
         } else {
+          const reason = `OpenAI账号认证失败（Refresh Token 缺失）：Token expired and no refresh token available for account ${account.name}`
+          await unifiedOpenAIScheduler
+            .markAccountUnauthorized(result.accountId, 'openai', sessionHash, reason)
+            .catch((markError) => {
+              logger.error(
+                '❌ Failed to mark OpenAI account unauthorized after missing refresh token:',
+                markError
+              )
+            })
           const error = new Error(
             `Token expired and no refresh token available for account ${account.name}`
           )

--- a/src/services/account/openaiAccountService.js
+++ b/src/services/account/openaiAccountService.js
@@ -14,6 +14,7 @@ const {
   logRefreshSkipped
 } = require('../../utils/tokenRefreshLogger')
 const tokenRefreshService = require('../tokenRefreshService')
+const { isTokenRefreshUnauthorizedError } = require('./openaiTokenErrors')
 const { createEncryptor } = require('../../utils/commonHelper')
 
 // 使用 commonHelper 的加密器
@@ -1240,6 +1241,7 @@ module.exports = {
   selectAvailableAccount,
   refreshAccountToken,
   isTokenExpired,
+  isTokenRefreshUnauthorizedError,
   setAccountRateLimited,
   markAccountUnauthorized,
   resetAccountStatus,

--- a/src/services/account/openaiTokenErrors.js
+++ b/src/services/account/openaiTokenErrors.js
@@ -1,0 +1,33 @@
+function isTokenRefreshUnauthorizedError(error) {
+  const status = error?.status || error?.response?.status
+  const errorCode = error?.details?.error?.code || error?.response?.data?.error?.code || error?.code
+  const errorType = error?.details?.error?.type || error?.response?.data?.error?.type
+  const message = [
+    error?.message,
+    error?.details?.error?.message,
+    error?.details?.error_description,
+    error?.response?.data?.error?.message,
+    error?.response?.data?.error_description,
+    error?.response?.data?.message
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  if (status === 401) {
+    return true
+  }
+
+  return (
+    /refresh_token_reused|invalid_grant|token_invalidated|invalid_refresh_token/i.test(
+      String(errorCode || '')
+    ) ||
+    /invalid_request_error/i.test(String(errorType || '')) ||
+    /refresh token.*(invalid|expired|reused)|token.*invalidated|Refresh Token 无效|认证失败/.test(
+      message
+    )
+  )
+}
+
+module.exports = {
+  isTokenRefreshUnauthorizedError
+}

--- a/src/services/scheduler/unifiedOpenAIScheduler.js
+++ b/src/services/scheduler/unifiedOpenAIScheduler.js
@@ -395,6 +395,17 @@ class UnifiedOpenAIScheduler {
             logger.warn(
               `⚠️ OpenAI account ${account.name} token expired and no refresh token available`
             )
+            await this.markAccountUnauthorized(
+              accountId,
+              'openai',
+              null,
+              `OpenAI账号认证失败（Refresh Token 缺失）：Token expired and no refresh token available for account ${account.name}`
+            ).catch((markError) => {
+              logger.error(
+                `❌ Failed to mark OpenAI account ${account.name} unauthorized after missing refresh token:`,
+                markError
+              )
+            })
             continue
           }
 
@@ -407,6 +418,19 @@ class UnifiedOpenAIScheduler {
             logger.info(`✅ Token refreshed successfully for ${account.name}`)
           } catch (refreshError) {
             logger.error(`❌ Failed to refresh token for ${account.name}:`, refreshError.message)
+            if (openaiAccountService.isTokenRefreshUnauthorizedError(refreshError)) {
+              await this.markAccountUnauthorized(
+                account.id,
+                'openai',
+                null,
+                `OpenAI账号认证失败（Refresh Token 无效）：${refreshError.message}`
+              ).catch((markError) => {
+                logger.error(
+                  `❌ Failed to mark OpenAI account ${account.name} unauthorized after refresh failure:`,
+                  markError
+                )
+              })
+            }
             continue // 刷新失败，跳过此账户
           }
         }

--- a/tests/openaiRefreshUnauthorized.test.js
+++ b/tests/openaiRefreshUnauthorized.test.js
@@ -1,0 +1,23 @@
+const { isTokenRefreshUnauthorizedError } = require('../src/services/account/openaiTokenErrors')
+
+describe('openai token refresh unauthorized detection', () => {
+  test.each([
+    [{ status: 401 }, '401 status'],
+    [{ code: 'invalid_refresh_token' }, 'invalid_refresh_token code'],
+    [{ details: { error: { code: 'refresh_token_reused' } } }, 'refresh_token_reused details'],
+    [{ response: { data: { error: { code: 'invalid_grant' } } } }, 'invalid_grant response'],
+    [
+      { response: { data: { error: { type: 'invalid_request_error' } } } },
+      'invalid_request_error type'
+    ],
+    [{ message: '认证失败：Refresh Token 无效' }, 'localized invalid refresh message']
+  ])('returns true for permanent refresh-token auth failures: %s', (error) => {
+    expect(isTokenRefreshUnauthorizedError(error)).toBe(true)
+  })
+
+  test('returns false for transient refresh failures', () => {
+    expect(isTokenRefreshUnauthorizedError({ status: 429 })).toBe(false)
+    expect(isTokenRefreshUnauthorizedError({ code: 'ECONNRESET' })).toBe(false)
+    expect(isTokenRefreshUnauthorizedError(new Error('network timeout'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

This PR makes OpenAI/Codex account refresh failures fail closed when the refresh token is permanently invalid.

When a refresh attempt returns a permanent auth failure such as HTTP 401, `invalid_refresh_token`, `invalid_grant`, `refresh_token_reused`, `token_invalidated`, or the localized `Refresh Token 无效` message, CRS now persists the account as unauthorized and unschedulable instead of leaving it in the scheduler pool.

## Why

We reproduced a production incident where:

- `/health` was healthy.
- `/openai/key-info` for caller API keys was healthy.
- All caller API keys using `/openai/v1/responses` failed with `403 Permission denied`.
- The underlying cause was that every bound OpenAI/Codex OAuth account had an invalid refresh token, but those accounts remained active/schedulable and kept being selected by the scheduler.

This makes the failure mode explicit and prevents repeated routing to accounts that cannot refresh.

## Relationship to existing PRs

This is the same issue class as #1191. I am opening this PR with an added small pure helper module and regression tests so the failure detector can be tested without loading the full Redis/config runtime.

## Changes

- Add `isTokenRefreshUnauthorizedError()` as a pure helper.
- Export the helper through `openaiAccountService` for existing call sites.
- In `openaiRoutes`, mark the selected OpenAI account unauthorized when route-level refresh fails permanently or when an expired account has no refresh token.
- In `unifiedOpenAIScheduler`, mark expired accounts unauthorized when they have no refresh token or when refresh fails with a permanent auth error.
- Add Jest coverage for permanent vs transient refresh failures.

## Validation

On a clean branch based on upstream `main`:

- `npx eslint src/services/account/openaiAccountService.js src/services/account/openaiTokenErrors.js src/routes/openaiRoutes.js src/services/scheduler/unifiedOpenAIScheduler.js tests/openaiRefreshUnauthorized.test.js`
- `npx prettier --check src/services/account/openaiAccountService.js src/services/account/openaiTokenErrors.js src/routes/openaiRoutes.js src/services/scheduler/unifiedOpenAIScheduler.js tests/openaiRefreshUnauthorized.test.js`
- `npx jest tests/openaiRefreshUnauthorized.test.js tests/openaiResponsesPayloadToggles.test.js --runInBand` → 17 passed

No credentials, tokens, internal hostnames, or private deployment details are included.
