### PR TITLE
feat: add OrcaRouter as a preset provider for OpenAI-Responses accounts

### DIFF
--- a/src/services/account/openaiResponsesAccountService.js
+++ b/src/services/account/openaiResponsesAccountService.js
@@ -35,6 +35,35 @@ class OpenAIResponsesAccountService {
     )
   }
 
+  // Preset third-party OpenAI-compatible gateway providers.
+  // When a named provider is selected, baseApi is auto-filled from the preset
+  // so users don't have to type the upstream URL by hand.
+  static get PROVIDER_BASE_URLS() {
+    return {
+      orcarouter: 'https://api.orcarouter.ai/v1',
+      custom: ''
+    }
+  }
+
+  // Resolve the provider selection: named providers use a preset base URL,
+  // while 'custom' keeps the baseApi the user entered.
+  _resolveProviderBaseApi(provider, baseApi) {
+    const normalizedProvider = (provider || 'custom').toLowerCase()
+    const presetUrl = OpenAIResponsesAccountService.PROVIDER_BASE_URLS[normalizedProvider]
+
+    if (normalizedProvider === 'custom') {
+      return { provider: 'custom', baseApi: baseApi || '' }
+    }
+
+    if (presetUrl) {
+      return { provider: normalizedProvider, baseApi: presetUrl }
+    }
+
+    throw new Error(
+      `Invalid provider: ${provider}. Must be one of: ${Object.keys(OpenAIResponsesAccountService.PROVIDER_BASE_URLS).join(', ')}`
+    )
+  }
+
   // 创建账户
   async createAccount(options = {}) {
     const {
@@ -52,11 +81,16 @@ class OpenAIResponsesAccountService {
       quotaResetTime = '00:00', // 额度重置时间（HH:mm格式）
       rateLimitDuration = 60, // 限流时间（分钟）
       disableAutoProtection = false, // 是否关闭自动防护（429/401/400/529 不自动禁用）
-      providerEndpoint = 'responses' // Provider 端点类型：responses | auto
+      providerEndpoint = 'responses', // Provider endpoint type: responses | auto
+      provider = 'custom' // Preset provider: orcarouter | custom
     } = options
 
+    // Resolve preset providers; a named provider auto-fills baseApi
+    const resolved = this._resolveProviderBaseApi(provider, baseApi)
+    const effectiveBaseApi = resolved.baseApi || baseApi
+
     // 验证必填字段
-    if (!baseApi || !apiKey) {
+    if (!effectiveBaseApi || !apiKey) {
       throw new Error('Base API URL and API Key are required for OpenAI-Responses account')
     }
 
@@ -69,7 +103,9 @@ class OpenAIResponsesAccountService {
     }
 
     // 规范化 baseApi（确保不以 / 结尾）
-    const normalizedBaseApi = baseApi.endsWith('/') ? baseApi.slice(0, -1) : baseApi
+    const normalizedBaseApi = effectiveBaseApi.endsWith('/')
+      ? effectiveBaseApi.slice(0, -1)
+      : effectiveBaseApi
 
     const accountId = uuidv4()
 
@@ -106,7 +142,8 @@ class OpenAIResponsesAccountService {
       quotaResetTime,
       quotaStoppedAt: '',
       disableAutoProtection: disableAutoProtection.toString(), // 关闭自动防护
-      providerEndpoint // Provider 端点类型：responses(默认) | auto
+      providerEndpoint, // Provider endpoint type: responses(default) | auto
+      provider: resolved.provider // Preset provider: orcarouter | custom
     }
 
     // 保存到 Redis
@@ -160,6 +197,17 @@ class OpenAIResponsesAccountService {
     // 处理 JSON 字段
     if (updates.proxy !== undefined) {
       updates.proxy = updates.proxy ? JSON.stringify(updates.proxy) : ''
+    }
+
+    // Resolve preset providers: switching to a named provider overwrites baseApi
+    // with the preset URL; switching to custom keeps the stored baseApi.
+    if (updates.provider !== undefined) {
+      const resolved = this._resolveProviderBaseApi(
+        updates.provider,
+        updates.baseApi || account.baseApi || ''
+      )
+      updates.provider = resolved.provider
+      updates.baseApi = resolved.baseApi
     }
 
     // 规范化 baseApi
@@ -281,6 +329,7 @@ class OpenAIResponsesAccountService {
       accountData.isActive = accountData.isActive === 'true'
       accountData.expiresAt = accountData.subscriptionExpiresAt || null
       accountData.platform = accountData.platform || 'openai-responses'
+      accountData.provider = accountData.provider || 'custom'
 
       accounts.push(accountData)
     })

--- a/src/services/relay/openaiResponsesRelayService.js
+++ b/src/services/relay/openaiResponsesRelayService.js
@@ -80,6 +80,11 @@ class OpenAIResponsesRelayService {
         throw new Error('Account not found')
       }
 
+      // Accounts created with a preset provider (e.g. orcarouter) carry a
+      // fixed baseApi; legacy accounts without a provider field behave as
+      // 'custom' to preserve existing behavior.
+      fullAccount.provider = fullAccount.provider || 'custom'
+
       // 创建 AbortController 用于取消请求
       abortController = new AbortController()
 

--- a/tests/openaiResponsesProviderPresets.test.js
+++ b/tests/openaiResponsesProviderPresets.test.js
@@ -1,0 +1,149 @@
+const mockHSet = jest.fn()
+const mockHGetAll = jest.fn()
+const mockSAdd = jest.fn()
+
+const mockClient = {
+  hset: mockHSet,
+  hgetall: mockHGetAll,
+  sadd: mockSAdd,
+  srem: jest.fn(),
+  del: jest.fn(),
+  pipeline: jest.fn()
+}
+
+jest.mock(
+  '../config/config',
+  () => ({
+    security: {
+      encryptionKey: 'test-encryption-key-32-characters!!'
+    }
+  }),
+  { virtual: true }
+)
+
+jest.mock('../src/models/redis', () => ({
+  getClientSafe: jest.fn(() => mockClient),
+  getDateStringInTimezone: jest.fn(() => '2026-08-27'),
+  addToIndex: jest.fn(),
+  removeFromIndex: jest.fn(),
+  getAllIdsByIndex: jest.fn()
+}))
+
+jest.mock('../src/utils/logger', () => ({
+  success: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  database: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn()
+}))
+
+const service = require('../src/services/account/openaiResponsesAccountService')
+
+describe('OpenAIResponsesAccountService provider presets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('createAccount', () => {
+    it('resolves orcarouter provider to the preset base URL', async () => {
+      const account = await service.createAccount({
+        name: 'OrcaRouter Pool',
+        apiKey: 'sk-orca-test',
+        provider: 'orcarouter'
+      })
+
+      expect(account.provider).toBe('orcarouter')
+      expect(account.baseApi).toBe('https://api.orcarouter.ai/v1')
+      // apiKey is masked in the returned data
+      expect(account.apiKey).toBe('***')
+      // the encrypted key was persisted via hset
+      expect(mockHSet).toHaveBeenCalled()
+      const saved = mockHSet.mock.calls[0][1]
+      expect(saved.baseApi).toBe('https://api.orcarouter.ai/v1')
+      expect(saved.provider).toBe('orcarouter')
+    })
+
+    it('keeps a custom baseApi when provider is custom', async () => {
+      const account = await service.createAccount({
+        name: 'Custom Gateway',
+        baseApi: 'https://my-gateway.example.com/v1',
+        apiKey: 'sk-custom-test',
+        provider: 'custom'
+      })
+
+      expect(account.provider).toBe('custom')
+      expect(account.baseApi).toBe('https://my-gateway.example.com/v1')
+    })
+
+    it('defaults to custom provider when provider is omitted', async () => {
+      const account = await service.createAccount({
+        name: 'Legacy Account',
+        baseApi: 'https://legacy.example.com/v1',
+        apiKey: 'sk-legacy-test'
+      })
+
+      expect(account.provider).toBe('custom')
+      expect(account.baseApi).toBe('https://legacy.example.com/v1')
+    })
+
+    it('rejects unknown provider names', async () => {
+      await expect(
+        service.createAccount({
+          name: 'Bad',
+          apiKey: 'sk-bad',
+          provider: 'not-a-provider'
+        })
+      ).rejects.toThrow(/Invalid provider: not-a-provider/)
+    })
+
+    it('still requires an apiKey even when provider is preset', async () => {
+      await expect(
+        service.createAccount({
+          name: 'No Key',
+          provider: 'orcarouter'
+        })
+      ).rejects.toThrow(/API Key are required/)
+    })
+  })
+
+  describe('updateAccount', () => {
+    it('switches an existing account to orcarouter and fills the preset URL', async () => {
+      mockHGetAll.mockResolvedValue({
+        id: 'acc-1',
+        platform: 'openai-responses',
+        name: 'Existing',
+        baseApi: 'https://old.example.com/v1',
+        apiKey: 'encrypted-key',
+        provider: 'custom',
+        isActive: 'true'
+      })
+
+      const result = await service.updateAccount('acc-1', { provider: 'orcarouter' })
+
+      expect(result.success).toBe(true)
+      const saved = mockHSet.mock.calls[0][1]
+      expect(saved.provider).toBe('orcarouter')
+      expect(saved.baseApi).toBe('https://api.orcarouter.ai/v1')
+    })
+
+    it('keeps the existing baseApi when updating to custom', async () => {
+      mockHGetAll.mockResolvedValue({
+        id: 'acc-2',
+        platform: 'openai-responses',
+        name: 'Existing',
+        baseApi: 'https://old.example.com/v1',
+        apiKey: 'encrypted-key',
+        provider: 'orcarouter',
+        isActive: 'true'
+      })
+
+      const result = await service.updateAccount('acc-2', { provider: 'custom' })
+
+      expect(result.success).toBe(true)
+      const saved = mockHSet.mock.calls[0][1]
+      expect(saved.provider).toBe('custom')
+      expect(saved.baseApi).toBe('https://old.example.com/v1')
+    })
+  })
+})

