### PR TITLE
fix(web): 展示全部模型家族限流徽章，并补齐上游按模型限定的 Fable 周额度

### DIFF
--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -2146,6 +2146,33 @@ class ClaudeAccountService {
     }
   }
 
+  // 🧮 从上游 limits[] 中提取「按模型限定的周窗口」
+  // 形如：{ kind: 'weekly_scoped', percent, resets_at, scope: { model: { display_name } } }
+  _extractWeeklyScopedModels(limits) {
+    if (!Array.isArray(limits)) {
+      return []
+    }
+
+    const result = []
+    for (const limit of limits) {
+      if (!limit || limit.kind !== 'weekly_scoped') {
+        continue
+      }
+      const modelName = limit.scope?.model?.display_name
+      if (!modelName) {
+        continue
+      }
+      result.push({
+        modelName: String(modelName),
+        utilization: this._toNumberOrNull(limit.percent),
+        resetsAt: limit.resets_at || null,
+        severity: limit.severity || null,
+        isActive: limit.is_active === true
+      })
+    }
+    return result
+  }
+
   // 📊 构建 Claude Usage 快照（从 Redis 数据）
   buildClaudeUsageSnapshot(accountData) {
     const updatedAt = accountData.claudeUsageUpdatedAt
@@ -2157,15 +2184,36 @@ class ClaudeAccountService {
     const sevenDayOpusUtilization = this._toNumberOrNull(accountData.claudeSevenDayOpusUtilization)
     const sevenDayOpusResetsAt = accountData.claudeSevenDayOpusResetsAt
 
+    let scopedModels = []
+    if (accountData.claudeWeeklyScopedModels) {
+      try {
+        const parsed = JSON.parse(accountData.claudeWeeklyScopedModels)
+        if (Array.isArray(parsed)) {
+          scopedModels = parsed
+        }
+      } catch {
+        // 脏数据不应该让整个用量快照失败
+        scopedModels = []
+      }
+    }
+
     const hasFiveHourData = fiveHourUtilization !== null || fiveHourResetsAt
     const hasSevenDayData = sevenDayUtilization !== null || sevenDayResetsAt
     const hasSevenDayOpusData = sevenDayOpusUtilization !== null || sevenDayOpusResetsAt
 
-    if (!updatedAt && !hasFiveHourData && !hasSevenDayData && !hasSevenDayOpusData) {
+    if (
+      !updatedAt &&
+      !hasFiveHourData &&
+      !hasSevenDayData &&
+      !hasSevenDayOpusData &&
+      scopedModels.length === 0
+    ) {
       return null
     }
 
     const now = Date.now()
+    const remainingFrom = (resetsAt) =>
+      resetsAt ? Math.max(0, Math.floor((new Date(resetsAt).getTime() - now) / 1000)) : null
 
     return {
       updatedAt,
@@ -2189,7 +2237,16 @@ class ClaudeAccountService {
         remainingSeconds: sevenDayOpusResetsAt
           ? Math.max(0, Math.floor((new Date(sevenDayOpusResetsAt).getTime() - now) / 1000))
           : null
-      }
+      },
+      // 上游按模型限定的周窗口（如 Fable），由 limits[] 解析而来
+      sevenDayScopedModels: scopedModels.map((item) => ({
+        modelName: item.modelName,
+        utilization: this._toNumberOrNull(item.utilization),
+        resetsAt: item.resetsAt || null,
+        severity: item.severity || null,
+        isActive: item.isActive === true,
+        remainingSeconds: remainingFrom(item.resetsAt)
+      }))
     }
   }
 
@@ -2229,6 +2286,17 @@ class ClaudeAccountService {
       if (usageData.seven_day_sonnet.resets_at) {
         updates.claudeSevenDayOpusResetsAt = usageData.seven_day_sonnet.resets_at
       }
+    }
+
+    // 按模型限定的周窗口。
+    // 上游把这类额度放在 limits[] 里，而不是顶层的具名窗口：
+    //   { kind: "weekly_scoped", percent: 9, resets_at: "...",
+    //     scope: { model: { display_name: "Fable" } }, is_active: true }
+    // 顶层的 seven_day_opus / seven_day_sonnet 对这些账号一直是 null，
+    // 真正有数据的是这里，所以模型级用量必须从 limits[] 取。
+    const scopedModels = this._extractWeeklyScopedModels(usageData.limits)
+    if (scopedModels.length > 0) {
+      updates.claudeWeeklyScopedModels = JSON.stringify(scopedModels)
     }
 
     if (Object.keys(updates).length === 0) {

--- a/tests/claudeWeeklyScopedModels.test.js
+++ b/tests/claudeWeeklyScopedModels.test.js
@@ -1,0 +1,156 @@
+// The upstream /api/oauth/usage response carries per-model weekly caps in `limits[]`,
+// NOT in a named top-level window. Observed on live Max accounts: `seven_day_opus` and
+// `seven_day_sonnet` were both null while limits[] held a real Fable entry at 9% / 49%.
+// Parsing only the named windows therefore showed an empty bar for accounts that were
+// actually approaching (or already past) their Fable cap.
+
+jest.mock('../src/models/redis', () => ({
+  getClaudeAccount: jest.fn(async () => ({})),
+  setClaudeAccount: jest.fn(async () => {}),
+  client: { hdel: jest.fn(async () => 1) }
+}))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn()
+}))
+jest.mock('../src/services/tokenRefreshService', () => ({}))
+jest.mock('../src/utils/tokenRefreshLogger', () => ({}))
+jest.mock('../src/utils/webhookNotifier', () => ({ sendAccountAnomalyNotification: jest.fn() }))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({
+  recordErrorHistory: jest.fn(() => ({ catch: jest.fn() })),
+  markTempUnavailable: jest.fn(() => ({ catch: jest.fn() })),
+  parseRetryAfter: jest.fn(() => null)
+}))
+jest.mock('../src/utils/proxyHelper', () => ({}))
+jest.mock('axios', () => ({}))
+
+// The service constructor starts a cache-cleanup setInterval at load; unref it so the
+// timer never keeps Jest alive.
+const _realSetInterval = global.setInterval
+global.setInterval = (fn, ms, ...args) => {
+  const timer = _realSetInterval(fn, ms, ...args)
+  if (timer && typeof timer.unref === 'function') {
+    timer.unref()
+  }
+  return timer
+}
+const claudeAccountService = require('../src/services/account/claudeAccountService')
+global.setInterval = _realSetInterval
+
+// Verbatim shape from the live upstream response.
+const LIMITS = [
+  {
+    kind: 'session',
+    group: 'session',
+    percent: 0,
+    severity: 'normal',
+    resets_at: '2026-09-05T10:40:00.509692+00:00',
+    scope: null,
+    is_active: false
+  },
+  {
+    kind: 'weekly_all',
+    group: 'weekly',
+    percent: 8,
+    severity: 'normal',
+    resets_at: '2026-09-09T07:00:00.509715+00:00',
+    scope: null,
+    is_active: false
+  },
+  {
+    kind: 'weekly_scoped',
+    group: 'weekly',
+    percent: 9,
+    severity: 'normal',
+    resets_at: '2026-09-09T07:00:00.509898+00:00',
+    scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+    is_active: true
+  }
+]
+
+describe('_extractWeeklyScopedModels', () => {
+  it('pulls the per-model weekly cap out of limits[]', () => {
+    const scoped = claudeAccountService._extractWeeklyScopedModels(LIMITS)
+
+    expect(scoped).toEqual([
+      {
+        modelName: 'Fable',
+        utilization: 9,
+        resetsAt: '2026-09-09T07:00:00.509898+00:00',
+        severity: 'normal',
+        isActive: true
+      }
+    ])
+  })
+
+  it('ignores account-wide entries and anything without a model name', () => {
+    expect(
+      claudeAccountService._extractWeeklyScopedModels([
+        { kind: 'weekly_all', percent: 8, scope: null },
+        { kind: 'weekly_scoped', percent: 5, scope: {} },
+        { kind: 'weekly_scoped', percent: 5, scope: { model: {} } },
+        null
+      ])
+    ).toEqual([])
+  })
+
+  it('tolerates a missing or malformed limits array', () => {
+    expect(claudeAccountService._extractWeeklyScopedModels(undefined)).toEqual([])
+    expect(claudeAccountService._extractWeeklyScopedModels(null)).toEqual([])
+    expect(claudeAccountService._extractWeeklyScopedModels({})).toEqual([])
+  })
+
+  it('keeps every scoped model when the upstream reports more than one', () => {
+    const scoped = claudeAccountService._extractWeeklyScopedModels([
+      ...LIMITS,
+      {
+        kind: 'weekly_scoped',
+        percent: 40,
+        severity: 'warning',
+        resets_at: '2026-09-10T00:00:00Z',
+        scope: { model: { display_name: 'Opus' } },
+        is_active: false
+      }
+    ])
+
+    expect(scoped.map((s) => s.modelName)).toEqual(['Fable', 'Opus'])
+    expect(scoped[1]).toMatchObject({ utilization: 40, severity: 'warning', isActive: false })
+  })
+})
+
+describe('buildClaudeUsageSnapshot', () => {
+  it('exposes scoped models with a computed remainingSeconds', () => {
+    const resetsAt = new Date(Date.now() + 3600 * 1000).toISOString()
+    const snapshot = claudeAccountService.buildClaudeUsageSnapshot({
+      claudeUsageUpdatedAt: '2026-09-05T05:00:00.000Z',
+      claudeWeeklyScopedModels: JSON.stringify([
+        { modelName: 'Fable', utilization: 9, resetsAt, severity: 'normal', isActive: true }
+      ])
+    })
+
+    expect(snapshot.sevenDayScopedModels).toHaveLength(1)
+    expect(snapshot.sevenDayScopedModels[0]).toMatchObject({
+      modelName: 'Fable',
+      utilization: 9,
+      isActive: true
+    })
+    expect(snapshot.sevenDayScopedModels[0].remainingSeconds).toBeGreaterThan(3500)
+    expect(snapshot.sevenDayScopedModels[0].remainingSeconds).toBeLessThanOrEqual(3600)
+  })
+
+  it('does not throw on malformed stored JSON', () => {
+    const snapshot = claudeAccountService.buildClaudeUsageSnapshot({
+      claudeUsageUpdatedAt: '2026-09-05T05:00:00.000Z',
+      claudeWeeklyScopedModels: '{not json'
+    })
+
+    expect(snapshot.sevenDayScopedModels).toEqual([])
+  })
+
+  it('still returns null when the account has no usage data at all', () => {
+    expect(claudeAccountService.buildClaudeUsageSnapshot({})).toBeNull()
+  })
+})

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -407,7 +407,8 @@
                               <div class="flex items-start gap-2">
                                 <i class="fas fa-gem mt-[2px] text-[10px] text-purple-500"></i>
                                 <span class="font-medium text-white dark:text-gray-900"
