### PR TITLE
fix(web): Codex 用量窗口标签按 windowMinutes 推导，修复 Pro 账号显示为「5h」的问题

### DIFF
--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -356,7 +356,7 @@
                               OpenAI
                             </div>
                             <div class="text-gray-200 dark:text-gray-600">
-                              进度条分别展示 5h 与周限窗口的额度使用比例，颜色含义与上方保持一致。
+                              进度条展示上游实际回传的额度窗口，标签按窗口长度自动生成，颜色含义与上方保持一致。
                             </div>
                             <div class="space-y-1 text-gray-200 dark:text-gray-600">
                               <div class="flex items-start gap-2">
@@ -369,6 +369,13 @@
                                 <i class="fas fa-history mt-[2px] text-[10px] text-emerald-500"></i>
                                 <span class="font-medium text-white dark:text-gray-900"
                                   >周限窗口：7天使用量进度，重置时同样回到 0%。</span
+                                >
+                              </div>
+                              <div class="flex items-start gap-2">
+                                <i class="fas fa-user-tag mt-[2px] text-[10px] text-amber-500"></i>
+                                <span class="font-medium text-white dark:text-gray-900"
+                                  >窗口数量随套餐而定：Pro 账号只有周限窗口，此时不会再显示 5h
+                                  进度条。</span
                                 >
                               </div>
                               <div class="flex items-start gap-2">
@@ -1146,13 +1153,16 @@
                     </div>
                   </div>
                   <div v-else-if="account.platform === 'openai'" class="space-y-2">
-                    <div v-if="account.codexUsage" class="space-y-2">
-                      <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                    <div v-if="hasAnyCodexWindow(account.codexUsage)" class="space-y-2">
+                      <div
+                        v-if="hasCodexWindow(account.codexUsage.primary)"
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300"
                           >