--- a/web/admin-spa/src/components/accounts/AccountForm.vue
+++ b/web/admin-spa/src/components/accounts/AccountForm.vue
@@ -1645,6 +1645,23 @@
             <div v-if="form.platform === 'openai-responses' && !isEdit" class="space-y-4">
               <div>
                 <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
+                  >Provider *</label
+                >
+                <select
+                  v-model="form.provider"
+                  class="form-input w-full border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+                  @change="onProviderChange"
+                >
+                  <option value="orcarouter">OrcaRouter</option>
+                  <option value="custom">自定义（Custom）</option>
+                </select>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  OrcaRouter 使用预设接入地址，无需填写 URL；选择自定义时手动填写 API 基础地址
+                </p>
+              </div>
+
+              <div>
+                <label class="mb-3 block text-sm font-semibold text-gray-700 dark:text-gray-300"
                   >API 基础地址 *</label
                 >
                 <input
@@ -3427,6 +3444,17 @@
           <!-- OpenAI-Responses 特定字段（编辑模式）-->
           <div v-if="form.platform === 'openai-responses'" class="space-y-4">
             <div>
+              <label class="mb-3 block text-sm font-semibold text-gray-700">Provider</label>
+              <select v-model="form.provider" class="form-input w-full" @change="onProviderChange">
+                <option value="orcarouter">OrcaRouter</option>
+                <option value="custom">自定义（Custom）</option>
+              </select>
+              <p class="mt-1 text-xs text-gray-500">
+                OrcaRouter 使用预设接入地址；选择自定义时手动填写 API 基础地址
+              </p>
+            </div>
+
+            <div>
               <label class="mb-3 block text-sm font-semibold text-gray-700">API 基础地址</label>
               <input
                 v-model="form.baseApi"