-                                  >Sonnet窗口：7天Sonnet模型专用限额。</span
+                                  >模型窗口：上游按模型限定的 7 天专用限额（如
+                                  Fable），标签取自上游返回的模型名，没有则不显示。</span
                                 >
                               </div>
                               <div class="flex items-start gap-2">
@@ -951,13 +952,17 @@
                           重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDay) }}
                         </div>
                       </div>
-                      <!-- 7天Opus窗口 -->
-                      <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                      <!-- 按模型限定的周窗口（上游 limits[] 中的 weekly_scoped，如 Fable） -->
+                      <div
+                        v-for="scoped in getScopedModelUsage(account)"
+                        :key="scoped.modelName"
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-purple-100 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:bg-purple-500/20 dark:text-purple-300"
                           >
-                            sonnet
+                            {{ scoped.modelName }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -965,23 +970,21 @@
                                 <div
                                   :class="[
                                     'h-2 rounded-full transition-all duration-300',
-                                    getClaudeUsageBarClass(account.claudeUsage.sevenDayOpus)
+                                    getClaudeUsageBarClass(scoped)
                                   ]"
-                                  :style="{
-                                    width: getClaudeUsageWidth(account.claudeUsage.sevenDayOpus)
-                                  }"
+                                  :style="{ width: getClaudeUsageWidth(scoped) }"
                                 />
                               </div>
                               <span
                                 class="w-12 text-right text-xs font-semibold text-gray-800 dark:text-gray-100"
                               >
