### PR TITLE
fix: Console 账户每日额度超限停用后无法在重置时间自动恢复调度

### DIFF
--- a/src/services/account/claudeConsoleAccountService.js
+++ b/src/services/account/claudeConsoleAccountService.js
@@ -713,24 +713,57 @@ class ClaudeConsoleAccountService {
 
   // 🔍 判断是否应该重置账户额度
   _shouldResetQuota(account) {
-    // 与 Redis 统计一致：按配置时区判断“今天”与时间点
-    const tzNow = redis.getDateInTimezone(new Date())
-    const today = redis.getDateStringInTimezone(tzNow)
+    const now = new Date()
+    // ⚠️ 这里必须传入真实时间 now：redis.getDateStringInTimezone() 内部会自行调用
+    // getDateInTimezone() 做一次时区偏移，若把已偏移过的 tzNow 再传进去就会叠加两次
+    // 偏移（+16 小时），导致每天 16:00 之后算出的“今天”变成明天，进而把刚停用的账户
+    // 立刻误判为应重置，出现“停用→秒恢复”的死循环。
+    const today = redis.getDateStringInTimezone(now)
 
     // 如果已经是今天重置过的，不需要重置
     if (account.lastResetDate === today) {
       return false
     }
 
-    // 检查是否到了重置时间点（按配置时区的小时/分钟）
-    const resetTime = account.quotaResetTime || '00:00'
-    const [resetHour, resetMinute] = resetTime.split(':').map((n) => parseInt(n))
+    // 解析重置时间点（HH:mm，非法值回退 00:00）
+    const resetParts = String(account.quotaResetTime || '00:00').split(':')
+    let resetHour = parseInt(resetParts[0], 10)
+    let resetMinute = parseInt(resetParts[1], 10)
+    if (isNaN(resetHour) || resetHour < 0 || resetHour > 23) {
+      resetHour = 0
+    }
+    if (isNaN(resetMinute) || resetMinute < 0 || resetMinute > 59) {
+      resetMinute = 0
+    }
 
-    const currentHour = tzNow.getUTCHours()
-    const currentMinute = tzNow.getUTCMinutes()
+    // 计算“最近一次重置时间点”：配置时区下今天的 resetHour:resetMinute；
+    // 若当前还没到今天的重置时间，则取昨天的重置时间点
+    const tzNow = redis.getDateInTimezone(now)
+    let boundary = Date.UTC(
+      tzNow.getUTCFullYear(),
+      tzNow.getUTCMonth(),
+      tzNow.getUTCDate(),
+      resetHour,
+      resetMinute
+    )
+    if (tzNow.getUTCHours() * 60 + tzNow.getUTCMinutes() < resetHour * 60 + resetMinute) {
+      boundary -= 24 * 3600000
+    }
 
-    // 如果当前时间已过重置时间且不是同一天重置的，应该重置
-    return currentHour > resetHour || (currentHour === resetHour && currentMinute >= resetMinute)
+    // boundary 处于“偏移空间”，减去时区偏移才能换回真实时间轴上的时刻
+    const offset = (config.system && config.system.timezoneOffset) || 8
+    const boundaryReal = new Date(boundary - offset * 3600000)
+
+    // 只有当最近一次重置时间点晚于停用时刻时，才说明已经跨过重置点，应该恢复
+    if (account.quotaStoppedAt) {
+      const stoppedAt = new Date(account.quotaStoppedAt)
+      if (!isNaN(stoppedAt.getTime())) {
+        return stoppedAt < boundaryReal
+      }
+    }
+
+    // 没有可用的停用时间时，退化为“不是今天重置的就重置”
+    return account.lastResetDate !== today
   }
 
   // 🚫 标记账号为未授权状态（401错误）

--- a/src/services/account/claudeConsoleAccountService.js
+++ b/src/services/account/claudeConsoleAccountService.js
@@ -357,12 +357,29 @@ class ClaudeConsoleAccountService {
         updatedData.autoStoppedAt = ''
         updatedData.stoppedReason = ''
 
+        // 仅当调用方未显式携带自动停止标记时，才视为管理员手动操作
+        const isManualChange =
+          updates.quotaAutoStopped === undefined && updates.rateLimitAutoStopped === undefined
+
         // 记录日志
-        if (updates.schedulable === true || updates.schedulable === 'true') {
+        if (!isManualChange) {
+          logger.debug(
+            `🤖 Automatic scheduling change for Claude Console account ${accountId}: schedulable=${updatedData.schedulable}`
+          )
+        } else if (updates.schedulable === true || updates.schedulable === 'true') {
           logger.info(`✅ Manually enabled scheduling for Claude Console account ${accountId}`)
         } else {
           logger.info(`⛔ Manually disabled scheduling for Claude Console account ${accountId}`)
         }
+      }
+
+      // 自动停止标记（由额度/限流自动停用逻辑显式传入时必须落库，
+      // 否则超额停用后第二天无法自动恢复调度）
+      if (updates.quotaAutoStopped !== undefined) {
+        updatedData.quotaAutoStopped = String(updates.quotaAutoStopped)
+      }
+      if (updates.rateLimitAutoStopped !== undefined) {
+        updatedData.rateLimitAutoStopped = String(updates.rateLimitAutoStopped)
       }
 
       // 额度管理相关字段

--- a/src/services/account/claudeConsoleAccountService.js
+++ b/src/services/account/claudeConsoleAccountService.js
@@ -360,13 +360,23 @@ class ClaudeConsoleAccountService {
         // 仅当调用方未显式携带自动停止标记时，才视为管理员手动操作
         const isManualChange =
           updates.quotaAutoStopped === undefined && updates.rateLimitAutoStopped === undefined
+        const isManualEnable =
+          isManualChange && (updates.schedulable === true || updates.schedulable === 'true')
+
+        // 管理员手动开启调度时一并清除额度停用标记：残留的 quotaStoppedAt 会让账户
+        // 在选号时继续被判为超额而跳过，使"打开调度"当天不生效。清除后下次选号会
+        // 重新评估用量，若仍超过上限会立即再次停用（需先调高上限才能真正放开）
+        if (isManualEnable && existingAccount.quotaStoppedAt) {
+          updatedData.quotaStoppedAt = ''
+          updatedData.errorMessage = ''
+        }
 
         // 记录日志
         if (!isManualChange) {
           logger.debug(
             `🤖 Automatic scheduling change for Claude Console account ${accountId}: schedulable=${updatedData.schedulable}`
           )
-        } else if (updates.schedulable === true || updates.schedulable === 'true') {
+        } else if (isManualEnable) {
           logger.info(`✅ Manually enabled scheduling for Claude Console account ${accountId}`)
         } else {
           logger.info(`⛔ Manually disabled scheduling for Claude Console account ${accountId}`)

--- a/src/services/scheduler/unifiedClaudeScheduler.js
+++ b/src/services/scheduler/unifiedClaudeScheduler.js
@@ -1690,8 +1690,42 @@ class UnifiedClaudeScheduler {
       // 使用现有的优先级排序逻辑
       const sortedAccounts = sortAccountsByPriority(availableAccounts)
 
-      // 选择第一个账户
-      const selectedAccount = sortedAccounts[0]
+      // 💰 按优先级惰性检查每日额度（避免对全部成员批量查询用量）
+      // 与共享池路径语义一致：选号时主动触发一次额度检查，超额账户跳过
+      let selectedAccount = null
+      for (const candidate of sortedAccounts) {
+        const quotaService =
+          candidate.accountType === 'claude-console'
+            ? claudeConsoleAccountService
+            : candidate.accountType === 'ccr'
+              ? ccrAccountService
+              : null
+
+        if (quotaService && parseFloat(candidate.dailyQuota || '0') > 0) {
+          try {
+            await quotaService.checkQuotaUsage(candidate.accountId)
+            const isQuotaExceeded = await quotaService.isAccountQuotaExceeded(candidate.accountId)
+            if (isQuotaExceeded) {
+              logger.info(
+                `🚫 Skipping group member ${candidate.name} (${candidate.accountId}) due to daily quota exceeded: $${candidate.dailyQuota}`
+              )
+              continue
+            }
+          } catch (error) {
+            // 额度检查失败不能阻塞调度，宁可放过一次
+            logger.warn(
+              `⚠️ Failed to check quota for group member ${candidate.name} (${candidate.accountId}): ${error.message}`
+            )
+          }
+        }
+
+        selectedAccount = candidate
+        break
+      }
+
+      if (!selectedAccount) {
+        throw new Error(`No available accounts in group ${group.name} (all quota exceeded)`)
+      }
 
       // 如果有会话哈希，建立新的映射
       if (sessionHash) {

--- a/tests/claudeConsoleQuotaRecovery.test.js
+++ b/tests/claudeConsoleQuotaRecovery.test.js
@@ -1,6 +1,26 @@
 const ACCOUNT_ID = 'console-quota-1'
 const ACCOUNT_KEY = `claude_console_account:${ACCOUNT_ID}`
 
+// 测试统一使用 UTC+8 时区
+const TZ_OFFSET_HOURS = 8
+const TZ_OFFSET_MS = TZ_OFFSET_HOURS * 3600000
+
+// 忠实复现 src/models/redis.js 的时区语义：
+// getDateInTimezone(d) 返回 d + offset 小时；
+// getDateStringInTimezone(d) 内部会再调用一次 getDateInTimezone(d)。
+// 如果调用方把已经偏移过的时间再传给 getDateStringInTimezone，就会叠加两次偏移。
+const tzDate = (date = new Date()) => new Date(date.getTime() + TZ_OFFSET_MS)
+const tzDateString = (date = new Date()) => {
+  const d = tzDate(date)
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(
+    d.getUTCDate()
+  ).padStart(2, '0')}`
+}
+
+// 把 "UTC+8 的墙上时间" 换算成真实的 UTC 时间点，方便用 +8 语义描述用例
+const tz8 = (year, month, day, hour = 0, minute = 0, second = 0) =>
+  new Date(Date.UTC(year, month - 1, day, hour, minute, second) - TZ_OFFSET_MS)
+
 // 内存 hash 存储，供 redis mock 使用
 const store = new Map()
 
@@ -42,7 +62,7 @@ jest.mock('../src/utils/logger', () => ({
   success: jest.fn()
 }))
 
-jest.mock('../config/config', () => ({}), { virtual: true })
+jest.mock('../config/config', () => ({ system: { timezoneOffset: 8 } }), { virtual: true })
 
 jest.mock('../src/utils/webhookNotifier', () => ({
   sendAccountAnomalyNotification: jest.fn(async () => undefined)
@@ -52,8 +72,8 @@ jest.mock('../src/models/redis', () => ({
   getClientSafe: jest.fn(() => mockClient),
   getAccountUsageStats: jest.fn(async () => ({ daily: { cost: 0 } })),
   getConsoleAccountConcurrency: jest.fn(async () => 0),
-  getDateStringInTimezone: jest.fn(() => '2026-09-04'),
-  getDateInTimezone: jest.fn(() => new Date(Date.UTC(2026, 8, 4, 10, 30, 0)))
+  getDateStringInTimezone: jest.fn((date) => tzDateString(date)),
+  getDateInTimezone: jest.fn((date) => tzDate(date))
 }))
 
 describe('Claude Console daily quota auto stop / auto recovery', () => {
@@ -91,7 +111,8 @@ describe('Claude Console daily quota auto stop / auto recovery', () => {
   beforeEach(() => {
     jest.resetModules()
     jest.useFakeTimers()
-    jest.setSystemTime(new Date('2026-09-04T10:30:00.000Z'))
+    // 2026-09-04 18:30 (UTC+8)
+    jest.setSystemTime(tz8(2026, 9, 4, 18, 30))
     store.clear()
     seedAccount()
     redis = require('../src/models/redis')
@@ -119,10 +140,8 @@ describe('Claude Console daily quota auto stop / auto recovery', () => {
     await service.checkQuotaUsage(ACCOUNT_ID)
     expect(store.get(ACCOUNT_KEY).schedulable).toBe('false')
 
-    // 进入第二天：上次重置日期为昨天，当前时间已过 00:00 重置点
-    store.get(ACCOUNT_KEY).lastResetDate = '2026-09-04'
-    redis.getDateStringInTimezone.mockReturnValue('2026-09-05')
-    redis.getDateInTimezone.mockReturnValue(new Date(Date.UTC(2026, 8, 5, 10, 30, 0)))
+    // 进入第二天 10:00 (UTC+8)：上次重置日期为昨天，已跨过 00:00 重置点
+    jest.setSystemTime(tz8(2026, 9, 5, 10, 0))
 
     const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
 
@@ -148,5 +167,124 @@ describe('Claude Console daily quota auto stop / auto recovery', () => {
     expect(saved.schedulable).toBe('false')
     expect(saved.quotaAutoStopped).toBe('')
     expect(saved.rateLimitAutoStopped).toBe('')
+  })
+
+  it('does not reset in the evening right after being stopped (double timezone offset regression)', async () => {
+    // 今天 19:00 (UTC+8) 超额停用
+    jest.setSystemTime(tz8(2026, 9, 4, 19, 0))
+    seedAccount({
+      schedulable: 'false',
+      quotaAutoStopped: 'true',
+      quotaStoppedAt: tz8(2026, 9, 4, 19, 0).toISOString(),
+      lastResetDate: '2026-09-04'
+    })
+
+    // 5 秒后调度器再次检查
+    jest.setSystemTime(tz8(2026, 9, 4, 19, 0, 5))
+
+    const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
+
+    const saved = store.get(ACCOUNT_KEY)
+    expect(exceeded).toBe(true)
+    expect(saved.schedulable).toBe('false')
+    expect(saved.quotaStoppedAt).toBe(tz8(2026, 9, 4, 19, 0).toISOString())
+  })
+
+  it('does not reset when lastResetDate is stale but the reset point predates the stop', async () => {
+    // lastResetDate 是 5 天前（账户从未重置过），今天 10:00 (UTC+8) 停用
+    jest.setSystemTime(tz8(2026, 9, 4, 10, 0))
+    seedAccount({
+      schedulable: 'false',
+      quotaAutoStopped: 'true',
+      quotaStoppedAt: tz8(2026, 9, 4, 10, 0).toISOString(),
+      lastResetDate: '2026-08-30'
+    })
+
+    jest.setSystemTime(tz8(2026, 9, 4, 10, 3))
+
+    const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
+
+    const saved = store.get(ACCOUNT_KEY)
+    expect(exceeded).toBe(true)
+    expect(saved.schedulable).toBe('false')
+    expect(saved.quotaAutoStopped).toBe('true')
+  })
+
+  it('restores after crossing the 00:00 reset point', async () => {
+    // 昨天 23:00 (UTC+8) 停用，今天 00:10 检查
+    seedAccount({
+      schedulable: 'false',
+      quotaAutoStopped: 'true',
+      quotaStoppedAt: tz8(2026, 9, 4, 23, 0).toISOString(),
+      lastResetDate: '2026-09-04'
+    })
+    jest.setSystemTime(tz8(2026, 9, 5, 0, 10))
+
+    const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
+
+    const saved = store.get(ACCOUNT_KEY)
+    expect(exceeded).toBe(false)
+    expect(saved.schedulable).toBe('true')
+    expect(saved.quotaStoppedAt).toBe('')
+    expect(saved.quotaAutoStopped).toBe('')
+    expect(saved.lastResetDate).toBe('2026-09-05')
+  })
+
+  describe('custom quota reset time 08:00', () => {
+    it('restores when stopped at 07:00 and checked at 09:00', async () => {
+      seedAccount({
+        schedulable: 'false',
+        quotaAutoStopped: 'true',
+        quotaResetTime: '08:00',
+        quotaStoppedAt: tz8(2026, 9, 4, 7, 0).toISOString(),
+        lastResetDate: '2026-09-03'
+      })
+      jest.setSystemTime(tz8(2026, 9, 4, 9, 0))
+
+      const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
+
+      const saved = store.get(ACCOUNT_KEY)
+      expect(exceeded).toBe(false)
+      expect(saved.schedulable).toBe('true')
+      expect(saved.quotaStoppedAt).toBe('')
+      expect(saved.lastResetDate).toBe('2026-09-04')
+    })
+
+    it('does not restore when stopped at 09:00 and checked at 10:00', async () => {
+      seedAccount({
+        schedulable: 'false',
+        quotaAutoStopped: 'true',
+        quotaResetTime: '08:00',
+        quotaStoppedAt: tz8(2026, 9, 4, 9, 0).toISOString(),
+        lastResetDate: '2026-09-03'
+      })
+      jest.setSystemTime(tz8(2026, 9, 4, 10, 0))
+
+      const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
+
+      const saved = store.get(ACCOUNT_KEY)
+      expect(exceeded).toBe(true)
+      expect(saved.schedulable).toBe('false')
+      expect(saved.quotaAutoStopped).toBe('true')
+    })
+
+    it('restores when stopped at 09:00 and checked at 08:05 the next day', async () => {
+      seedAccount({
+        schedulable: 'false',
+        quotaAutoStopped: 'true',
+        quotaResetTime: '08:00',
+        quotaStoppedAt: tz8(2026, 9, 4, 9, 0).toISOString(),
+        lastResetDate: '2026-09-04'
+      })
+      jest.setSystemTime(tz8(2026, 9, 5, 8, 5))
+
+      const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
+
+      const saved = store.get(ACCOUNT_KEY)
+      expect(exceeded).toBe(false)
+      expect(saved.schedulable).toBe('true')
+      expect(saved.quotaStoppedAt).toBe('')
+      expect(saved.lastResetDate).toBe('2026-09-05')
+    })
   })
 })

--- a/tests/claudeConsoleQuotaRecovery.test.js
+++ b/tests/claudeConsoleQuotaRecovery.test.js
@@ -230,6 +230,65 @@ describe('Claude Console daily quota auto stop / auto recovery', () => {
     expect(saved.lastResetDate).toBe('2026-09-05')
   })
 
+  describe('manual re-enable clears the quota stop marker', () => {
+    it('clears quotaStoppedAt when an admin manually enables scheduling', async () => {
+      seedAccount({
+        schedulable: 'false',
+        quotaAutoStopped: 'true',
+        quotaStoppedAt: tz8(2026, 9, 4, 12, 0).toISOString(),
+        errorMessage: 'Daily quota exceeded: $12.00 / $10.00'
+      })
+
+      await service.updateAccount(ACCOUNT_ID, { schedulable: true })
+
+      const saved = store.get(ACCOUNT_KEY)
+      expect(saved.schedulable).toBe('true')
+      expect(saved.quotaStoppedAt).toBe('')
+      expect(saved.errorMessage).toBe('')
+      expect(saved.quotaAutoStopped).toBe('')
+    })
+
+    it('does not treat the account as exceeded after a manual re-enable', async () => {
+      seedAccount({
+        schedulable: 'false',
+        quotaAutoStopped: 'true',
+        quotaStoppedAt: tz8(2026, 9, 4, 12, 0).toISOString()
+      })
+      // 管理员先调高上限，再打开调度
+      await service.updateAccount(ACCOUNT_ID, { dailyQuota: 20 })
+      await service.updateAccount(ACCOUNT_ID, { schedulable: true })
+
+      redis.getAccountUsageStats.mockResolvedValue({ daily: { cost: 12 } })
+      const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
+
+      expect(exceeded).toBe(false)
+      expect(store.get(ACCOUNT_KEY).schedulable).toBe('true')
+    })
+
+    it('keeps quotaStoppedAt when an admin disables scheduling', async () => {
+      const stoppedAt = tz8(2026, 9, 4, 12, 0).toISOString()
+      seedAccount({
+        schedulable: 'false',
+        quotaAutoStopped: 'true',
+        quotaStoppedAt: stoppedAt
+      })
+
+      await service.updateAccount(ACCOUNT_ID, { schedulable: false })
+
+      expect(store.get(ACCOUNT_KEY).quotaStoppedAt).toBe(stoppedAt)
+    })
+
+    it('keeps quotaStoppedAt when the change comes from automatic quota logic', async () => {
+      const stoppedAt = tz8(2026, 9, 4, 12, 0).toISOString()
+      seedAccount({ schedulable: 'false', quotaStoppedAt: stoppedAt })
+
+      // 自动逻辑会显式携带自动停止标记，不应被视为管理员手动操作
+      await service.updateAccount(ACCOUNT_ID, { schedulable: true, quotaAutoStopped: '' })
+
+      expect(store.get(ACCOUNT_KEY).quotaStoppedAt).toBe(stoppedAt)
+    })
+  })
+
   describe('custom quota reset time 08:00', () => {
     it('restores when stopped at 07:00 and checked at 09:00', async () => {
       seedAccount({

--- a/tests/claudeConsoleQuotaRecovery.test.js
+++ b/tests/claudeConsoleQuotaRecovery.test.js
@@ -1,0 +1,152 @@
+const ACCOUNT_ID = 'console-quota-1'
+const ACCOUNT_KEY = `claude_console_account:${ACCOUNT_ID}`
+
+// 内存 hash 存储，供 redis mock 使用
+const store = new Map()
+
+const getHash = (key) => {
+  if (!store.has(key)) {
+    store.set(key, {})
+  }
+  return store.get(key)
+}
+
+const mockClient = {
+  hset: jest.fn(async (key, data) => {
+    const hash = getHash(key)
+    for (const [field, value] of Object.entries(data)) {
+      hash[field] = value === null || value === undefined ? '' : String(value)
+    }
+    return Object.keys(data).length
+  }),
+  hget: jest.fn(async (key, field) => {
+    const hash = store.get(key)
+    return hash && hash[field] !== undefined ? hash[field] : null
+  }),
+  hmget: jest.fn(async (key, ...fields) => {
+    const hash = store.get(key) || {}
+    return fields.flat().map((field) => (hash[field] !== undefined ? hash[field] : null))
+  }),
+  hgetall: jest.fn(async (key) => ({ ...(store.get(key) || {}) })),
+  sadd: jest.fn(async () => 1),
+  srem: jest.fn(async () => 1),
+  expire: jest.fn(async () => 1),
+  del: jest.fn(async (key) => (store.delete(key) ? 1 : 0))
+}
+
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn()
+}))
+
+jest.mock('../config/config', () => ({}), { virtual: true })
+
+jest.mock('../src/utils/webhookNotifier', () => ({
+  sendAccountAnomalyNotification: jest.fn(async () => undefined)
+}))
+
+jest.mock('../src/models/redis', () => ({
+  getClientSafe: jest.fn(() => mockClient),
+  getAccountUsageStats: jest.fn(async () => ({ daily: { cost: 0 } })),
+  getConsoleAccountConcurrency: jest.fn(async () => 0),
+  getDateStringInTimezone: jest.fn(() => '2026-09-04'),
+  getDateInTimezone: jest.fn(() => new Date(Date.UTC(2026, 8, 4, 10, 30, 0)))
+}))
+
+describe('Claude Console daily quota auto stop / auto recovery', () => {
+  let service
+  let redis
+
+  const seedAccount = (overrides = {}) => {
+    store.set(ACCOUNT_KEY, {
+      id: ACCOUNT_ID,
+      name: 'Console Quota Account',
+      apiUrl: 'https://console.example.com',
+      apiKey: '',
+      priority: '50',
+      supportedModels: '[]',
+      userAgent: '',
+      rateLimitDuration: '60',
+      proxy: '',
+      isActive: 'true',
+      accountType: 'shared',
+      status: 'active',
+      errorMessage: '',
+      schedulable: 'true',
+      dailyQuota: '10',
+      dailyUsage: '0',
+      quotaResetTime: '00:00',
+      lastResetDate: '2026-09-04',
+      quotaStoppedAt: '',
+      quotaAutoStopped: '',
+      rateLimitAutoStopped: '',
+      maxConcurrentTasks: '0',
+      ...overrides
+    })
+  }
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-09-04T10:30:00.000Z'))
+    store.clear()
+    seedAccount()
+    redis = require('../src/models/redis')
+    service = require('../src/services/account/claudeConsoleAccountService')
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  it('persists quotaAutoStopped marker when the daily quota is exceeded', async () => {
+    redis.getAccountUsageStats.mockResolvedValue({ daily: { cost: 12 } })
+
+    await service.checkQuotaUsage(ACCOUNT_ID)
+
+    const saved = store.get(ACCOUNT_KEY)
+    expect(saved.schedulable).toBe('false')
+    expect(saved.quotaAutoStopped).toBe('true')
+    expect(saved.quotaStoppedAt).toBeTruthy()
+  })
+
+  it('restores scheduling on the next day after the quota reset time', async () => {
+    redis.getAccountUsageStats.mockResolvedValue({ daily: { cost: 12 } })
+    await service.checkQuotaUsage(ACCOUNT_ID)
+    expect(store.get(ACCOUNT_KEY).schedulable).toBe('false')
+
+    // 进入第二天：上次重置日期为昨天，当前时间已过 00:00 重置点
+    store.get(ACCOUNT_KEY).lastResetDate = '2026-09-04'
+    redis.getDateStringInTimezone.mockReturnValue('2026-09-05')
+    redis.getDateInTimezone.mockReturnValue(new Date(Date.UTC(2026, 8, 5, 10, 30, 0)))
+
+    const exceeded = await service.isAccountQuotaExceeded(ACCOUNT_ID)
+
+    const saved = store.get(ACCOUNT_KEY)
+    expect(exceeded).toBe(false)
+    expect(saved.schedulable).toBe('true')
+    expect(saved.quotaStoppedAt).toBe('')
+    expect(saved.quotaAutoStopped).toBe('')
+    expect(saved.lastResetDate).toBe('2026-09-05')
+  })
+
+  it('still clears auto stop markers when scheduling is toggled manually', async () => {
+    seedAccount({
+      schedulable: 'false',
+      quotaAutoStopped: 'true',
+      rateLimitAutoStopped: 'true',
+      quotaStoppedAt: '2026-09-04T09:00:00.000Z'
+    })
+
+    await service.updateAccount(ACCOUNT_ID, { schedulable: false })
+
+    const saved = store.get(ACCOUNT_KEY)
+    expect(saved.schedulable).toBe('false')
+    expect(saved.quotaAutoStopped).toBe('')
+    expect(saved.rateLimitAutoStopped).toBe('')
+  })
+})

--- a/tests/groupQuotaEnforcement.test.js
+++ b/tests/groupQuotaEnforcement.test.js
@@ -1,0 +1,169 @@
+// Regression test: Claude Console accounts scheduled through a GROUP ignored dailyQuota.
+//
+// Bug: selectAccountFromGroup() never called claudeConsoleAccountService.checkQuotaUsage(),
+// so the only code that compares today's cost against dailyQuota (and stops the account)
+// ran exclusively on the shared-pool path and on upstream 429 responses. Group members
+// could therefore run unbounded over their daily quota.
+
+const mockConfig = { claude: {} }
+
+jest.mock('../config/config', () => mockConfig)
+jest.mock('../src/services/account/claudeAccountService', () => ({
+  isAccountRateLimited: jest.fn(),
+  isAccountModelRateLimited: jest.fn()
+}))
+jest.mock('../src/services/account/claudeConsoleAccountService', () => ({
+  getAccount: jest.fn(),
+  checkQuotaUsage: jest.fn(),
+  isAccountQuotaExceeded: jest.fn()
+}))
+jest.mock('../src/services/account/bedrockAccountService', () => ({}))
+jest.mock('../src/services/account/ccrAccountService', () => ({
+  getAccount: jest.fn(),
+  checkQuotaUsage: jest.fn(),
+  isAccountQuotaExceeded: jest.fn()
+}))
+jest.mock('../src/services/accountGroupService', () => ({
+  getGroup: jest.fn(),
+  getGroupMembers: jest.fn()
+}))
+jest.mock('../src/models/redis', () => ({
+  getClaudeAccount: jest.fn(),
+  getConsoleAccountConcurrency: jest.fn()
+}))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn()
+}))
+jest.mock('../src/utils/modelHelper', () => ({
+  parseVendorPrefixedModel: jest.fn((model) => ({ model })),
+  isOpus45OrNewer: jest.fn(() => false),
+  getRateLimitModelFamily: jest.fn(() => null)
+}))
+jest.mock('../src/utils/commonHelper', () => ({
+  isSchedulable: jest.fn((value) => value !== false && value !== 'false'),
+  // real behaviour: lower priority number wins
+  sortAccountsByPriority: jest.fn((accounts) =>
+    [...accounts].sort((a, b) => a.priority - b.priority)
+  )
+}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({}))
+
+const consoleAccount = (id, name, priority, dailyQuota) => ({
+  id,
+  name,
+  isActive: true,
+  status: 'active',
+  schedulable: true,
+  priority: String(priority),
+  dailyQuota: String(dailyQuota),
+  maxConcurrentTasks: 0
+})
+
+describe('group scheduling enforces Claude Console dailyQuota', () => {
+  let scheduler
+  let claudeConsoleAccountService
+  let accountGroupService
+  let redis
+  let tempSpy
+  let rateSpy
+
+  beforeEach(() => {
+    jest.resetModules()
+    // re-require after resetModules so the test and the scheduler share mock instances
+    claudeConsoleAccountService = require('../src/services/account/claudeConsoleAccountService')
+    accountGroupService = require('../src/services/accountGroupService')
+    redis = require('../src/models/redis')
+    scheduler = require('../src/services/scheduler/unifiedClaudeScheduler')
+
+    accountGroupService.getGroup.mockResolvedValue({
+      id: 'grp-1',
+      name: 'kimi-group',
+      platform: 'claude'
+    })
+    redis.getClaudeAccount.mockResolvedValue(null)
+    redis.getConsoleAccountConcurrency.mockResolvedValue(0)
+    claudeConsoleAccountService.checkQuotaUsage.mockResolvedValue({ success: true })
+    claudeConsoleAccountService.isAccountQuotaExceeded.mockResolvedValue(false)
+
+    tempSpy = jest.spyOn(scheduler, 'isAccountTemporarilyUnavailable').mockResolvedValue(false)
+    rateSpy = jest.spyOn(scheduler, 'isAccountRateLimited').mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    tempSpy.mockRestore()
+    rateSpy.mockRestore()
+    jest.clearAllMocks()
+  })
+
+  it('skips a quota-exceeded higher-priority member and selects the next one', async () => {
+    const a = consoleAccount('acct-a', 'kimi-a', 10, 60)
+    const b = consoleAccount('acct-b', 'kimi-b', 20, 60)
+    accountGroupService.getGroupMembers.mockResolvedValue([a.id, b.id])
+    claudeConsoleAccountService.getAccount.mockImplementation(async (id) =>
+      id === a.id ? a : id === b.id ? b : null
+    )
+    claudeConsoleAccountService.isAccountQuotaExceeded.mockImplementation(async (id) => id === a.id)
+
+    await expect(scheduler.selectAccountFromGroup('grp-1')).resolves.toEqual({
+      accountId: 'acct-b',
+      accountType: 'claude-console'
+    })
+    expect(claudeConsoleAccountService.checkQuotaUsage).toHaveBeenCalledWith('acct-a')
+  })
+
+  it('throws when every member is quota exceeded instead of returning one', async () => {
+    const a = consoleAccount('acct-a', 'kimi-a', 10, 60)
+    const b = consoleAccount('acct-b', 'kimi-b', 20, 60)
+    accountGroupService.getGroupMembers.mockResolvedValue([a.id, b.id])
+    claudeConsoleAccountService.getAccount.mockImplementation(async (id) =>
+      id === a.id ? a : id === b.id ? b : null
+    )
+    claudeConsoleAccountService.isAccountQuotaExceeded.mockResolvedValue(true)
+
+    await expect(scheduler.selectAccountFromGroup('grp-1')).rejects.toThrow(
+      /No available accounts in group kimi-group/
+    )
+  })
+
+  it('returns the single member unchanged when it is under quota', async () => {
+    const a = consoleAccount('acct-a', 'kimi-a', 10, 60)
+    accountGroupService.getGroupMembers.mockResolvedValue([a.id])
+    claudeConsoleAccountService.getAccount.mockResolvedValue(a)
+
+    await expect(scheduler.selectAccountFromGroup('grp-1')).resolves.toEqual({
+      accountId: 'acct-a',
+      accountType: 'claude-console'
+    })
+    expect(claudeConsoleAccountService.checkQuotaUsage).toHaveBeenCalledTimes(1)
+    expect(claudeConsoleAccountService.checkQuotaUsage).toHaveBeenCalledWith('acct-a')
+  })
+
+  it('does not check quota for members with dailyQuota = 0 (unlimited)', async () => {
+    const a = consoleAccount('acct-a', 'kimi-a', 10, 0)
+    accountGroupService.getGroupMembers.mockResolvedValue([a.id])
+    claudeConsoleAccountService.getAccount.mockResolvedValue(a)
+
+    await expect(scheduler.selectAccountFromGroup('grp-1')).resolves.toEqual({
+      accountId: 'acct-a',
+      accountType: 'claude-console'
+    })
+    expect(claudeConsoleAccountService.checkQuotaUsage).not.toHaveBeenCalled()
+    expect(claudeConsoleAccountService.isAccountQuotaExceeded).not.toHaveBeenCalled()
+  })
+
+  it('still selects the candidate when the quota check throws', async () => {
+    const a = consoleAccount('acct-a', 'kimi-a', 10, 60)
+    accountGroupService.getGroupMembers.mockResolvedValue([a.id])
+    claudeConsoleAccountService.getAccount.mockResolvedValue(a)
+    claudeConsoleAccountService.checkQuotaUsage.mockRejectedValue(new Error('redis down'))
+
+    await expect(scheduler.selectAccountFromGroup('grp-1')).resolves.toEqual({
+      accountId: 'acct-a',
+      accountType: 'claude-console'
+    })
+  })
+})


### PR DESCRIPTION
Claude Console 账户的「每日额度(dailyQuota)」功能存在一组相互叠加的缺陷，实际效果是额度基本不生效；而一旦生效，账户又无法自动恢复。本 PR 修四处，均限于两个文件。

## 问题现象

- 配了 dailyQuota 的账户可以远远超出上限继续服务（生产实测一个账户冲到 $179.50/$140；另一个账户累计 29840 次请求、`lastResetDate` 停在三个月前，从未被额度停用过）。
- 一旦被停用，后台看状态 active、无报错，只有"调度"是关闭的，**永远不会自动恢复**，只能手动打开。
- 手动打开"调度"后当天仍然不参与调度，要到次日重置点之后才真正放开。

## 根因与修复

### 1. `updateAccount` 丢弃自动停止标记(`c7668d49`)

`checkQuotaUsage` 超额时调用 `updateAccount(id, { ..., schedulable: false, quotaAutoStopped: 'true' })`。但 `updateAccount` 是白名单式逐字段拷贝，没有拷贝 `quotaAutoStopped`；且 `schedulable` 分支无条件写 `quotaAutoStopped = ''`（原意是"管理员手动改调度时清除自动标记"，但分不清自动与手动）。标记从未落库 → `resetDailyUsage` 恢复调度的条件 `quotaAutoStopped === 'true'` 永远不满足。

**修复**：让调用方显式传入的 `quotaAutoStopped` / `rateLimitAutoStopped` 落库；"手动开关调度"日志仅在未携带自动标记时打印；管理员手动修改 `schedulable`（不带标记）时行为不变。

### 2. `_shouldResetQuota` 时区双重偏移(`176e67e2`)

```js
const tzNow = redis.getDateInTimezone(new Date())   // 已 +8h
const today = redis.getDateStringInTimezone(tzNow)  // 内部再 +8h
```

`getDateStringInTimezone` 内部会再次调用 `getDateInTimezone`，"今天"被叠加 +16 小时。每天 16:00(UTC+8)之后算出的日期是明天，`lastResetDate === today` 永远不成立，后续时分判断在 00:00 重置时间下恒为 true → 每次检查都判定应重置，停用后数秒即被撤销。另外原逻辑只比较日期字符串与当前时分，从不检查"最近一次重置时间点是否晚于停用时刻"，因此 `lastResetDate` 陈旧时一天内首次停用也会被立刻撤销。

**修复**：`today` 用真实时间单次偏移；计算配置时区下最近一次重置时间点（今天的 `quotaResetTime`，未到则取昨天），换回真实时间轴后与 `quotaStoppedAt` 比较，仅当停用时刻早于该时间点才恢复；`quotaResetTime` 非法值回退 `00:00`。

### 3. 分组调度路径没有额度检测(`72ff4fae`)

`checkQuotaUsage` 是唯一执行"今日花费 vs dailyQuota"比较的代码，其调用点只有：relay 的三个 429 分支、`_getAllAvailableAccounts`（共享池，且要求 `accountType === 'shared'`）、以及粘性会话命中时的 `_isAccountAvailable`。**`selectAccountFromGroup()` 的成员枚举完全没有额度检测**；`_isAccountAvailable` 里的 `isAccountQuotaExceeded` 在 `quotaStoppedAt` 为空时直接返回 false（只能恢复已停用账户，无法发现新的超额）。

于是：通过分组调度、且客户端不产生 `sessionHash` 的账户，每次请求都走成员枚举，dailyQuota 形同失效，只有上游偶然返回 429 时才被顺带发现（生产上验证了这一点：44 个粘性会话映射无一指向该账户，而它当天服务了 555 次请求）。

**修复**：排序后按优先级惰性检查，只对即将选中的候选调一次额度检测，超额则跳到下一优先级；`claude-official` 跳过；检测异常用 try/catch 兜住并放行，不阻塞调度。开销为每请求 1 次，而非每请求 N 个成员。

### 4. 手动开启调度时未清除额度停用标记(`e7c621f5`)

修复 3 之后暴露出来的操作问题：因超额停用的账户，管理员在后台打开"调度"后，残留的 `quotaStoppedAt` 会让 `isAccountQuotaExceeded` 继续返回 true，账户在选号时仍被跳过。

**修复**：仅当本次是管理员手动开启（未携带自动停止标记且 `schedulable` 置为 true）且账户此前确实因额度停用时，一并清除 `quotaStoppedAt` 与 `errorMessage`。清除后下次选号会重新评估用量，若仍超过上限会立即再次停用，因此需先调高上限才能真正放开——这一行为符合预期。

## 测试

- `tests/claudeConsoleQuotaRecovery.test.js`（13 个用例）：标记落库、跨天恢复、傍晚停用不误重置、`lastResetDate` 陈旧不误重置、自定义 08:00 重置时间的三种边界、手动开启/关闭与自动变更对标记的处理。
- `tests/groupQuotaEnforcement.test.js`（5 个用例）：高优先级超额时落到下一个、全部超额时抛错、未超额行为不变、`dailyQuota = 0` 不触发检查、检测抛异常仍可调度。

每一处修复都有在修复前失败的回归用例（redis 时区 mock 忠实复现 `src/models/redis.js` 的偏移语义，否则测不出缺陷 2）。

```
npm run lint:check  → 无告警
npm test            → Test Suites: 27 passed / Tests: 294 passed, 8 skipped
```

## 补充

- `ccrAccountService.js` 的额度停用只用 `quotaStoppedAt` 门控、无 `_shouldResetQuota`，不受缺陷 1/2 影响；修复 3 已同时覆盖分组中的 CCR 成员。
- 另发现一处未在本 PR 处理的小问题：`updateAccount` 不处理 `updates.errorMessage`，因此 `checkQuotaUsage` 传入的 "Daily quota exceeded: $X / $Y" 和 `resetDailyUsage` 传入的清空都会被静默丢弃（后台看不到停用原因）。如维护者认为合适，可另行补一个字段透传。
- 前三处修复已在生产环境（v1.1.314，多个 Console 账户配置 dailyQuota，通过分组调度）以单文件覆盖方式验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
