### PR TITLE
fix: 模型级限流按「被拒绝的窗口」取 reset，避免账号被误停数天

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -51,6 +51,13 @@ const config = {
     betaHeader:
       process.env.CLAUDE_BETA_HEADER ||
       'claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
+    // 模型级限流「兜底时长」上限（秒）。
+    // 上游 429 时会优先读取 status=rejected 的那个窗口（5h / 7d / 7d_oi）的 reset；
+    // 只有在上游没回传窗口信息时，才退回 anthropic-ratelimit-unified-reset。
+    // 而后者是「代表窗口」的 reset，可能指向一周之后 —— 不钳制就会把某个模型
+    // 在这个账号上误停数天。钳制后最坏是每小时多试一次（代价一个 429）。
+    maxModelRateLimitFallbackSeconds:
+      parseInt(process.env.CLAUDE_MAX_MODEL_RATE_LIMIT_FALLBACK_SECONDS) || 3600,
     overloadHandling: {
       enabled: (() => {
         const minutes = parseInt(process.env.CLAUDE_OVERLOAD_HANDLING_MINUTES) || 0

--- a/src/services/relay/claudeRelayService.js
+++ b/src/services/relay/claudeRelayService.js
@@ -9,6 +9,7 @@ const sessionHelper = require('../../utils/sessionHelper')
 const logger = require('../../utils/logger')
 const config = require('../../../config/config')
 const { getRateLimitModelFamily } = require('../../utils/modelHelper')
+const { resolveRateLimitReset } = require('../../utils/rateLimitHeaderHelper')
 const claudeCodeHeadersService = require('../claudeCodeHeadersService')
 const redis = require('../../models/redis')
 const ClaudeCodeValidator = require('../../validators/clients/claudeCodeValidator')
@@ -252,6 +253,32 @@ class ClaudeRelayService {
       return false
     }
     return message.toLowerCase().includes('extra usage')
+  }
+
+  // ⏱️ 解析一次 429 应该使用的限流 reset 时间戳。
+  //
+  // 不能直接用 anthropic-ratelimit-unified-reset：那是「代表窗口」的 reset，会漂移。
+  // 当代表窗口是 7d 时，一次 5h 窗口打满引发的 429 会被记成「该模型限流到一周之后」，
+  // 把这个账号上的该模型白白停掉数天（实测：账号周用量 0%~4%，fable 却被停到 4~5 天后，
+  // 且 fableRateLimitEndAt 与 sevenDay.resetsAt 完全相同）。
+  //
+  // 这里优先采用「明确 status=rejected 的那个窗口」自己的 reset；拿不到窗口信息时
+  // 才退回 unified-reset，并按 maxModelRateLimitFallbackSeconds 钳制。
+  _resolveRateLimitReset(headers, modelFamily, tag = '') {
+    const resolution = resolveRateLimitReset(headers, modelFamily, {
+      maxFallbackSeconds: parseInt(config.claude?.maxModelRateLimitFallbackSeconds, 10) || undefined
+    })
+
+    if (resolution.resetTimestamp) {
+      const prefix = tag ? `${tag} ` : ''
+      logger.info(
+        `⏱️ ${prefix}Rate limit reset resolved to ${new Date(resolution.resetTimestamp * 1000).toISOString()} ` +
+          `(window: ${resolution.windowKey || 'unified-reset fallback'}, scope: ${resolution.scope}, ` +
+          `authoritative: ${resolution.authoritative}${resolution.clamped ? ', clamped' : ''})`
+      )
+    }
+
+    return resolution
   }
 
   _toPascalCaseToolName(name) {
@@ -841,10 +868,12 @@ class ClaudeRelayService {
               `💰 [Non-Stream] "Extra usage required" 429 for account ${accountId}, skipping rate limit marking`
             )
           } else {
-            const resetHeader = response.headers
-              ? response.headers['anthropic-ratelimit-unified-reset']
-              : null
-            const parsedResetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN
+            const rateLimitReset = this._resolveRateLimitReset(
+              response.headers,
+              requestModelFamily,
+              '[Non-Stream]'
+            )
+            const parsedResetTimestamp = rateLimitReset.resetTimestamp ?? NaN
 
             if (requestModelFamily && !Number.isNaN(parsedResetTimestamp)) {
               // 模型级限额：只停用该模型家族，不改写为账号级限流
@@ -2245,10 +2274,12 @@ class ClaudeRelayService {
             }
 
             // 真正的限流处理
-            const resetHeader = res.headers
-              ? res.headers['anthropic-ratelimit-unified-reset']
-              : null
-            const parsedResetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN
+            const rateLimitReset = this._resolveRateLimitReset(
+              res.headers,
+              requestModelFamily,
+              '[Stream]'
+            )
+            const parsedResetTimestamp = rateLimitReset.resetTimestamp ?? NaN
 
             if (requestModelFamily) {
               if (!Number.isNaN(parsedResetTimestamp)) {
@@ -2947,10 +2978,12 @@ class ClaudeRelayService {
 
           // 处理限流状态
           if (rateLimitDetected || res.statusCode === 429) {
-            const resetHeader = res.headers
-              ? res.headers['anthropic-ratelimit-unified-reset']
-              : null
-            const parsedResetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN
+            const rateLimitReset = this._resolveRateLimitReset(
+              res.headers,
+              requestModelFamily,
+              '[Stream End]'
+            )
+            const parsedResetTimestamp = rateLimitReset.resetTimestamp ?? NaN
 
             if (requestModelFamily && !Number.isNaN(parsedResetTimestamp)) {
               // 模型级限额：只停用该模型家族，不改写为账号级限流

--- a/src/utils/rateLimitHeaderHelper.js
+++ b/src/utils/rateLimitHeaderHelper.js
@@ -1,0 +1,209 @@
+/**
+ * 🧮 Anthropic 统一限流响应头解析
+ *
+ * 上游会在每个响应里回传多个「限流窗口」的独立状态：
+ *
+ *   anthropic-ratelimit-unified-5h-{status,reset,utilization}      账号级 5 小时窗口
+ *   anthropic-ratelimit-unified-7d-{status,reset,utilization}      账号级 7 天窗口
+ *   anthropic-ratelimit-unified-7d_oi-{status,reset,utilization}   Opus 专属 7 天窗口
+ *   anthropic-ratelimit-unified-representative-claim               当前「代表窗口」(five_hour / seven_day)
+ *   anthropic-ratelimit-unified-status                             代表窗口的状态
+ *   anthropic-ratelimit-unified-reset                              代表窗口的 reset —— 会漂移！
+ *
+ * ⚠️ 关键点：`anthropic-ratelimit-unified-reset` 不是某个模型家族的 reset，
+ * 它只是 representative-claim 当前指向的那个窗口的 reset。当代表窗口是 7d 时，
+ * 一次「5h 窗口被打满」引发的 429 会被记成「该模型家族限流到一周之后」，
+ * 于是这个账号的该模型被白白停掉好几天 —— 即使账号周用量只有个位数百分比。
+ *
+ * 因此判断限流时长必须先看「哪个窗口 status === rejected」，用那个窗口自己的 reset；
+ * 只有在上游没给出可用的窗口信息时，才退回 unified-reset，并由调用方钳制上限。
+ */
+
+const logger = require('./logger')
+
+// 上游会回传的窗口后缀。7d_oi = seven day opus intensive（Opus 专属周窗口）
+const RATE_LIMIT_WINDOW_KEYS = ['5h', '7d', '7d_oi']
+
+// 窗口 → 模型家族。只有 Opus 专属周窗口是真正「按模型」的，
+// 5h / 7d 是整个账号共享的窗口，不隶属于任何单一模型家族。
+const WINDOW_MODEL_FAMILY = {
+  '7d_oi': 'opus'
+}
+
+// 被拒绝的窗口状态。上游取值：allowed / allowed_warning / rejected
+const REJECTED_STATUS = 'rejected'
+
+// 兜底时长上限（秒）。仅在无法识别「哪个窗口被拒绝」时生效。
+const DEFAULT_MAX_FALLBACK_SECONDS = 3600
+
+/**
+ * 大小写不敏感地读取响应头。Node 的 http 会把头名转成小写，
+ * 但经过代理/改写后不一定，这里统一兜一层。
+ */
+function getHeader(headers, name) {
+  if (!headers || typeof headers !== 'object') {
+    return undefined
+  }
+  if (headers[name] !== undefined) {
+    return headers[name]
+  }
+  const lower = name.toLowerCase()
+  if (headers[lower] !== undefined) {
+    return headers[lower]
+  }
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) {
+      return headers[key]
+    }
+  }
+  return undefined
+}
+
+function parseTimestamp(value) {
+  if (value === undefined || value === null || value === '') {
+    return null
+  }
+  const raw = String(value).trim()
+
+  // 绝大多数情况下是 Unix 秒。必须先确认整串都是数字：
+  // parseInt('2026-09-05T06:10:00Z') 会返回 2026，把 ISO 时间误读成一个 1970 年的时间戳。
+  if (/^\d+$/.test(raw)) {
+    const seconds = parseInt(raw, 10)
+    return seconds > 0 ? seconds : null
+  }
+
+  // 兼容 ISO 时间格式
+  const date = new Date(raw)
+  if (!Number.isNaN(date.getTime())) {
+    return Math.floor(date.getTime() / 1000)
+  }
+  return null
+}
+
+function parseUtilization(value) {
+  if (value === undefined || value === null || value === '') {
+    return null
+  }
+  const parsed = parseFloat(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+/**
+ * 解析所有限流窗口。
+ * @param {object} headers - 上游响应头
+ * @returns {Array<{key:string, status:string|null, reset:number|null, utilization:number|null, family:string|null, isAccountWide:boolean}>}
+ */
+function parseRateLimitWindows(headers) {
+  return RATE_LIMIT_WINDOW_KEYS.map((key) => {
+    const status = getHeader(headers, `anthropic-ratelimit-unified-${key}-status`)
+    const family = WINDOW_MODEL_FAMILY[key] || null
+    return {
+      key,
+      status: status ? String(status).toLowerCase() : null,
+      reset: parseTimestamp(getHeader(headers, `anthropic-ratelimit-unified-${key}-reset`)),
+      utilization: parseUtilization(
+        getHeader(headers, `anthropic-ratelimit-unified-${key}-utilization`)
+      ),
+      family,
+      isAccountWide: family === null
+    }
+  }).filter((w) => w.status !== null || w.reset !== null)
+}
+
+/**
+ * 解析一次 429 应该使用的 reset 时间戳。
+ *
+ * 优先级：
+ *   1. 与请求模型家族匹配、且 status=rejected 的模型级窗口（如 Opus 的 7d_oi）
+ *   2. status=rejected 的账号级窗口（5h / 7d），取最晚的那个 —— 只有它们全部
+ *      恢复后账号才真正可用
+ *   3. 兜底：代表窗口的 unified-reset，并按 maxFallbackSeconds 钳制
+ *
+ * @param {object} headers - 上游响应头
+ * @param {string|null} modelFamily - 请求模型所属家族（opus/sonnet/haiku/fable）
+ * @param {object} [options]
+ * @param {number} [options.maxFallbackSeconds] - 兜底路径的最大时长（秒）
+ * @param {number} [options.now] - 当前时间戳（毫秒），便于测试
+ * @returns {{resetTimestamp:number|null, windowKey:string|null, scope:'model'|'account'|null, authoritative:boolean, clamped:boolean}}
+ */
+function resolveRateLimitReset(headers, modelFamily = null, options = {}) {
+  const maxFallbackSeconds = Number.isFinite(options.maxFallbackSeconds)
+    ? options.maxFallbackSeconds
+    : DEFAULT_MAX_FALLBACK_SECONDS
+  const now = options.now || Date.now()
+
+  const windows = parseRateLimitWindows(headers)
+  const rejected = windows.filter((w) => w.status === REJECTED_STATUS && w.reset !== null)
+
+  // 1) 模型级窗口被拒绝，且正是本次请求的模型家族 —— 这是最精确的信息
+  if (modelFamily) {
+    const modelWindow = rejected.find((w) => w.family === modelFamily)
+    if (modelWindow) {
+      return {
+        resetTimestamp: modelWindow.reset,
+        windowKey: modelWindow.key,
+        scope: 'model',
+        authoritative: true,
+        clamped: false
+      }
+    }
+  }
+
+  // 2) 账号级窗口被拒绝 —— 取最晚的 reset，因为要全部恢复账号才可用
+  const accountWindows = rejected.filter((w) => w.isAccountWide)
+  if (accountWindows.length > 0) {
+    const latest = accountWindows.reduce((a, b) => (b.reset > a.reset ? b : a))
+    return {
+      resetTimestamp: latest.reset,
+      windowKey: latest.key,
+      scope: 'account',
+      authoritative: true,
+      clamped: false
+    }
+  }
+
+  // 3) 兜底：只能用代表窗口的 reset，但它可能指向一周之后，必须钳制。
+  //    最坏情况是每 maxFallbackSeconds 多试一次（代价是一个 429），
+  //    远好于把某个模型在这个账号上误停数天。
+  const fallback = parseTimestamp(getHeader(headers, 'anthropic-ratelimit-unified-reset'))
+  if (fallback === null) {
+    return {
+      resetTimestamp: null,
+      windowKey: null,
+      scope: null,
+      authoritative: false,
+      clamped: false
+    }
+  }
+
+  const capTimestamp = Math.floor(now / 1000) + maxFallbackSeconds
+  if (fallback > capTimestamp) {
+    logger.warn(
+      `⏱️ Unified reset ${new Date(fallback * 1000).toISOString()} exceeds the ${maxFallbackSeconds}s fallback cap ` +
+        `(no rejected window reported); clamping to ${new Date(capTimestamp * 1000).toISOString()}`
+    )
+    return {
+      resetTimestamp: capTimestamp,
+      windowKey: null,
+      scope: modelFamily ? 'model' : 'account',
+      authoritative: false,
+      clamped: true
+    }
+  }
+
+  return {
+    resetTimestamp: fallback,
+    windowKey: null,
+    scope: modelFamily ? 'model' : 'account',
+    authoritative: false,
+    clamped: false
+  }
+}
+
+module.exports = {
+  RATE_LIMIT_WINDOW_KEYS,
+  WINDOW_MODEL_FAMILY,
+  DEFAULT_MAX_FALLBACK_SECONDS,
+  parseRateLimitWindows,
+  resolveRateLimitReset
+}

--- a/tests/rateLimitResetWindow.test.js
+++ b/tests/rateLimitResetWindow.test.js
@@ -1,0 +1,199 @@
+// Regression test: a model-family rate-limit block must be anchored to the window that
+// was actually rejected — never to `anthropic-ratelimit-unified-reset`.
+//
+// Observed in production: four Claude OAuth accounts were each blocked for `claude-fable-5-1`
+// for 4-5 days while their 7-day utilization sat at 0-4%. In every case the stored
+// `fableRateLimitEndAt` was byte-identical to that account's `sevenDay.resetsAt`, because
+// `anthropic-ratelimit-unified-reset` mirrors whichever window `representative-claim` points
+// at (it floats). A temporary 5-hour exhaustion was therefore recorded as a week-long
+// per-model block, the fable pool drained one account at a time, and every fable request
+// eventually failed with "No available Claude accounts support the requested model".
+
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}))
+
+const {
+  parseRateLimitWindows,
+  resolveRateLimitReset,
+  DEFAULT_MAX_FALLBACK_SECONDS
+} = require('../src/utils/rateLimitHeaderHelper')
+
+const ts = (iso) => Math.floor(Date.parse(iso) / 1000)
+
+// The exact shape observed on the wire (2026-09-05, 200 response).
+const NOW = Date.parse('2026-09-05T04:25:00Z')
+const FIVE_HOUR_RESET = ts('2026-09-05T06:10:00Z')
+const SEVEN_DAY_RESET = ts('2026-09-09T04:00:00Z')
+
+const headers = (overrides = {}) => ({
+  'anthropic-ratelimit-unified-status': 'rejected',
+  'anthropic-ratelimit-unified-5h-status': 'allowed',
+  'anthropic-ratelimit-unified-5h-reset': String(FIVE_HOUR_RESET),
+  'anthropic-ratelimit-unified-5h-utilization': '0.11',
+  'anthropic-ratelimit-unified-7d-status': 'allowed',
+  'anthropic-ratelimit-unified-7d-reset': String(SEVEN_DAY_RESET),
+  'anthropic-ratelimit-unified-7d-utilization': '0.04',
+  'anthropic-ratelimit-unified-7d_oi-status': 'allowed',
+  'anthropic-ratelimit-unified-7d_oi-reset': String(SEVEN_DAY_RESET),
+  'anthropic-ratelimit-unified-7d_oi-utilization': '0.0',
+  'anthropic-ratelimit-unified-representative-claim': 'seven_day',
+  // The floating one. Points at the 7d window here.
+  'anthropic-ratelimit-unified-reset': String(SEVEN_DAY_RESET),
+  ...overrides
+})
+
+describe('resolveRateLimitReset', () => {
+  it('anchors to the rejected 5h window, not the 7d unified-reset (the production bug)', () => {
+    const result = resolveRateLimitReset(
+      headers({ 'anthropic-ratelimit-unified-5h-status': 'rejected' }),
+      'fable',
+      { now: NOW }
+    )
+
+    expect(result.resetTimestamp).toBe(FIVE_HOUR_RESET)
+    expect(result.resetTimestamp).not.toBe(SEVEN_DAY_RESET)
+    expect(result.windowKey).toBe('5h')
+    expect(result.scope).toBe('account')
+    expect(result.authoritative).toBe(true)
+  })
+
+  it('prefers the model-scoped window when it is the one rejected', () => {
+    const result = resolveRateLimitReset(
+      headers({
+        'anthropic-ratelimit-unified-7d_oi-status': 'rejected',
+        'anthropic-ratelimit-unified-5h-status': 'rejected'
+      }),
+      'opus',
+      { now: NOW }
+    )
+
+    expect(result.resetTimestamp).toBe(SEVEN_DAY_RESET)
+    expect(result.windowKey).toBe('7d_oi')
+    expect(result.scope).toBe('model')
+    expect(result.authoritative).toBe(true)
+  })
+
+  it('does not hand the opus-only window to a different family', () => {
+    const result = resolveRateLimitReset(
+      headers({
+        'anthropic-ratelimit-unified-7d_oi-status': 'rejected',
+        'anthropic-ratelimit-unified-5h-status': 'rejected'
+      }),
+      'fable',
+      { now: NOW }
+    )
+
+    // fable has no dedicated window upstream, so it falls to the account-wide one
+    expect(result.windowKey).toBe('5h')
+    expect(result.scope).toBe('account')
+  })
+
+  it('takes the latest reset when several account windows are rejected', () => {
+    const result = resolveRateLimitReset(
+      headers({
+        'anthropic-ratelimit-unified-5h-status': 'rejected',
+        'anthropic-ratelimit-unified-7d-status': 'rejected'
+      }),
+      'sonnet',
+      { now: NOW }
+    )
+
+    expect(result.resetTimestamp).toBe(SEVEN_DAY_RESET)
+    expect(result.windowKey).toBe('7d')
+  })
+
+  it('clamps the unified-reset fallback when no window reports a rejection', () => {
+    const result = resolveRateLimitReset(headers(), 'fable', { now: NOW })
+
+    expect(result.authoritative).toBe(false)
+    expect(result.clamped).toBe(true)
+    expect(result.resetTimestamp).toBe(Math.floor(NOW / 1000) + DEFAULT_MAX_FALLBACK_SECONDS)
+    // 4 days out would have been stored verbatim before this fix
+    expect(result.resetTimestamp).toBeLessThan(SEVEN_DAY_RESET)
+  })
+
+  it('honours a custom fallback cap', () => {
+    const result = resolveRateLimitReset(headers(), 'fable', {
+      now: NOW,
+      maxFallbackSeconds: 900
+    })
+
+    expect(result.resetTimestamp).toBe(Math.floor(NOW / 1000) + 900)
+    expect(result.clamped).toBe(true)
+  })
+
+  it('leaves a near-term fallback reset untouched', () => {
+    const soon = Math.floor(NOW / 1000) + 120
+    const result = resolveRateLimitReset(
+      {
+        'anthropic-ratelimit-unified-reset': String(soon)
+      },
+      'fable',
+      { now: NOW }
+    )
+
+    expect(result.resetTimestamp).toBe(soon)
+    expect(result.clamped).toBe(false)
+  })
+
+  it('reads headers case-insensitively', () => {
+    const result = resolveRateLimitReset(
+      {
+        'Anthropic-RateLimit-Unified-5h-Status': 'rejected',
+        'Anthropic-RateLimit-Unified-5h-Reset': String(FIVE_HOUR_RESET)
+      },
+      'fable',
+      { now: NOW }
+    )
+
+    expect(result.resetTimestamp).toBe(FIVE_HOUR_RESET)
+    expect(result.windowKey).toBe('5h')
+  })
+
+  it('accepts ISO timestamps as well as unix seconds', () => {
+    const result = resolveRateLimitReset(
+      {
+        'anthropic-ratelimit-unified-5h-status': 'rejected',
+        'anthropic-ratelimit-unified-5h-reset': '2026-09-05T06:10:00Z'
+      },
+      'fable',
+      { now: NOW }
+    )
+
+    expect(result.resetTimestamp).toBe(FIVE_HOUR_RESET)
+  })
+
+  it('returns null when there is nothing usable to go on', () => {
+    expect(resolveRateLimitReset({}, 'fable', { now: NOW }).resetTimestamp).toBeNull()
+    expect(resolveRateLimitReset(null, 'fable', { now: NOW }).resetTimestamp).toBeNull()
+    expect(resolveRateLimitReset(undefined, null, { now: NOW }).resetTimestamp).toBeNull()
+  })
+})
+
+describe('parseRateLimitWindows', () => {
+  it('parses every window the upstream reports', () => {
+    const windows = parseRateLimitWindows(headers())
+    expect(windows.map((w) => w.key)).toEqual(['5h', '7d', '7d_oi'])
+
+    const fiveHour = windows.find((w) => w.key === '5h')
+    expect(fiveHour).toMatchObject({
+      status: 'allowed',
+      reset: FIVE_HOUR_RESET,
+      utilization: 0.11,
+      family: null,
+      isAccountWide: true
+    })
+
+    const opusWindow = windows.find((w) => w.key === '7d_oi')
+    expect(opusWindow).toMatchObject({ family: 'opus', isAccountWide: false })
+  })
+
+  it('skips windows the upstream did not report', () => {
+    expect(parseRateLimitWindows({})).toEqual([])
+    expect(parseRateLimitWindows(null)).toEqual([])
+  })
+})


### PR DESCRIPTION
## 问题

`anthropic-ratelimit-unified-reset` 并不是某个模型家族的 reset —— 它是 `anthropic-ratelimit-unified-representative-claim` 当前指向的那个「代表窗口」的 reset，会随代表窗口漂移。

上游其实是按窗口分别回传的（线上抓的 200 响应，摘录）：

```
anthropic-ratelimit-unified-status: allowed
anthropic-ratelimit-unified-5h-status: allowed
anthropic-ratelimit-unified-5h-reset: 1788586800          # 2026-09-05T05:40:00Z
anthropic-ratelimit-unified-5h-utilization: 0.11
anthropic-ratelimit-unified-7d-status: allowed
anthropic-ratelimit-unified-7d-reset: 1788937200          # 2026-09-09T07:00:00Z
anthropic-ratelimit-unified-7d-utilization: 0.02
anthropic-ratelimit-unified-7d_oi-status: allowed
anthropic-ratelimit-unified-7d_oi-reset: 1788937200
anthropic-ratelimit-unified-7d_oi-utilization: 0.0
anthropic-ratelimit-unified-representative-claim: five_hour
anthropic-ratelimit-unified-reset: 1788586800             # ← 跟随 representative-claim 漂移
```

而 `claudeRelayService` 的三处 429 分支都直接把 `unified-reset` 写进了模型级限流桶：

```js
const resetHeader = res.headers['anthropic-ratelimit-unified-reset']
const parsedResetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN

if (requestModelFamily && !Number.isNaN(parsedResetTimestamp)) {
  await claudeAccountService.markAccountModelRateLimited(
    accountId,
    requestModelFamily,
    parsedResetTimestamp
  )
}
```

当代表窗口是 `seven_day` 时，一次「5h 窗口被打满」引发的 429，就会被记成「这个模型限流到一周之后」。

## 线上现象

4 个 `claude_max_20x` 账号（下称 A/B/C/D）的 `claude-fable-5-1` 全部被停到 4~5 天之后，但账号本身几乎没有用量：

| 账号 | 5h 用量 | 7d 用量 | `fableRateLimitEndAt` | `claudeUsage.sevenDay.resetsAt` |
|---|---|---|---|---|
| A | 2% | 4% | 2026-09-09T04:00 | **2026-09-09T04:00** |
| B | 11% | 3% | 2026-09-09T07:00 | **2026-09-09T07:00** |
| C | 1% | 0% | 2026-09-08T07:00 | **2026-09-08T07:00** |
| D | 100% | 26% | 2026-09-05T06:10 | （= 其 `fiveHour.resetsAt`） |

`fableRateLimitEndAt` 与 `sevenDay.resetsAt` 逐秒一致 —— 写进模型桶的正是 7d 窗口的 reset。

账号被逐个排空之后（每次 429 停掉一个），日志是这样的：

```
🚫 Skipping account A (...) due to active fable limit
🚫 Skipping account B (...) due to active fable limit
🚫 Skipping account C (...) due to active fable limit
🚫 Skipping account D (...) due to active fable limit
❌ Failed to select account for API key: No available Claude accounts support the requested model: claude-fable-5-1
```

顺带一提：最后这句报错来自 `unifiedClaudeScheduler.js` 里「账号池为空」的兜底分支，跟模型支持其实没有关系（`_isModelSupportedByAccount` 对 `claude-` 开头的模型一律放行），排查时很容易被带偏方向。

**验证**：把 7d 用量 0%、当时被停到 09-08 的账号 C 的 fable 限流状态清掉，立刻请求 `claude-fable-5-1`，直接 200 返回 —— 说明那个限额早就不存在了，只是我们把一个过期的结果一直留着并持续执行。

## 改动

1. 新增 `src/utils/rateLimitHeaderHelper.js`：
   - `parseRateLimitWindows(headers)`：解析 `5h` / `7d` / `7d_oi` 三组 `status` / `reset` / `utilization`
   - `resolveRateLimitReset(headers, modelFamily, options)`：按优先级定位 reset
     1. 与请求模型家族匹配、且 `status=rejected` 的**模型级**窗口（目前只有 Opus 的 `7d_oi`）
     2. `status=rejected` 的**账号级**窗口（`5h` / `7d`）；多个同时被拒时取最晚的 reset，因为要全部恢复账号才真正可用
     3. 以上都拿不到时，才退回 `unified-reset`，并钳制
   - 顺手修掉一个坑：`parseInt('2026-09-05T06:10:00Z')` 会返回 `2026`，所以走 Unix 秒分支前先确认整串都是数字，避免 ISO 格式被误读成 1970 年的时间戳
2. 新增配置 `claude.maxModelRateLimitFallbackSeconds`（环境变量 `CLAUDE_MAX_MODEL_RATE_LIMIT_FALLBACK_SECONDS`，默认 3600 秒），**只作用于兜底路径**：拿不到窗口信息时最坏每小时多试一次（代价是一个 429），而不是把某个模型在这个账号上白停数天。
   思路和 #1232 里 `upstreamError.maxCustomTtlSeconds` 把 retry-after 钳到 1800s 是一致的 —— 那次的注释写的是「长时限额应由账号级/模型级限流桶承担」，而这次的问题恰恰是这个桶自己把时间取错了。
3. `claudeRelayService` 三处 429 分支（非流式 / 流式 / 流式结束）统一走 `_resolveRateLimitReset()`，并打日志说明用了哪个窗口、是否权威值、有没有被钳制，方便下次排查。
4. 回归测试 `tests/rateLimitResetWindow.test.js`（12 例），用线上实际抓到的响应头覆盖各个分支。

## 兼容性

- 没有改动限流桶的字段名，也没有改动「模型级 429 不改写成账号级限流」这个既有语义（#1228 / #1232 的行为保持不变），只修正写进桶里的**时间**。
- 上游若不回传按窗口的头，行为退化为原来的 `unified-reset`，只是多了一层上限钳制。
- 已经写坏的存量 `{family}RateLimitEndAt` 本 PR 不会自动清理，需要的话手动调用 `claudeAccountService.clearAccountModelRateLimit(accountId, family)`。

## 测试

```
npm test           → 26 suites / 288 passed, 8 skipped
npm run lint:check → 无告警
prettier --check   → 通过
```

## 后续可讨论（本 PR 未改）

`5h` / `7d` 被拒其实是**账号级**的：此时账号上所有模型都不可用，但当前逻辑只要请求带模型家族就只停这一个家族，于是同一账号上的其它模型还要各自再吃一个 429 才会被停（线上能看到上表账号 D 的 opus / sonnet / fable 先后被标记到同一个 `06:10`）。要不要在「窗口明确是账号级」时直接走账号级限流，牵涉到 #1228 的初衷，想先听听维护者意见，就没有放进这个 PR。