-                                {{ formatClaudeUsagePercent(account.claudeUsage.sevenDayOpus) }}
+                                {{ formatClaudeUsagePercent(scoped) }}
                               </span>
                             </div>
                           </div>
                         </div>
                         <div class="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
-                          重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDayOpus) }}
+                          重置剩余 {{ formatClaudeRemaining(scoped) }}
                         </div>
                       </div>
                     </div>
@@ -1651,13 +1654,17 @@
                     重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDay) }}
                   </div>
                 </div>
-                <!-- 7天Opus窗口 -->
-                <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                <!-- 按模型限定的周窗口（上游 limits[] 中的 weekly_scoped，如 Fable） -->
+                <div
+                  v-for="scoped in getScopedModelUsage(account)"
+                  :key="scoped.modelName"
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-purple-100 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:bg-purple-500/20 dark:text-purple-300"
                     >
-                      Opus
+                      {{ scoped.modelName }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -1665,23 +1672,21 @@
                           <div
                             :class="[
                               'h-2 rounded-full transition-all duration-300',
-                              getClaudeUsageBarClass(account.claudeUsage.sevenDayOpus)
+                              getClaudeUsageBarClass(scoped)
                             ]"
-                            :style="{
-                              width: getClaudeUsageWidth(account.claudeUsage.sevenDayOpus)
-                            }"
+                            :style="{ width: getClaudeUsageWidth(scoped) }"
                           />
                         </div>
                         <span
                           class="w-12 text-right text-xs font-semibold text-gray-800 dark:text-gray-100"
                         >