-                            {{ getCodexWindowLabel('primary') }}
+                            {{ getCodexWindowLabel(account.codexUsage.primary, 'primary') }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -1179,12 +1189,15 @@
                           重置剩余 {{ formatCodexRemaining(account.codexUsage.primary) }}
                         </div>
                       </div>
-                      <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                      <div
+                        v-if="hasCodexWindow(account.codexUsage.secondary)"
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:bg-blue-500/20 dark:text-blue-300"
                           >
-                            {{ getCodexWindowLabel('secondary') }}
+                            {{ getCodexWindowLabel(account.codexUsage.secondary, 'secondary') }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -1746,13 +1759,16 @@
               <div v-else class="text-xs text-gray-400">暂无统计</div>
             </div>
             <div v-else-if="account.platform === 'openai'" class="space-y-2">
-              <div v-if="account.codexUsage" class="space-y-2">
-                <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700">
+              <div v-if="hasAnyCodexWindow(account.codexUsage)" class="space-y-2">
+                <div
+                  v-if="hasCodexWindow(account.codexUsage.primary)"
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700"
+                >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300"
                     >
-                      {{ getCodexWindowLabel('primary') }}
+                      {{ getCodexWindowLabel(account.codexUsage.primary, 'primary') }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -1779,12 +1795,15 @@
                     重置剩余 {{ formatCodexRemaining(account.codexUsage.primary) }}
                   </div>
                 </div>
-                <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700">
+                <div
+                  v-if="hasCodexWindow(account.codexUsage.secondary)"
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700"
+                >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:bg-blue-500/20 dark:text-blue-300"
                     >
-                      {{ getCodexWindowLabel('secondary') }}
+                      {{ getCodexWindowLabel(account.codexUsage.secondary, 'secondary') }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -1812,7 +1831,9 @@
                   </div>
                 </div>
               </div>
-              <div v-if="!account.codexUsage" class="text-xs text-gray-400">暂无统计</div>
+              <div v-if="!hasAnyCodexWindow(account.codexUsage)" class="text-xs text-gray-400">
+                暂无统计
+              </div>
             </div>
 
             <!-- 最后使用时间 -->
@@ -4950,12 +4971,54 @@ const getCodexUsageWidth = (usageItem) => {
 }
 
 // 时间窗口标签
-const getCodexWindowLabel = (type) => {
-  if (type === 'secondary') {
-    return '周限'
+// 把窗口长度（分钟）转成展示名。
+const formatCodexWindowMinutes = (minutes) => {
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return ''
   }
-  return '5h'
+  if (minutes % 10080 === 0) {
+    const weeks = minutes / 10080
+    return weeks === 1 ? '周限' : `${weeks}周`
+  }
+  if (minutes % 1440 === 0) {
+    return `${minutes / 1440}天`
+  }
+  if (minutes % 60 === 0) {
+    return `${minutes / 60}h`
+  }
+  return `${minutes}m`
 }
+
+// Codex 用量窗口的展示名必须按 windowMinutes 推导，不能按槽位硬编码。
+// 上游会按套餐回传不同的窗口组合：Plus 一般是 5h(300) + 周限(10080) 两个；
+// 而 Pro 只回传一个窗口，且落在 primary 槽位里，windowMinutes = 10080（7 天）。
+// 旧代码固定 primary='5h' / secondary='周限'，Pro 账号就会显示成
+// 「5h 75%」+「周限 0% 重置剩余 0秒」——两个标签都是错的。
+const getCodexWindowLabel = (usageItem, fallbackType) => {
+  const label = formatCodexWindowMinutes(usageItem?.windowMinutes)
+  if (label) {
+    return label
+  }
+  return fallbackType === 'secondary' ? '周限' : '5h'
+}
+
+// 上游没有回传的窗口不应该渲染成一条 0% 的进度条。
+const hasCodexWindow = (usageItem) => {
+  if (!usageItem) {
+    return false
+  }
+  if (Number.isFinite(usageItem.windowMinutes) && usageItem.windowMinutes > 0) {
+    return true
+  }
+  // 兼容没有记录 windowMinutes 的旧数据：只要有用量或重置信息就仍然展示
+  return (
+    (Number.isFinite(usageItem.usedPercent) && usageItem.usedPercent > 0) ||
+    (Number.isFinite(usageItem.resetAfterSeconds) && usageItem.resetAfterSeconds > 0)
+  )
+}
+
+const hasAnyCodexWindow = (codexUsage) =>
+  !!codexUsage && (hasCodexWindow(codexUsage.primary) || hasCodexWindow(codexUsage.secondary))
 
 // 格式化剩余时间
 const formatCodexRemaining = (usageItem) => {


### PR DESCRIPTION
## 问题

前端把 `codexUsage` 的两个槽位写死成了固定标签：

```js
const getCodexWindowLabel = (type) => {
  if (type === 'secondary') {
    return '周限'
  }
  return '5h'
}
```

但上游按套餐回传的窗口组合并不一样。**Pro 账号只有一个窗口，而且落在 `primary` 槽位里，`windowMinutes = 10080`（7 天）**：

```json
"codexUsage": {
  "primary":   { "usedPercent": 75, "windowMinutes": 10080, "resetAfterSeconds": 162257, "resetAt": "2026-09-07T02:26:35.870Z" },
  "secondary": { "usedPercent": 0,  "windowMinutes": 0,     "resetAfterSeconds": 0,      "resetAt": "2026-09-05T05:22:18.870Z" }
}
```

界面上就显示成：

```
5h    75.0%   重置剩余 1天21小时
周限   0.0%   重置剩余 0秒
```

两条都是错的：

- 上面那条把一个 **7 天**窗口标成了 `5h`。看到「5h 75%」会以为几小时后就恢复，实际要等到 2 天后 —— 「重置剩余 1天21小时」和「5h」这两个信息本身就自相矛盾。
- 下面那条是上游根本没回传的空窗口（`windowMinutes: 0`），却被渲染成一条 0%、重置剩余 0 秒的进度条。

后端其实一直有把 `windowMinutes` 透出来（`openaiAccountService.js` 的 `primaryWindowMinutes` / `secondaryWindowMinutes`），只是前端没用。

## 改动

只动前端 `web/admin-spa/src/views/AccountsView.vue`：

- 新增 `formatCodexWindowMinutes()`，按窗口长度生成标签：

  | windowMinutes | 标签 |
  |---|---|
  | 300 | `5h` |
  | 10080 | `周限` |
  | 1440 | `1天` |
  | 20160 | `2周` |
  | 其它 | 按 `h` / `m` 兜底 |

- `getCodexWindowLabel(usageItem, fallbackType)` 改为按 `windowMinutes` 推导；取不到时才退回原来的槽位默认值，兼容没记录 `windowMinutes` 的旧数据
- 新增 `hasCodexWindow()`：上游没回传的窗口不再渲染成一条 0% 的进度条。旧数据只要有用量或重置信息就仍然展示，不会因为缺 `windowMinutes` 而整条消失
- 新增 `hasAnyCodexWindow()`：两个窗口都没有时显示「暂无统计」
- 列表视图和卡片视图两处都已覆盖；帮助浮层补一句「窗口数量随套餐而定：Pro 账号只有周限窗口，此时不会再显示 5h 进度条」

## 修复后

同一个 Pro 账号只会显示一条正确的进度条：

```
周限   75.0%   重置剩余 1天21小时
```

Plus 账号（`primary` 300 / `secondary` 10080）显示不变，仍是 `5h` + `周限` 两条。

## 测试

```
npx eslint src/views/AccountsView.vue   → 无告警
npx prettier --check                    → 通过
npx vite build                          → ✓ built in 13.57s
```

标签推导用线上实际取到的 windowMinutes 逐个核对过：`300→5h`、`10080→周限`、`1440→1天`、`20160→2周`、`0/null→空（走兜底并隐藏）`。


## 截图

一个 `planType: pro` 的 OpenAI 账号（截图已脱敏：账号名替换为占位符，账号 UUID 与金额已打码）：

![Pro 账号只显示一条正确的周限进度条](https://raw.githubusercontent.com/lovinrain/claude-relay-service/assets/pr-screenshots/docs/screenshots/row-codex-weekly.png)

只有一条 **`周限 75.0%　重置剩余 1天20小时`**：标签与 `windowMinutes: 10080` 一致，剩余时间也对得上。

改动前同一行会显示成：

```
5h    75.0%   重置剩余 1天20小时     ← 7 天窗口被标成 5h，与剩余时间自相矛盾
周限   0.0%   重置剩余 0秒          ← 上游根本没回传的空窗口
```