@@ -4344,6 +4372,7 @@ const form = ref({
   // OpenAI-Responses 特定字段
   baseApi: props.account?.baseApi || '',
   providerEndpoint: props.account?.providerEndpoint || 'responses',
+  provider: props.account?.provider || 'custom',
   // Gemini-API 特定字段
   baseUrl: props.account?.baseUrl || 'https://generativelanguage.googleapis.com',
   rateLimitDuration: props.account?.rateLimitDuration || 60,
@@ -4920,6 +4949,22 @@ const onAuthMethodChange = () => {
     setupTokenAuthUrl.value = ''
     setupTokenAuthCode.value = ''
     setupTokenSessionId.value = ''
+  }
+}
+
+// Preset providers (e.g. OrcaRouter) auto-fill the base URL; custom is manual
+const ORCAROUTER_BASE_API = 'https://api.orcarouter.ai/v1'
+
+const onProviderChange = () => {
+  if (form.value.platform !== 'openai-responses') return
+  if (form.value.provider === 'orcarouter') {
+    form.value.baseApi = ORCAROUTER_BASE_API
+  } else if (form.value.provider === 'custom') {
+    // Only clear when the field still holds the preset URL, so a manually
+    // entered custom baseApi is never dropped by accident.
+    if (form.value.baseApi === ORCAROUTER_BASE_API) {
+      form.value.baseApi = ''
+    }
   }
 }
 
@@ -5519,6 +5564,7 @@ const createAccount = async () => {
       data.maxConcurrentTasks = form.value.maxConcurrentTasks || 0
     } else if (form.value.platform === 'openai-responses') {
       // OpenAI-Responses 账户特定数据
+      data.provider = form.value.provider || 'custom'
       data.baseApi = form.value.baseApi
       data.apiKey = form.value.apiKey
       data.userAgent = form.value.userAgent || ''
@@ -5869,6 +5915,7 @@ const updateAccount = async () => {
 
     // OpenAI-Responses 特定更新
     if (props.account.platform === 'openai-responses') {
+      data.provider = form.value.provider || 'custom'
       data.baseApi = form.value.baseApi
       if (form.value.apiKey) {
         data.apiKey = form.value.apiKey


### PR DESCRIPTION
Add [OrcaRouter](https://www.orcarouter.ai) as a preset provider for the existing **OpenAI-Responses** account type, so this self-hosted Claude API relay service can route to OrcaRouter as a first-class named provider instead of an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a preset means this project's users can point the OpenAI-Responses relay at `orcarouter/auto` and get that whole stack, without treating OrcaRouter as a random third-party URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The account form gains a `Provider` selector (OrcaRouter / Custom) mirroring how `providerEndpoint` is already handled; choosing OrcaRouter auto-fills `https://api.orcarouter.ai/v1`, and the relay passes model names like `orcarouter/auto` through unchanged.

**Validation**
- `npx prettier --write` + `npx eslint` clean on touched files
- New unit tests in `tests/openaiResponsesProviderPresets.test.js` (7 cases) pass; full suite: 204 tests passed
- Live check: `POST https://api.orcarouter.ai/v1/chat/completions` with model `orcarouter/auto` → HTTP 200

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