-                          {{ formatClaudeUsagePercent(account.claudeUsage.sevenDayOpus) }}
+                          {{ formatClaudeUsagePercent(scoped) }}
                         </span>
                       </div>
                     </div>
                   </div>
                   <div class="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
-                    重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDayOpus) }}
+                    重置剩余 {{ formatClaudeRemaining(scoped) }}
                   </div>
                 </div>
               </div>
@@ -3739,11 +3744,13 @@ const formatRemainingTime = (minutes) => {
 }
 
 // 格式化限流时间（支持显示天数）
-// 参与「按模型独立限流」的家族及其展示名。
-// 顺序即徽章展示顺序，与后端 RATE_LIMITED_MODEL_FAMILIES 保持一致。
+// 需要在账号列表上展示徽章的模型家族，顺序即展示顺序。
+// 后端 RATE_LIMITED_MODEL_FAMILIES 还包含 sonnet，但这里刻意不展示：
+// sonnet 是默认主力模型，限流触发频繁且几乎所有账号都会周期性命中，
+// 徽章会一直亮着，反而把 Opus / Fable 这类真正影响路由判断的信号淹没。
+// sonnet 的限流状态仍然在 modelRateLimitStatus 里，调度行为不受影响。
 const MODEL_RATE_LIMIT_FAMILIES = [
   { key: 'opus', label: 'Opus' },
-  { key: 'sonnet', label: 'Sonnet' },
   { key: 'haiku', label: 'Haiku' },
   { key: 'fable', label: 'Fable' }
 ]
@@ -3769,6 +3776,16 @@ const getLimitedModelFamilies = (account) => {
 
     return { key, label, minutesRemaining, resetAt: status.resetAt || null }
   }).filter(Boolean)
+}
+
+// 上游按模型限定的周窗口（limits[] 里的 weekly_scoped），标签用上游给的
+// display_name，有几个就显示几条；上游没回传就不显示。
+const getScopedModelUsage = (account) => {
+  const scoped = account?.claudeUsage?.sevenDayScopedModels
+  if (!Array.isArray(scoped)) {
+    return []
+  }
+  return scoped.filter((item) => item?.modelName && item.utilization !== null)
 }
 
 const formatRateLimitTime = (minutes) => {

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -795,20 +795,14 @@
                       </el-tooltip>
                     </span>
                     <span
-                      v-if="
-                        account.opusRateLimitStatus && account.opusRateLimitStatus.isRateLimited
-                      "
+                      v-for="family in getLimitedModelFamilies(account)"
+                      :key="family.key"
                       class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-800"
                     >
                       <i class="fas fa-hourglass-half mr-1" />
-                      Opus限流
-                      <span
-                        v-if="
-                          Number.isFinite(account.opusRateLimitStatus.minutesRemaining) &&
-                          account.opusRateLimitStatus.minutesRemaining > 0
-                        "
-                      >
-                        ({{ formatRateLimitTime(account.opusRateLimitStatus.minutesRemaining) }})
+                      {{ family.label }}限流
+                      <span v-if="family.minutesRemaining > 0">
+                        ({{ formatRateLimitTime(family.minutesRemaining) }})
                       </span>
                     </span>
                     <span
@@ -3745,6 +3739,38 @@ const formatRemainingTime = (minutes) => {
 }
 
 // 格式化限流时间（支持显示天数）
+// 参与「按模型独立限流」的家族及其展示名。
+// 顺序即徽章展示顺序，与后端 RATE_LIMITED_MODEL_FAMILIES 保持一致。
+const MODEL_RATE_LIMIT_FAMILIES = [
+  { key: 'opus', label: 'Opus' },
+  { key: 'sonnet', label: 'Sonnet' },
+  { key: 'haiku', label: 'Haiku' },
+  { key: 'fable', label: 'Fable' }
+]
+
+// 取出账号上所有处于限流中的模型家族。
+// 后端 /admin/claude-accounts 返回 modelRateLimitStatus（含全部家族）；
+// 同时兼容只有 opusRateLimitStatus / fableRateLimitStatus 的旧数据。
+const getLimitedModelFamilies = (account) => {
+  if (!account) return []
+
+  const legacy = {
+    opus: account.opusRateLimitStatus,
+    fable: account.fableRateLimitStatus
+  }
+
+  return MODEL_RATE_LIMIT_FAMILIES.map(({ key, label }) => {
+    const status = account.modelRateLimitStatus?.[key] || legacy[key]
+    if (!status?.isRateLimited) return null
+
+    const minutesRemaining = Number.isFinite(status.minutesRemaining)
+      ? Math.max(0, Math.ceil(status.minutesRemaining))
+      : 0
+
+    return { key, label, minutesRemaining, resetAt: status.resetAt || null }
+  }).filter(Boolean)
+}
+
 const formatRateLimitTime = (minutes) => {
   if (!minutes || minutes <= 0) return ''
 
@@ -4560,7 +4586,7 @@ const isAccountRoutingBlocked = (account) => {
     return true
   }
 
-  if (account.opusRateLimitStatus?.isRateLimited) {
+  if (getLimitedModelFamilies(account).length > 0) {
     return true
   }
 
@@ -4638,14 +4664,11 @@ const getRoutingBlockReasons = (account) => {
     reasons.push(tempReason)
   }
 
-  if (account.opusRateLimitStatus?.isRateLimited) {
-    const opusMinutes = Number.isFinite(account.opusRateLimitStatus.minutesRemaining)
-      ? Math.max(0, Math.ceil(account.opusRateLimitStatus.minutesRemaining))
-      : 0
+  for (const family of getLimitedModelFamilies(account)) {
     reasons.push(
-      opusMinutes > 0
-        ? `Opus 模型限流中（约 ${formatRateLimitTime(opusMinutes)} 后恢复）`
-        : 'Opus 模型限流中'
+      family.minutesRemaining > 0
+        ? `${family.label} 模型限流中（约 ${formatRateLimitTime(family.minutesRemaining)} 后恢复）`
+        : `${family.label} 模型限流中`
     )
   }
 


### PR DESCRIPTION
## 问题

### 1. 限流徽章只认 Opus

后端 `/admin/claude-accounts` 自 #1232 起就返回 `modelRateLimitStatus`（opus / sonnet / haiku / fable 四个家族各自的状态），但前端只读 `opusRateLimitStatus`：

```js
if (account.opusRateLimitStatus?.isRateLimited) { ... }   // 只有 Opus
```

于是 fable / haiku 被限流时，账号列表既没有徽章，「不可路由」原因里也看不到，只能去 Redis 里翻 `{family}RateLimitEndAt` 才知道调度器为什么绕开这个账号。

### 2. 第三条用量条永远是空的

第三条进度条把标签写死成 `sonnet`，数据却绑在 `claudeUsage.sevenDayOpus` 上，而后端给该字段填的是上游的 `seven_day_sonnet` —— 变量名、标签、数据源三者互不一致。

更关键的是：这些**顶层具名窗口在 Max 账号上一直是 `null`**。实测 `/api/oauth/usage` 的返回：

```
five_hour            util=0    resets=2026-09-05T10:40:00Z
seven_day            util=8    resets=2026-09-09T07:00:00Z
seven_day_opus       null
seven_day_sonnet     null
```

所以那条进度条恒定显示「`-` 重置剩余 `-`」。

**但按模型限定的额度其实是有的，它在 `limits[]` 里，不是顶层具名窗口：**

```json
{
  "kind": "weekly_scoped",
  "group": "weekly",
  "percent": 9,
  "severity": "normal",
  "resets_at": "2026-09-09T07:00:00.509898+00:00",
  "scope": { "model": { "id": null, "display_name": "Fable" } },
  "is_active": true
}
```

线上两个账号分别是 Fable 周用量 **9%** 和 **49%** —— 数据一直都在，只是从来没被解析过。

> 更正：本 PR 早前的版本里我写过「上游没有 Fable 窗口，所以做不了 Fable 用量条」。那是只看了响应头（`anthropic-ratelimit-unified-{5h,7d,7d_oi}-*`）得出的结论，**是错的**：usage 接口通过 `limits[].scope.model.display_name` 暴露了它。

## 改动

**后端** `src/services/account/claudeAccountService.js`
- 新增 `_extractWeeklyScopedModels()` 解析 `limits[]` 中 `kind === 'weekly_scoped'` 且带 `scope.model.display_name` 的条目
- 以 `claudeWeeklyScopedModels` 持久化，并在 `claudeUsage` 中透出 `sevenDayScopedModels`（`modelName` / `utilization` / `resetsAt` / `remainingSeconds` / `severity` / `isActive`）
- 顶层 `seven_day_opus` / `seven_day_sonnet` 的既有解析原样保留，不改动现有字段语义

**前端** `web/admin-spa/src/views/AccountsView.vue`
- 新增 `MODEL_RATE_LIMIT_FAMILIES` + `getLimitedModelFamilies()`，徽章与「不可路由」原因统一从 `modelRateLimitStatus` 取，兼容只有 `opusRateLimitStatus` / `fableRateLimitStatus` 的旧数据
- 第三条进度条改为**数据驱动**：按 `sevenDayScopedModels` 逐条渲染，标签取上游返回的 `display_name`，上游没回传就不显示。思路与 #1262 一致 —— 标签由数据决定，不写死
- 列表视图与卡片视图两处都已覆盖；帮助浮层同步更新

**徽章不展示 Sonnet**：Sonnet 是默认主力模型，限流触发频繁、几乎所有账号都会周期性命中，徽章长期亮着反而会淹没 Opus / Fable 这类真正影响路由判断的信号。展示集合收敛为 Opus / Haiku / Fable。`sonnet` 的限流状态仍在 `modelRateLimitStatus` 里，**调度行为完全不受影响**，只是不再占用徽章位置。如果维护者认为不该在前端做这个取舍，把 `sonnet` 加回 `MODEL_RATE_LIMIT_FAMILIES` 即可。

## 效果

同一个账号，改动前后：

```
改前：  Opus限流(41分钟)                              sonnet  -     重置剩余 -
改后：  Opus限流(41分钟)  Fable限流(41分钟)            Fable   49%   重置剩余 4天12小时
```

## 测试

```
npm test                                → 26 suites / 283 passed, 8 skipped
  └─ 新增 tests/claudeWeeklyScopedModels.test.js（7 例，用线上实际 limits[] 覆盖）
npx eslint / prettier --check           → 无告警
npx vite build                          → ✓ built in 13.56s
```


## 截图

同一个账号（截图已脱敏：账号名替换为占位符，账号 UUID 与金额已打码）：

![账号列表：Opus/Fable 限流徽章 + 真实 Fable 周额度进度条](https://raw.githubusercontent.com/lovinrain/claude-relay-service/assets/pr-screenshots/docs/screenshots/row-badges-and-fable.png)

- **状态列**：`Opus限流(12分钟)` 与 `Fable限流(12分钟)` 两个徽章并存，下方「不可路由」原因也逐条列出。改动前这里只会有一个 `Opus限流` 徽章，Fable 完全不可见。
- **会话窗口列**：`5h 100%` / `7d 26%` / **`Fable 49%`**。第三条以前标签写死为 `sonnet`、数据绑在恒为 null 的 `sevenDayOpus` 上，永远显示「`-` 重置剩余 `-`」；现在展示的是从 `limits[]` 解析出来的真实 Fable 周用量。
- 徽章里没有 Sonnet —— 即本 PR 说明中提到的收敛。
