### PR TITLE
fix(openai): 把 Codex 容量降载当作可重试的请求级瞬时故障，改写致命错误码

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,15 @@ TRUST_PROXY=true
 # UPSTREAM_ERROR_AUTH_TTL_SECONDS=1800        # 401/403认证错误暂停时间（默认30分钟）
 # UPSTREAM_ERROR_TIMEOUT_TTL_SECONDS=300      # 504超时暂停时间（默认5分钟）
 
+# 🧯 Codex/OpenAI 容量降载（capacity shed）同账号重试（可选）
+# 上游 server_is_overloaded / slow_down / "Selected model is at capacity…" 是请求级瞬时信号，
+# 换账号无用。默认在同一账号上最多尝试 3 次（500ms / 1s / 2s 退避），用尽后把错误码改写为
+# server_error，让 Codex CLI 走内置退避而不是直接终止会话。
+# OPENAI_CAPACITY_SHED_MAX_ATTEMPTS=3     # 同账号最大尝试次数（含首次）
+# OPENAI_CAPACITY_SHED_MAX_DELAY_MS=8000  # 单次退避上限（也用于裁剪 Retry-After）
+# OPENAI_CAPACITY_SHED_BUFFER_BYTES=262144 # 首个真实输出前的 SSE 缓冲字节上限
+# OPENAI_CAPACITY_SHED_BUFFER_MS=15000     # 首个真实输出前的 SSE 缓冲时间上限
+
 # 🔒 客户端限制（可选）
 # ALLOW_CUSTOM_CLIENTS=false
 # Claude Code 系统提示词最少匹配条目数

--- a/config/config.example.js
+++ b/config/config.example.js
@@ -108,6 +108,17 @@ const config = {
   // ⏱️ 请求超时配置
   requestTimeout: parseInt(process.env.REQUEST_TIMEOUT) || 600000, // 默认 10 分钟
 
+  // 🧯 Codex/OpenAI 容量降载（capacity shed）同账号有界重试
+  // 上游 server_is_overloaded / slow_down / "Selected model is at capacity…" 是请求级
+  // 瞬时信号，换账号无用；这里控制同账号重试次数、退避上限，以及首个真实输出出现前
+  // 的 SSE 缓冲上限（字节 / 时间）
+  openaiCapacityShed: {
+    maxAttempts: parseInt(process.env.OPENAI_CAPACITY_SHED_MAX_ATTEMPTS) || 3,
+    maxDelayMs: parseInt(process.env.OPENAI_CAPACITY_SHED_MAX_DELAY_MS) || 8000,
+    bufferLimitBytes: parseInt(process.env.OPENAI_CAPACITY_SHED_BUFFER_BYTES) || 256 * 1024,
+    preOutputBufferMs: parseInt(process.env.OPENAI_CAPACITY_SHED_BUFFER_MS) || 15000
+  },
+
   // 📈 使用限制
   limits: {
     defaultTokenLimit: parseInt(process.env.DEFAULT_TOKEN_LIMIT) || 1000000

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -14,6 +14,20 @@ const crypto = require('crypto')
 const ProxyHelper = require('../utils/proxyHelper')
 const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
 const { IncrementalSSEParser } = require('../utils/sseParser')
+const {
+  RETRYABLE_CLIENT_CODE,
+  computeRetryDelayMs,
+  extractErrorCode,
+  extractErrorMessage,
+  isCapacityShedEvent,
+  isCapacityShedResponse,
+  resolveSettings: resolveCapacityShedSettings
+} = require('../utils/openaiCapacityShed')
+const {
+  delay,
+  pipeWithCapacityShedBuffer,
+  readUpstreamBody
+} = require('../utils/openaiCapacityShedStream')
 const { getSafeMessage } = require('../utils/errorSanitizer')
 const {
   createRequestDetailMeta,
@@ -454,225 +468,6 @@ const handleResponses = async (req, res) => {
       ? 'https://chatgpt.com/backend-api/codex/responses/compact'
       : 'https://chatgpt.com/backend-api/codex/responses'
 
-    // 根据 stream 参数决定请求类型
-    if (isStream) {
-      // 流式请求
-      upstream = await axios.post(codexEndpoint, req.body, {
-        ...axiosConfig,
-        responseType: 'stream'
-      })
-    } else {
-      // 非流式请求
-      upstream = await axios.post(codexEndpoint, req.body, axiosConfig)
-    }
-
-    const codexUsageSnapshot = extractCodexUsageHeaders(upstream.headers)
-    if (codexUsageSnapshot) {
-      try {
-        await openaiAccountService.updateCodexUsageSnapshot(accountId, codexUsageSnapshot)
-      } catch (codexError) {
-        logger.error('⚠️ 更新 Codex 使用统计失败:', codexError)
-      }
-    }
-
-    // 处理 429 限流错误
-    if (upstream.status === 429) {
-      logger.warn(`🚫 Rate limit detected for OpenAI account ${accountId} (Codex API)`)
-
-      // 解析响应体中的限流信息
-      let resetsInSeconds = null
-      let errorData = null
-
-      try {
-        // 对于429错误，无论是否是流式请求，响应都会是完整的JSON错误对象
-        if (isStream && upstream.data) {
-          // 流式响应需要先收集数据
-          const chunks = []
-          await new Promise((resolve, reject) => {
-            upstream.data.on('data', (chunk) => chunks.push(chunk))
-            upstream.data.on('end', resolve)
-            upstream.data.on('error', reject)
-            // 设置超时防止无限等待
-            setTimeout(resolve, 5000)
-          })
-
-          const fullResponse = Buffer.concat(chunks).toString()
-          try {
-            errorData = JSON.parse(fullResponse)
-          } catch (e) {
-            logger.error('Failed to parse 429 error response:', e)
-            logger.debug('Raw response:', fullResponse)
-          }
-        } else {
-          // 非流式响应直接使用data
-          errorData = upstream.data
-        }
-
-        // 提取重置时间
-        if (errorData && errorData.error && errorData.error.resets_in_seconds) {
-          resetsInSeconds = errorData.error.resets_in_seconds
-          logger.info(
-            `🕐 Codex rate limit will reset in ${resetsInSeconds} seconds (${Math.ceil(resetsInSeconds / 60)} minutes / ${Math.ceil(resetsInSeconds / 3600)} hours)`
-          )
-        } else {
-          logger.warn(
-            '⚠️ Could not extract resets_in_seconds from 429 response, using default 60 minutes'
-          )
-        }
-      } catch (e) {
-        logger.error('⚠️ Failed to parse rate limit error:', e)
-      }
-
-      // 标记账户为限流状态
-      await unifiedOpenAIScheduler.markAccountRateLimited(
-        accountId,
-        'openai',
-        sessionHash,
-        resetsInSeconds
-      )
-
-      // 返回错误响应给客户端
-      const errorResponse = errorData || {
-        error: {
-          type: 'usage_limit_reached',
-          message: 'The usage limit has been reached',
-          resets_in_seconds: resetsInSeconds
-        }
-      }
-
-      if (isStream) {
-        // 流式响应也需要设置正确的状态码
-        res.status(429)
-        res.setHeader('Content-Type', 'text/event-stream')
-        res.setHeader('Cache-Control', 'no-cache')
-        res.setHeader('Connection', 'keep-alive')
-        res.write(`data: ${JSON.stringify(errorResponse)}\n\n`)
-        res.end()
-      } else {
-        res.status(429).json(errorResponse)
-      }
-
-      return
-    } else if (upstream.status === 401 || upstream.status === 402) {
-      const unauthorizedStatus = upstream.status
-      const statusDescription = unauthorizedStatus === 401 ? 'Unauthorized' : 'Payment required'
-      logger.warn(
-        `🔐 ${statusDescription} error detected for OpenAI account ${accountId} (Codex API)`
-      )
-
-      let errorData = null
-
-      try {
-        if (isStream && upstream.data && typeof upstream.data.on === 'function') {
-          const chunks = []
-          await new Promise((resolve, reject) => {
-            upstream.data.on('data', (chunk) => chunks.push(chunk))
-            upstream.data.on('end', resolve)
-            upstream.data.on('error', reject)
-            setTimeout(resolve, 5000)
-          })
-
-          const fullResponse = Buffer.concat(chunks).toString()
-          try {
-            errorData = JSON.parse(fullResponse)
-          } catch (parseError) {
-            logger.error(`Failed to parse ${unauthorizedStatus} error response:`, parseError)
-            logger.debug(`Raw ${unauthorizedStatus} response:`, fullResponse)
-            errorData = { error: { message: fullResponse || 'Unauthorized' } }
-          }
-        } else {
-          errorData = upstream.data
-        }
-      } catch (parseError) {
-        logger.error(`⚠️ Failed to handle ${unauthorizedStatus} error response:`, parseError)
-      }
-
-      const statusLabel = unauthorizedStatus === 401 ? '401错误' : '402错误'
-      const extraHint = unauthorizedStatus === 402 ? '，可能欠费' : ''
-      let reason = `OpenAI账号认证失败（${statusLabel}${extraHint}）`
-      if (errorData) {
-        const messageCandidate =
-          errorData.error &&
-          typeof errorData.error.message === 'string' &&
-          errorData.error.message.trim()
-            ? errorData.error.message.trim()
-            : typeof errorData.message === 'string' && errorData.message.trim()
-              ? errorData.message.trim()
-              : null
-        if (messageCandidate) {
-          reason = `OpenAI账号认证失败（${statusLabel}${extraHint}）：${messageCandidate}`
-        }
-      }
-
-      try {
-        await unifiedOpenAIScheduler.markAccountUnauthorized(
-          accountId,
-          'openai',
-          sessionHash,
-          reason
-        )
-      } catch (markError) {
-        logger.error(
-          `❌ Failed to mark OpenAI account unauthorized after ${unauthorizedStatus}:`,
-          markError
-        )
-      }
-
-      let errorResponse = errorData
-      if (!errorResponse || typeof errorResponse !== 'object' || Buffer.isBuffer(errorResponse)) {
-        const fallbackMessage =
-          typeof errorData === 'string' && errorData.trim() ? errorData.trim() : 'Unauthorized'
-        errorResponse = {
-          error: {
-            message: fallbackMessage,
-            type: 'unauthorized',
-            code: 'unauthorized'
-          }
-        }
-      }
-
-      res.status(unauthorizedStatus).json(errorResponse)
-      return
-    } else if (upstream.status === 200 || upstream.status === 201) {
-      // 请求成功，检查并移除限流状态
-      const isRateLimited = await unifiedOpenAIScheduler.isAccountRateLimited(accountId)
-      if (isRateLimited) {
-        logger.info(
-          `✅ Removing rate limit for OpenAI account ${accountId} after successful request`
-        )
-        await unifiedOpenAIScheduler.removeAccountRateLimit(accountId, 'openai')
-      }
-    }
-
-    res.status(upstream.status)
-
-    if (isStream) {
-      // 流式响应头
-      res.setHeader('Content-Type', 'text/event-stream')
-      res.setHeader('Cache-Control', 'no-cache')
-      res.setHeader('Connection', 'keep-alive')
-      res.setHeader('X-Accel-Buffering', 'no')
-    } else {
-      // 非流式响应头
-      res.setHeader('Content-Type', 'application/json')
-    }
-
-    // 透传关键诊断头，避免传递不安全或与传输相关的头
-    const passThroughHeaderKeys = ['openai-version', 'x-request-id', 'openai-processing-ms']
-    for (const key of passThroughHeaderKeys) {
-      const val = upstream.headers?.[key]
-      if (val !== undefined) {
-        res.setHeader(key, val)
-      }
-    }
-
-    if (isStream) {
-      // 立即刷新响应头，开始 SSE
-      if (typeof res.flushHeaders === 'function') {
-        res.flushHeaders()
-      }
-    }
-
     // 处理响应并捕获 usage 数据和真实的 model
     let usageData = null
     let actualModel = null
@@ -680,78 +475,8 @@ const handleResponses = async (req, res) => {
     let rateLimitDetected = false
     let rateLimitResetsInSeconds = null
 
-    if (!isStream) {
-      // 非流式响应处理
-      try {
-        logger.info(`📄 Processing OpenAI non-stream response for model: ${upstreamRequestedModel}`)
-
-        // 直接获取完整响应
-        const responseData = upstream.data
-
-        // 从响应中获取实际的 model 和 usage
-        actualModel = responseData.model || upstreamRequestedModel || 'gpt-4'
-        usageData = responseData.usage
-
-        logger.debug(`📊 Non-stream response - Model: ${actualModel}, Usage:`, usageData)
-
-        // 记录使用统计
-        if (usageData) {
-          const totalInputTokens = usageData.input_tokens || usageData.prompt_tokens || 0
-          const outputTokens = usageData.output_tokens || usageData.completion_tokens || 0
-          const cacheReadTokens = extractOpenAICacheReadTokens(usageData)
-          // 计算实际输入token（总输入减去缓存部分）
-          const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
-
-          const nonStreamCosts = await apiKeyService.recordUsage(
-            apiKeyData.id,
-            actualInputTokens, // 传递实际输入（不含缓存）
-            outputTokens,
-            0, // OpenAI没有cache_creation_tokens
-            cacheReadTokens,
-            actualModel,
-            accountId,
-            'openai',
-            req._serviceTier,
-            createRequestDetailMeta(req, {
-              requestBody: req.body,
-              stream: false,
-              statusCode: upstream.status
-            })
-          )
-
-          logger.info(
-            `📊 Recorded OpenAI non-stream usage - Input: ${totalInputTokens}(actual:${actualInputTokens}+cached:${cacheReadTokens}), Output: ${outputTokens}, Total: ${usageData.total_tokens || totalInputTokens + outputTokens}, Model: ${actualModel}`
-          )
-
-          await applyRateLimitTracking(
-            req,
-            {
-              inputTokens: actualInputTokens,
-              outputTokens,
-              cacheCreateTokens: 0,
-              cacheReadTokens
-            },
-            actualModel,
-            'openai-non-stream',
-            'openai',
-            nonStreamCosts
-          )
-        }
-
-        // 返回响应
-        res.json(responseData)
-        return
-      } catch (error) {
-        logger.error('Failed to process non-stream response:', error)
-        if (!res.headersSent) {
-          res.status(500).json({ error: { message: 'Failed to process response' } })
-        }
-        return
-      }
-    }
-
-    // 使用增量 SSE 解析器
-    const sseParser = new IncrementalSSEParser()
+    // 使用增量 SSE 解析器（每次上游尝试重建一次）
+    let sseParser = new IncrementalSSEParser()
 
     // 处理解析出的事件
     const processSSEEvent = (eventData) => {
@@ -781,27 +506,462 @@ const handleResponses = async (req, res) => {
         }
       }
     }
+    const feedUsageParser = (text) => {
+      const events = sseParser.feed(text)
+      for (const event of events) {
+        if (event.type === 'data' && event.data) {
+          processSSEEvent(event.data)
+        }
+      }
+    }
 
-    upstream.data.on('data', (chunk) => {
+    // 响应头惰性提交：容量降载重试期间不能先把状态码和 SSE 头写出去，
+    // 否则一旦重试成功就再也改不了响应状态了
+    let responseHeadersCommitted = false
+    const commitResponseHeaders = () => {
+      if (responseHeadersCommitted) {
+        return
+      }
+      responseHeadersCommitted = true
+
+      res.status(upstream.status)
+
+      if (isStream) {
+        // 流式响应头
+        res.setHeader('Content-Type', 'text/event-stream')
+        res.setHeader('Cache-Control', 'no-cache')
+        res.setHeader('Connection', 'keep-alive')
+        res.setHeader('X-Accel-Buffering', 'no')
+      } else {
+        // 非流式响应头
+        res.setHeader('Content-Type', 'application/json')
+      }
+
+      // 透传关键诊断头，避免传递不安全或与传输相关的头
+      const passThroughHeaderKeys = ['openai-version', 'x-request-id', 'openai-processing-ms']
+      for (const key of passThroughHeaderKeys) {
+        const val = upstream.headers?.[key]
+        if (val !== undefined) {
+          res.setHeader(key, val)
+        }
+      }
+
+      if (isStream) {
+        // 立即刷新响应头，开始 SSE
+        if (typeof res.flushHeaders === 'function') {
+          res.flushHeaders()
+        }
+      }
+    }
+
+    // 客户端断开时清理上游流（仅流式路径需要，监听器在首次进入流转发前注册一次）
+    let abortListenersBound = false
+    const cleanup = () => {
       try {
-        // 转发数据给客户端
-        if (!res.destroyed) {
-          res.write(chunk)
+        upstream?.data?.unpipe?.(res)
+        upstream?.data?.destroy?.()
+      } catch (_) {
+        //
+      }
+    }
+    const bindAbortListeners = () => {
+      if (abortListenersBound) {
+        return
+      }
+      abortListenersBound = true
+      req.on('close', cleanup)
+      req.on('aborted', cleanup)
+    }
+    // 断线判据只能看 res。Node 在请求体读完后会自动销毁 request 流，所以
+    // req.destroyed 和 req 的 'close' 在每个 POST 上开局几毫秒内就为真 —— 拿它们
+    // 判断客户端是否还在必然全是误判，重试会被整体跳过。
+    const isClientGone = () =>
+      res.writableEnded !== true && (res.destroyed === true || res.writable === false)
+
+    // 🧯 容量降载（capacity shed）同账号有界重试
+    // 上游在模型容量紧张时返回 server_is_overloaded / slow_down / "Selected model is at
+    // capacity…"。Codex CLI 把前两个码判为致命并直接结束回合，而这是请求级瞬时信号：
+    // 换账号不改变降载因素，只会让一个请求把整池账号逐个消耗掉。所以先在同一账号上
+    // 重试，用尽后再把错误码改写成 server_error 让客户端自己退避。
+    const shedSettings = resolveCapacityShedSettings(config.openaiCapacityShed)
+    let attempt = 0
+
+    for (;;) {
+      attempt += 1
+      usageData = null
+      actualModel = null
+      usageReported = false
+      rateLimitDetected = false
+      rateLimitResetsInSeconds = null
+      sseParser = new IncrementalSSEParser()
+
+      // 根据 stream 参数决定请求类型
+      if (isStream) {
+        // 流式请求
+        upstream = await axios.post(codexEndpoint, req.body, {
+          ...axiosConfig,
+          responseType: 'stream'
+        })
+      } else {
+        // 非流式请求
+        upstream = await axios.post(codexEndpoint, req.body, axiosConfig)
+      }
+
+      const codexUsageSnapshot = extractCodexUsageHeaders(upstream.headers)
+      if (codexUsageSnapshot) {
+        try {
+          await openaiAccountService.updateCodexUsageSnapshot(accountId, codexUsageSnapshot)
+        } catch (codexError) {
+          logger.error('⚠️ 更新 Codex 使用统计失败:', codexError)
+        }
+      }
+
+      // 处理 429 限流错误
+      if (upstream.status === 429) {
+        logger.warn(`🚫 Rate limit detected for OpenAI account ${accountId} (Codex API)`)
+
+        // 解析响应体中的限流信息
+        let resetsInSeconds = null
+        let errorData = null
+
+        try {
+          // 对于429错误，无论是否是流式请求，响应都会是完整的JSON错误对象
+          if (isStream && upstream.data) {
+            // 流式响应需要先收集数据
+            const chunks = []
+            await new Promise((resolve, reject) => {
+              upstream.data.on('data', (chunk) => chunks.push(chunk))
+              upstream.data.on('end', resolve)
+              upstream.data.on('error', reject)
+              // 设置超时防止无限等待
+              setTimeout(resolve, 5000)
+            })
+
+            const fullResponse = Buffer.concat(chunks).toString()
+            try {
+              errorData = JSON.parse(fullResponse)
+            } catch (e) {
+              logger.error('Failed to parse 429 error response:', e)
+              logger.debug('Raw response:', fullResponse)
+            }
+          } else {
+            // 非流式响应直接使用data
+            errorData = upstream.data
+          }
+
+          // 提取重置时间
+          if (errorData && errorData.error && errorData.error.resets_in_seconds) {
+            resetsInSeconds = errorData.error.resets_in_seconds
+            logger.info(
+              `🕐 Codex rate limit will reset in ${resetsInSeconds} seconds (${Math.ceil(resetsInSeconds / 60)} minutes / ${Math.ceil(resetsInSeconds / 3600)} hours)`
+            )
+          } else {
+            logger.warn(
+              '⚠️ Could not extract resets_in_seconds from 429 response, using default 60 minutes'
+            )
+          }
+        } catch (e) {
+          logger.error('⚠️ Failed to parse rate limit error:', e)
         }
 
-        // 使用增量解析器处理数据
-        const events = sseParser.feed(chunk.toString())
-        for (const event of events) {
-          if (event.type === 'data' && event.data) {
-            processSSEEvent(event.data)
+        // 标记账户为限流状态
+        await unifiedOpenAIScheduler.markAccountRateLimited(
+          accountId,
+          'openai',
+          sessionHash,
+          resetsInSeconds
+        )
+
+        // 返回错误响应给客户端
+        const errorResponse = errorData || {
+          error: {
+            type: 'usage_limit_reached',
+            message: 'The usage limit has been reached',
+            resets_in_seconds: resetsInSeconds
           }
         }
-      } catch (error) {
-        logger.error('Error processing OpenAI stream chunk:', error)
-      }
-    })
 
-    upstream.data.on('end', async () => {
+        if (isStream) {
+          // 流式响应也需要设置正确的状态码
+          res.status(429)
+          res.setHeader('Content-Type', 'text/event-stream')
+          res.setHeader('Cache-Control', 'no-cache')
+          res.setHeader('Connection', 'keep-alive')
+          res.write(`data: ${JSON.stringify(errorResponse)}\n\n`)
+          res.end()
+        } else {
+          res.status(429).json(errorResponse)
+        }
+
+        return
+      } else if (upstream.status === 401 || upstream.status === 402) {
+        const unauthorizedStatus = upstream.status
+        const statusDescription = unauthorizedStatus === 401 ? 'Unauthorized' : 'Payment required'
+        logger.warn(
+          `🔐 ${statusDescription} error detected for OpenAI account ${accountId} (Codex API)`
+        )
+
+        let errorData = null
+
+        try {
+          if (isStream && upstream.data && typeof upstream.data.on === 'function') {
+            const chunks = []
+            await new Promise((resolve, reject) => {
+              upstream.data.on('data', (chunk) => chunks.push(chunk))
+              upstream.data.on('end', resolve)
+              upstream.data.on('error', reject)
+              setTimeout(resolve, 5000)
+            })
+
+            const fullResponse = Buffer.concat(chunks).toString()
+            try {
+              errorData = JSON.parse(fullResponse)
+            } catch (parseError) {
+              logger.error(`Failed to parse ${unauthorizedStatus} error response:`, parseError)
+              logger.debug(`Raw ${unauthorizedStatus} response:`, fullResponse)
+              errorData = { error: { message: fullResponse || 'Unauthorized' } }
+            }
+          } else {
+            errorData = upstream.data
+          }
+        } catch (parseError) {
+          logger.error(`⚠️ Failed to handle ${unauthorizedStatus} error response:`, parseError)
+        }
+
+        const statusLabel = unauthorizedStatus === 401 ? '401错误' : '402错误'
+        const extraHint = unauthorizedStatus === 402 ? '，可能欠费' : ''
+        let reason = `OpenAI账号认证失败（${statusLabel}${extraHint}）`
+        if (errorData) {
+          const messageCandidate =
+            errorData.error &&
+            typeof errorData.error.message === 'string' &&
+            errorData.error.message.trim()
+              ? errorData.error.message.trim()
+              : typeof errorData.message === 'string' && errorData.message.trim()
+                ? errorData.message.trim()
+                : null
+          if (messageCandidate) {
+            reason = `OpenAI账号认证失败（${statusLabel}${extraHint}）：${messageCandidate}`
+          }
+        }
+
+        try {
+          await unifiedOpenAIScheduler.markAccountUnauthorized(
+            accountId,
+            'openai',
+            sessionHash,
+            reason
+          )
+        } catch (markError) {
+          logger.error(
+            `❌ Failed to mark OpenAI account unauthorized after ${unauthorizedStatus}:`,
+            markError
+          )
+        }
+
+        let errorResponse = errorData
+        if (!errorResponse || typeof errorResponse !== 'object' || Buffer.isBuffer(errorResponse)) {
+          const fallbackMessage =
+            typeof errorData === 'string' && errorData.trim() ? errorData.trim() : 'Unauthorized'
+          errorResponse = {
+            error: {
+              message: fallbackMessage,
+              type: 'unauthorized',
+              code: 'unauthorized'
+            }
+          }
+        }
+
+        res.status(unauthorizedStatus).json(errorResponse)
+        return
+      } else if (upstream.status === 200 || upstream.status === 201) {
+        // 请求成功，检查并移除限流状态
+        const isRateLimited = await unifiedOpenAIScheduler.isAccountRateLimited(accountId)
+        if (isRateLimited) {
+          logger.info(
+            `✅ Removing rate limit for OpenAI account ${accountId} after successful request`
+          )
+          await unifiedOpenAIScheduler.removeAccountRateLimit(accountId, 'openai')
+        }
+      }
+
+      // ---- 容量降载判定（HTTP 层）----
+      if (upstream.status >= 400 || (!isStream && isCapacityShedEvent(upstream.data))) {
+        const upstreamBody = await readUpstreamBody(upstream, isStream)
+        const upstreamRequestId = upstream.headers?.['x-request-id'] || 'n/a'
+
+        if (
+          isCapacityShedResponse({
+            status: upstream.status,
+            payload: upstreamBody.payload,
+            rawBody: upstreamBody.rawBody
+          })
+        ) {
+          const shedCode = extractErrorCode(upstreamBody.payload) || 'n/a'
+          const shedMessage =
+            extractErrorMessage(upstreamBody.payload) || (upstreamBody.rawBody || '').trim()
+
+          if (attempt < shedSettings.maxAttempts && !isClientGone()) {
+            const delayMs = computeRetryDelayMs(
+              attempt,
+              upstream.headers?.['retry-after'],
+              shedSettings
+            )
+            logger.warn(
+              `⚠️ codex.capacity_shed_retry account=${accountId} attempt=${attempt}/${shedSettings.maxAttempts} status=${upstream.status} delay=${delayMs}ms request_id=${upstreamRequestId} code=${shedCode}`
+            )
+            await delay(delayMs)
+            continue
+          }
+
+          // 重试用尽（或客户端已断开）：把致命码改写成 server_error 再回给客户端，
+          // Codex 会走内置退避重试而不是打印 "Selected model is at capacity…" 后退出
+          logger.warn(
+            `⚠️ codex.capacity_shed_rewrite account=${accountId} attempts=${attempt} status=${upstream.status} request_id=${upstreamRequestId} code=${shedCode}->${RETRYABLE_CLIENT_CODE}`
+          )
+          if (!res.headersSent) {
+            res.status(503).json({
+              error: {
+                type: 'server_error',
+                code: RETRYABLE_CLIENT_CODE,
+                message:
+                  shedMessage || 'Upstream service is temporarily overloaded, please retry later'
+              }
+            })
+          }
+          return
+        }
+
+        if (upstreamBody.drained) {
+          // 流式请求上的非降载错误响应：上游流已被读空，按原字节回写
+          commitResponseHeaders()
+          if (upstreamBody.rawBody) {
+            res.write(upstreamBody.rawBody)
+          }
+          res.end()
+          return
+        }
+      }
+
+      if (!isStream) {
+        // 非流式响应处理
+        commitResponseHeaders()
+        try {
+          logger.info(
+            `📄 Processing OpenAI non-stream response for model: ${upstreamRequestedModel}`
+          )
+
+          // 直接获取完整响应
+          const responseData = upstream.data
+
+          // 从响应中获取实际的 model 和 usage
+          actualModel = responseData.model || upstreamRequestedModel || 'gpt-4'
+          usageData = responseData.usage
+
+          logger.debug(`📊 Non-stream response - Model: ${actualModel}, Usage:`, usageData)
+
+          // 记录使用统计
+          if (usageData) {
+            const totalInputTokens = usageData.input_tokens || usageData.prompt_tokens || 0
+            const outputTokens = usageData.output_tokens || usageData.completion_tokens || 0
+            const cacheReadTokens = extractOpenAICacheReadTokens(usageData)
+            // 计算实际输入token（总输入减去缓存部分）
+            const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
+
+            const nonStreamCosts = await apiKeyService.recordUsage(
+              apiKeyData.id,
+              actualInputTokens, // 传递实际输入（不含缓存）
+              outputTokens,
+              0, // OpenAI没有cache_creation_tokens
+              cacheReadTokens,
+              actualModel,
+              accountId,
+              'openai',
+              req._serviceTier,
+              createRequestDetailMeta(req, {
+                requestBody: req.body,
+                stream: false,
+                statusCode: upstream.status
+              })
+            )
+
+            logger.info(
+              `📊 Recorded OpenAI non-stream usage - Input: ${totalInputTokens}(actual:${actualInputTokens}+cached:${cacheReadTokens}), Output: ${outputTokens}, Total: ${usageData.total_tokens || totalInputTokens + outputTokens}, Model: ${actualModel}`
+            )
+
+            await applyRateLimitTracking(
+              req,
+              {
+                inputTokens: actualInputTokens,
+                outputTokens,
+                cacheCreateTokens: 0,
+                cacheReadTokens
+              },
+              actualModel,
+              'openai-non-stream',
+              'openai',
+              nonStreamCosts
+            )
+          }
+
+          // 返回响应
+          res.json(responseData)
+          return
+        } catch (error) {
+          logger.error('Failed to process non-stream response:', error)
+          if (!res.headersSent) {
+            res.status(500).json({ error: { message: 'Failed to process response' } })
+          }
+          return
+        }
+      }
+      bindAbortListeners()
+
+      // 缓冲式转发上游 SSE：客户端收到真实输出前先把事件攒住，
+      // 期间命中降载即可丢弃缓冲并在同账号上重试；重试用尽时由缓冲器改写错误码
+      const streamResult = await pipeWithCapacityShedBuffer({
+        stream: upstream.data,
+        res,
+        onEventText: feedUsageParser,
+        commitHeaders: commitResponseHeaders,
+        retryEnabled: attempt < shedSettings.maxAttempts && !isClientGone(),
+        bufferLimitBytes: shedSettings.bufferLimitBytes,
+        preOutputBufferMs: shedSettings.preOutputBufferMs,
+        onShedRewrite: ({ outputStarted }) => {
+          logger.warn(
+            `⚠️ codex.capacity_shed_rewrite account=${accountId} attempts=${attempt} stream_output_started=${outputStarted} code=->${RETRYABLE_CLIENT_CODE}`
+          )
+          if (outputStarted) {
+            logger.warn(
+              `⚠️ codex.capacity_shed_suppressed_after_output account=${accountId} attempts=${attempt}`
+            )
+          }
+        }
+      })
+
+      if (streamResult.outcome === 'shed' && attempt < shedSettings.maxAttempts) {
+        const delayMs = computeRetryDelayMs(
+          attempt,
+          upstream.headers?.['retry-after'],
+          shedSettings
+        )
+        logger.warn(
+          `⚠️ codex.capacity_shed_retry account=${accountId} attempt=${attempt}/${shedSettings.maxAttempts} stream=1 delay=${delayMs}ms request_id=${upstream.headers?.['x-request-id'] || 'n/a'} code=${extractErrorCode(streamResult.shedPayload) || 'n/a'}`
+        )
+        await delay(delayMs)
+        continue
+      }
+
+      if (streamResult.outcome === 'error') {
+        logger.error('Upstream stream error:', streamResult.error)
+        if (!res.headersSent) {
+          res.status(502).json({ error: { message: 'Upstream stream error' } })
+        } else {
+          res.end()
+        }
+        return
+      }
+
       // 处理剩余的 buffer
       const remaining = sseParser.getRemaining()
       if (remaining.trim()) {
@@ -886,28 +1046,8 @@ const handleResponses = async (req, res) => {
       }
 
       res.end()
-    })
-
-    upstream.data.on('error', (err) => {
-      logger.error('Upstream stream error:', err)
-      if (!res.headersSent) {
-        res.status(502).json({ error: { message: 'Upstream stream error' } })
-      } else {
-        res.end()
-      }
-    })
-
-    // 客户端断开时清理上游流
-    const cleanup = () => {
-      try {
-        upstream.data?.unpipe?.(res)
-        upstream.data?.destroy?.()
-      } catch (_) {
-        //
-      }
+      return
     }
-    req.on('close', cleanup)
-    req.on('aborted', cleanup)
   } catch (error) {
     logger.error('Proxy to ChatGPT codex/responses failed:', error)
     // 优先使用主动设置的 statusCode，然后是上游响应的状态码，最后默认 500

--- a/src/services/relay/openaiResponsesRelayService.js
+++ b/src/services/relay/openaiResponsesRelayService.js
@@ -13,6 +13,20 @@ const {
   createRequestDetailMeta,
   extractOpenAICacheReadTokens
 } = require('../../utils/requestDetailHelper')
+const {
+  RETRYABLE_CLIENT_CODE,
+  computeRetryDelayMs,
+  extractErrorCode,
+  extractErrorMessage,
+  isCapacityShedEvent,
+  isCapacityShedResponse,
+  resolveSettings: resolveCapacityShedSettings
+} = require('../../utils/openaiCapacityShed')
+const {
+  delay,
+  pipeWithCapacityShedBuffer,
+  readUpstreamBody
+} = require('../../utils/openaiCapacityShedStream')
 
 // lastUsedAt 更新节流（每账户 60 秒内最多更新一次，使用 LRU 防止内存泄漏）
 const lastUsedAtThrottle = new LRUCache(1000) // 最多缓存 1000 个账户
@@ -175,8 +189,77 @@ class OpenAIResponsesRelayService {
         userAgent: headers['User-Agent'] || 'not set'
       })
 
-      // 发送请求
-      const response = await axios(requestOptions)
+      // 🧯 容量降载（capacity shed）同账号有界重试
+      // 上游 server_is_overloaded / slow_down / "Selected model is at capacity…" 是请求级
+      // 瞬时信号：换账号不改变降载因素，只会把整池账号逐个消耗掉，且绝不能因此摘号。
+      const shedSettings = resolveCapacityShedSettings(config.openaiCapacityShed)
+      const isStreamRequest = Boolean(req.body?.stream)
+      // 断线判据只能看 res：Node 在请求体读完后会自动销毁 request 流，req.destroyed
+      // 在每个 POST 上开局就为真，用它判断客户端是否还在会让重试永远不触发。
+      const isClientGone = () =>
+        res.writableEnded !== true && (res.destroyed === true || res.writable === false)
+      let attempt = 0
+      let response = null
+      let upstreamBody = null
+
+      // eslint-disable-next-line no-constant-condition
+      for (;;) {
+        attempt += 1
+        upstreamBody = null
+
+        // 发送请求
+        response = await axios(requestOptions)
+
+        if (response.status === 429) {
+          break
+        }
+
+        if (response.status < 400 && !(!isStreamRequest && isCapacityShedEvent(response.data))) {
+          break
+        }
+
+        upstreamBody = await readUpstreamBody(response, isStreamRequest)
+        if (
+          !isCapacityShedResponse({
+            status: response.status,
+            payload: upstreamBody.payload,
+            rawBody: upstreamBody.rawBody
+          })
+        ) {
+          break
+        }
+
+        const shedCode = extractErrorCode(upstreamBody.payload) || 'n/a'
+        const shedMessage =
+          extractErrorMessage(upstreamBody.payload) || (upstreamBody.rawBody || '').trim()
+
+        if (attempt < shedSettings.maxAttempts && !isClientGone()) {
+          const delayMs = computeRetryDelayMs(
+            attempt,
+            response.headers?.['retry-after'],
+            shedSettings
+          )
+          logger.warn(
+            `⚠️ codex.capacity_shed_retry account=${account.id} attempt=${attempt}/${shedSettings.maxAttempts} status=${response.status} delay=${delayMs}ms code=${shedCode}`
+          )
+          await delay(delayMs)
+          continue
+        }
+
+        // 重试用尽：改写错误码后回给客户端；降载是请求级信号，绝不摘号
+        logger.warn(
+          `⚠️ codex.capacity_shed_rewrite account=${account.id} attempts=${attempt} status=${response.status} code=${shedCode}->${RETRYABLE_CLIENT_CODE}`
+        )
+        req.removeListener('close', handleClientDisconnect)
+        res.removeListener('close', handleClientDisconnect)
+        return res.status(503).json({
+          error: {
+            type: 'server_error',
+            code: RETRYABLE_CLIENT_CODE,
+            message: shedMessage || 'Upstream service is temporarily overloaded, please retry later'
+          }
+        })
+      }
 
       // 处理 429 限流错误
       if (response.status === 429) {
@@ -214,41 +297,10 @@ class OpenAIResponsesRelayService {
 
       // 处理其他错误状态码
       if (response.status >= 400) {
-        // 处理流式错误响应
-        let errorData = response.data
-        if (response.data && typeof response.data.pipe === 'function') {
-          // 流式响应需要先读取内容
-          const chunks = []
-          await new Promise((resolve) => {
-            response.data.on('data', (chunk) => chunks.push(chunk))
-            response.data.on('end', resolve)
-            response.data.on('error', resolve)
-            setTimeout(resolve, 5000) // 超时保护
-          })
-          const fullResponse = Buffer.concat(chunks).toString()
-
-          // 尝试解析错误响应
-          try {
-            if (fullResponse.includes('data: ')) {
-              // SSE格式
-              const lines = fullResponse.split('\n')
-              for (const line of lines) {
-                if (line.startsWith('data: ')) {
-                  const jsonStr = line.slice(6).trim()
-                  if (jsonStr && jsonStr !== '[DONE]') {
-                    errorData = JSON.parse(jsonStr)
-                    break
-                  }
-                }
-              }
-            } else {
-              // 普通JSON
-              errorData = JSON.parse(fullResponse)
-            }
-          } catch (e) {
-            logger.error('Failed to parse error response:', e)
-            errorData = { error: { message: fullResponse || 'Unknown error' } }
-          }
+        // 响应体已在降载判定阶段读取（流式错误响应也已读空，不能再 pipe）
+        let errorData = upstreamBody?.payload || response.data
+        if (upstreamBody?.drained && !upstreamBody.payload) {
+          errorData = { error: { message: upstreamBody.rawBody || 'Unknown error' } }
         }
 
         logger.error('OpenAI-Responses API error', {
@@ -341,15 +393,53 @@ class OpenAIResponsesRelayService {
 
       // 处理流式响应
       if (req.body?.stream && response.data && typeof response.data.pipe === 'function') {
-        return this._handleStreamResponse(
-          response,
-          res,
-          account,
-          apiKeyData,
-          req.body?.model,
-          handleClientDisconnect,
-          req
-        )
+        // eslint-disable-next-line no-constant-condition
+        for (;;) {
+          const outcome = await this._handleStreamResponse(
+            response,
+            res,
+            account,
+            apiKeyData,
+            req.body?.model,
+            handleClientDisconnect,
+            req,
+            { attempt, settings: shedSettings, isClientGone }
+          )
+
+          if (outcome !== 'shed' || attempt >= shedSettings.maxAttempts) {
+            return
+          }
+
+          // 流内降载：同账号重试，客户端还没收到任何字节
+          const delayMs = computeRetryDelayMs(
+            attempt,
+            response.headers?.['retry-after'],
+            shedSettings
+          )
+          logger.warn(
+            `⚠️ codex.capacity_shed_retry account=${account.id} attempt=${attempt}/${shedSettings.maxAttempts} stream=1 delay=${delayMs}ms`
+          )
+          await delay(delayMs)
+          attempt += 1
+          response = await axios(requestOptions)
+
+          if (
+            response.status >= 400 ||
+            !response.data ||
+            typeof response.data.pipe !== 'function'
+          ) {
+            // 重试后不再是可转发的 200 流：交回给客户端一个可重试的错误
+            req.removeListener('close', handleClientDisconnect)
+            res.removeListener('close', handleClientDisconnect)
+            return res.status(503).json({
+              error: {
+                type: 'server_error',
+                code: RETRYABLE_CLIENT_CODE,
+                message: 'Upstream service is temporarily overloaded, please retry later'
+              }
+            })
+          }
+        }
       }
 
       // 处理非流式响应
@@ -473,6 +563,16 @@ class OpenAIResponsesRelayService {
   }
 
   // 处理流式响应
+  /**
+   * 缓冲式转发上游 SSE。
+   *
+   * 上游降载（server_is_overloaded / slow_down）会在 HTTP 200 之后立刻推 error 帧，
+   * 一旦写给客户端，Codex CLI 就地终止会话。因此在出现真实输出之前先把事件攒住：
+   * 命中降载则返回 'shed'，由 handleRequest 在同一账号上重试；重试用尽时把错误码
+   * 改写成 server_error 再转发，让客户端走内置退避。
+   *
+   * @returns {Promise<'completed'|'shed'|'error'>}
+   */
   async _handleStreamResponse(
     response,
     res,
@@ -480,20 +580,33 @@ class OpenAIResponsesRelayService {
     apiKeyData,
     requestedModel,
     handleClientDisconnect,
-    req
+    req,
+    shedContext = {}
   ) {
-    // 设置 SSE 响应头
-    res.setHeader('Content-Type', 'text/event-stream')
-    res.setHeader('Cache-Control', 'no-cache')
-    res.setHeader('Connection', 'keep-alive')
-    res.setHeader('X-Accel-Buffering', 'no')
+    const {
+      attempt = 1,
+      settings = resolveCapacityShedSettings(config.openaiCapacityShed),
+      isClientGone = () => false
+    } = shedContext
+
+    // SSE 响应头惰性提交：降载重试期间不能先把头写出去
+    let headersCommitted = false
+    const commitHeaders = () => {
+      if (headersCommitted) {
+        return
+      }
+      headersCommitted = true
+      res.setHeader('Content-Type', 'text/event-stream')
+      res.setHeader('Cache-Control', 'no-cache')
+      res.setHeader('Connection', 'keep-alive')
+      res.setHeader('X-Accel-Buffering', 'no')
+    }
 
     let usageData = null
     let actualModel = null
     let buffer = ''
     let rateLimitDetected = false
     let rateLimitResetsInSeconds = null
-    let streamEnded = false
 
     // 解析 SSE 事件以捕获 usage 数据和 model
     const parseSSEForUsage = (data) => {
@@ -551,160 +664,22 @@ class OpenAIResponsesRelayService {
         }
       }
     }
-
-    // 监听数据流
-    response.data.on('data', (chunk) => {
-      try {
-        const chunkStr = chunk.toString()
-
-        // 转发数据给客户端
-        if (!res.destroyed && !streamEnded) {
-          res.write(chunk)
-        }
-
-        // 同时解析数据以捕获 usage 信息
-        buffer += chunkStr
-
-        // 处理完整的 SSE 事件
-        if (buffer.includes('\n\n')) {
-          const events = buffer.split('\n\n')
-          buffer = events.pop() || ''
-
-          for (const event of events) {
-            if (event.trim()) {
-              parseSSEForUsage(event)
-            }
-          }
-        }
-      } catch (error) {
-        logger.error('Error processing stream chunk:', error)
+    const feedUsageParser = (text) => {
+      buffer += text
+      if (!buffer.includes('\n\n')) {
+        return
       }
-    })
-
-    response.data.on('end', async () => {
-      streamEnded = true
-
-      // 处理剩余的 buffer
-      if (buffer.trim()) {
-        parseSSEForUsage(buffer)
-      }
-
-      // 记录使用统计
-      if (usageData) {
-        try {
-          // OpenAI-Responses 使用 input_tokens/output_tokens，标准 OpenAI 使用 prompt_tokens/completion_tokens
-          const totalInputTokens = usageData.input_tokens || usageData.prompt_tokens || 0
-          const outputTokens = usageData.output_tokens || usageData.completion_tokens || 0
-
-          // 提取缓存相关的 tokens（如果存在）
-          const cacheReadTokens = extractOpenAICacheReadTokens(usageData)
-          const cacheCreateTokens = extractCacheCreationTokens(usageData)
-          // 计算实际输入token（总输入减去缓存部分）
-          const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
-
-          const totalTokens =
-            usageData.total_tokens || totalInputTokens + outputTokens + cacheCreateTokens
-          const modelToRecord = actualModel || requestedModel || 'gpt-4'
-
-          const serviceTier = req._serviceTier || null
-          await apiKeyService.recordUsage(
-            apiKeyData.id,
-            actualInputTokens, // 传递实际输入（不含缓存）
-            outputTokens,
-            cacheCreateTokens,
-            cacheReadTokens,
-            modelToRecord,
-            account.id,
-            'openai-responses',
-            serviceTier,
-            createRequestDetailMeta(req, {
-              requestBody: req.body,
-              stream: true,
-              statusCode: res.statusCode
-            })
-          )
-
-          logger.info(
-            `📊 Recorded usage - Input: ${totalInputTokens}(actual:${actualInputTokens}+cached:${cacheReadTokens}), CacheCreate: ${cacheCreateTokens}, Output: ${outputTokens}, Total: ${totalTokens}, Model: ${modelToRecord}`
-          )
-
-          // 更新账户的 token 使用统计
-          await openaiResponsesAccountService.updateAccountUsage(account.id, totalTokens)
-
-          // 更新账户使用额度（如果设置了额度限制）
-          if (parseFloat(account.dailyQuota) > 0) {
-            // 使用CostCalculator正确计算费用（考虑缓存token的不同价格）
-            const CostCalculator = require('../../utils/costCalculator')
-            const costInfo = CostCalculator.calculateCost(
-              {
-                input_tokens: actualInputTokens, // 实际输入（不含缓存）
-                output_tokens: outputTokens,
-                cache_creation_input_tokens: cacheCreateTokens,
-                cache_read_input_tokens: cacheReadTokens
-              },
-              modelToRecord,
-              serviceTier
-            )
-            await openaiResponsesAccountService.updateUsageQuota(account.id, costInfo.costs.total)
-          }
-        } catch (error) {
-          logger.error('Failed to record usage:', error)
+      const events = buffer.split('\n\n')
+      buffer = events.pop() || ''
+      for (const event of events) {
+        if (event.trim()) {
+          parseSSEForUsage(event)
         }
       }
-
-      // 如果在流式响应中检测到限流
-      if (rateLimitDetected) {
-        // 使用统一调度器处理限流（与非流式响应保持一致）
-        const sessionId = req.headers['session_id'] || req.body?.session_id
-        const sessionHash = sessionId
-          ? crypto.createHash('sha256').update(sessionId).digest('hex')
-          : null
-
-        await unifiedOpenAIScheduler.markAccountRateLimited(
-          account.id,
-          'openai-responses',
-          sessionHash,
-          rateLimitResetsInSeconds
-        )
-
-        logger.warn(
-          `🚫 Processing rate limit for OpenAI-Responses account ${account.id} from stream`
-        )
-      }
-
-      // 清理监听器
-      req.removeListener('close', handleClientDisconnect)
-      res.removeListener('close', handleClientDisconnect)
-
-      if (!res.destroyed) {
-        res.end()
-      }
-
-      logger.info('Stream response completed', {
-        accountId: account.id,
-        hasUsage: !!usageData,
-        actualModel: actualModel || 'unknown'
-      })
-    })
-
-    response.data.on('error', (error) => {
-      streamEnded = true
-      logger.error('Stream error:', error)
-
-      // 清理监听器
-      req.removeListener('close', handleClientDisconnect)
-      res.removeListener('close', handleClientDisconnect)
-
-      if (!res.headersSent) {
-        res.status(502).json({ error: { message: 'Upstream stream error' } })
-      } else if (!res.destroyed) {
-        res.end()
-      }
-    })
+    }
 
     // 处理客户端断开连接
     const cleanup = () => {
-      streamEnded = true
       try {
         response.data?.unpipe?.(res)
         response.data?.destroy?.()
@@ -715,6 +690,148 @@ class OpenAIResponsesRelayService {
 
     req.on('close', cleanup)
     req.on('aborted', cleanup)
+
+    const streamResult = await pipeWithCapacityShedBuffer({
+      stream: response.data,
+      res,
+      onEventText: feedUsageParser,
+      commitHeaders,
+      retryEnabled: attempt < settings.maxAttempts && !isClientGone(),
+      bufferLimitBytes: settings.bufferLimitBytes,
+      preOutputBufferMs: settings.preOutputBufferMs,
+      onShedRewrite: ({ outputStarted }) => {
+        logger.warn(
+          `⚠️ codex.capacity_shed_rewrite account=${account.id} attempts=${attempt} stream_output_started=${outputStarted} code=->${RETRYABLE_CLIENT_CODE}`
+        )
+        if (outputStarted) {
+          logger.warn(
+            `⚠️ codex.capacity_shed_suppressed_after_output account=${account.id} attempts=${attempt}`
+          )
+        }
+      }
+    })
+
+    if (streamResult.outcome === 'shed' && attempt < settings.maxAttempts) {
+      req.removeListener('close', cleanup)
+      req.removeListener('aborted', cleanup)
+      return 'shed'
+    }
+
+    if (streamResult.outcome === 'error') {
+      logger.error('Stream error:', streamResult.error)
+
+      // 清理监听器
+      req.removeListener('close', handleClientDisconnect)
+      res.removeListener('close', handleClientDisconnect)
+
+      if (!res.headersSent) {
+        res.status(502).json({ error: { message: 'Upstream stream error' } })
+      } else if (!res.destroyed) {
+        res.end()
+      }
+      return 'error'
+    }
+
+    // 处理剩余的 buffer
+    if (buffer.trim()) {
+      parseSSEForUsage(buffer)
+    }
+
+    // 记录使用统计
+    if (usageData) {
+      try {
+        // OpenAI-Responses 使用 input_tokens/output_tokens，标准 OpenAI 使用 prompt_tokens/completion_tokens
+        const totalInputTokens = usageData.input_tokens || usageData.prompt_tokens || 0
+        const outputTokens = usageData.output_tokens || usageData.completion_tokens || 0
+
+        // 提取缓存相关的 tokens（如果存在）
+        const cacheReadTokens = extractOpenAICacheReadTokens(usageData)
+        const cacheCreateTokens = extractCacheCreationTokens(usageData)
+        // 计算实际输入token（总输入减去缓存部分）
+        const actualInputTokens = Math.max(0, totalInputTokens - cacheReadTokens)
+
+        const totalTokens =
+          usageData.total_tokens || totalInputTokens + outputTokens + cacheCreateTokens
+        const modelToRecord = actualModel || requestedModel || 'gpt-4'
+
+        const serviceTier = req._serviceTier || null
+        await apiKeyService.recordUsage(
+          apiKeyData.id,
+          actualInputTokens, // 传递实际输入（不含缓存）
+          outputTokens,
+          cacheCreateTokens,
+          cacheReadTokens,
+          modelToRecord,
+          account.id,
+          'openai-responses',
+          serviceTier,
+          createRequestDetailMeta(req, {
+            requestBody: req.body,
+            stream: true,
+            statusCode: res.statusCode
+          })
+        )
+
+        logger.info(
+          `📊 Recorded usage - Input: ${totalInputTokens}(actual:${actualInputTokens}+cached:${cacheReadTokens}), CacheCreate: ${cacheCreateTokens}, Output: ${outputTokens}, Total: ${totalTokens}, Model: ${modelToRecord}`
+        )
+
+        // 更新账户的 token 使用统计
+        await openaiResponsesAccountService.updateAccountUsage(account.id, totalTokens)
+
+        // 更新账户使用额度（如果设置了额度限制）
+        if (parseFloat(account.dailyQuota) > 0) {
+          // 使用CostCalculator正确计算费用（考虑缓存token的不同价格）
+          const CostCalculator = require('../../utils/costCalculator')
+          const costInfo = CostCalculator.calculateCost(
+            {
+              input_tokens: actualInputTokens, // 实际输入（不含缓存）
+              output_tokens: outputTokens,
+              cache_creation_input_tokens: cacheCreateTokens,
+              cache_read_input_tokens: cacheReadTokens
+            },
+            modelToRecord,
+            serviceTier
+          )
+          await openaiResponsesAccountService.updateUsageQuota(account.id, costInfo.costs.total)
+        }
+      } catch (error) {
+        logger.error('Failed to record usage:', error)
+      }
+    }
+
+    // 如果在流式响应中检测到限流
+    if (rateLimitDetected) {
+      // 使用统一调度器处理限流（与非流式响应保持一致）
+      const sessionId = req.headers['session_id'] || req.body?.session_id
+      const sessionHash = sessionId
+        ? crypto.createHash('sha256').update(sessionId).digest('hex')
+        : null
+
+      await unifiedOpenAIScheduler.markAccountRateLimited(
+        account.id,
+        'openai-responses',
+        sessionHash,
+        rateLimitResetsInSeconds
+      )
+
+      logger.warn(`🚫 Processing rate limit for OpenAI-Responses account ${account.id} from stream`)
+    }
+    // 清理监听器
+    req.removeListener('close', handleClientDisconnect)
+    res.removeListener('close', handleClientDisconnect)
+
+    if (!res.destroyed) {
+      res.end()
+    }
+
+    logger.info('Stream response completed', {
+      accountId: account.id,
+      hasUsage: !!usageData,
+      actualModel: actualModel || 'unknown'
+    })
+
+    return 'completed'
   }
 
   // 处理非流式响应

--- a/src/utils/openaiCapacityShed.js
+++ b/src/utils/openaiCapacityShed.js
@@ -1,0 +1,484 @@
+/**
+ * Codex / OpenAI 容量降载（capacity shed）识别与改写工具
+ *
+ * 背景：ChatGPT Codex 后端在模型容量紧张时会把请求丢进「降载」路径，返回
+ * `error.code = server_is_overloaded` 或 `slow_down`。Codex CLI 按错误码闭集
+ * 分类（codex-rs/codex-api/src/sse/responses.rs 的 is_server_overloaded_error），
+ * 这两个码会被映射成 CodexErr::ServerOverloaded，而 CodexErr::is_retryable()
+ * 对它返回 false —— 客户端直接打印
+ * "Selected model is at capacity. Please try a different model." 并结束当前回合。
+ *
+ * 降载是**请求级**信号，不是账号级故障：换账号并不改变被降载的因素（模型容量、
+ * 后端负载都与账号无关），只会让一个请求把整池账号逐个消耗掉。因此正确做法是
+ * 在同一账号上做有界重试；重试用尽后把错误码改写成客户端可重试的 server_error，
+ * 让 Codex 走内置退避而不是就地终止。
+ *
+ * 行为参考实现：sub2api（openai_gateway_upstream_errors.go / openai_gateway_passthrough.go）。
+ *
+ * 本模块只包含纯函数，不依赖 config / redis / logger，便于单测。
+ *
+ * @module openaiCapacityShed
+ */
+
+// 上游降载错误码闭集，与 Codex CLI 的致命集一致
+const CAPACITY_SHED_CODES = new Set(['server_is_overloaded', 'slow_down'])
+
+// 改写后交给客户端的错误码：Codex 对 server_error 执行内置退避重试
+const RETRYABLE_CLIENT_CODE = 'server_error'
+
+// 降载消息特征（大小写不敏感）
+const CAPACITY_SHED_MESSAGE_MARKERS = [
+  'server is overloaded',
+  'servers are overloaded',
+  'servers are currently overloaded'
+]
+
+// 仅在 HTTP 400 上生效的「瞬时处理失败」特征
+const TRANSIENT_400_MARKERS = [
+  'selected model is at capacity',
+  'an error occurred while processing your request'
+]
+const TRANSIENT_400_REQUEST_ID_MARKERS = [
+  'you can retry your request',
+  'help.openai.com',
+  'request id'
+]
+
+// SSE preamble 事件：只是握手，不构成客户端输出
+const PREAMBLE_EVENT_TYPES = new Set(['response.created', 'response.in_progress'])
+
+const DEFAULT_SETTINGS = {
+  maxAttempts: 3,
+  retryDelaysMs: [500, 1000, 2000],
+  maxDelayMs: 8000,
+  bufferLimitBytes: 256 * 1024,
+  // 预输出缓冲的时间上限。降载在 HTTP 200 之后一两秒内就会到达，所以这个窗口
+  // 不影响识别率；但它保证 CRS 不会长时间对客户端一言不发 —— nginx 之类的反向
+  // 代理 proxy_read_timeout 默认只有 60s，超时会直接掐断连接。
+  preOutputBufferMs: 15000
+}
+
+function toLowerTrimmed(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * 按 `a.b.c` 取值，任一层不是对象即返回 undefined
+ */
+function getPath(payload, path) {
+  if (!isPlainObject(payload)) {
+    return undefined
+  }
+  let current = payload
+  for (const segment of path.split('.')) {
+    if (!isPlainObject(current)) {
+      return undefined
+    }
+    current = current[segment]
+  }
+  return current
+}
+
+function getStringAt(payload, path) {
+  const value = getPath(payload, path)
+  return typeof value === 'string' ? value : ''
+}
+
+/**
+ * 提取降载判定用的错误码（小写），兼容 response.failed 的嵌套形态与裸 error 形态
+ * @param {Object} payload
+ * @returns {string}
+ */
+function extractErrorCode(payload) {
+  const nested = toLowerTrimmed(getStringAt(payload, 'response.error.code'))
+  if (nested) {
+    return nested
+  }
+  return toLowerTrimmed(getStringAt(payload, 'error.code'))
+}
+
+/**
+ * 提取错误消息，按 error.message → response.error.message → message 顺序
+ * @param {Object} payload
+ * @returns {string}
+ */
+function extractErrorMessage(payload) {
+  for (const path of ['error.message', 'response.error.message', 'message']) {
+    const value = getStringAt(payload, path)
+    if (value.trim()) {
+      return value.trim()
+    }
+  }
+  return ''
+}
+
+/**
+ * 消息是否命中降载特征
+ * @param {string} text
+ * @returns {boolean}
+ */
+function isCapacityShedMessage(text) {
+  const lower = toLowerTrimmed(text)
+  if (!lower) {
+    return false
+  }
+  return CAPACITY_SHED_MESSAGE_MARKERS.some((marker) => lower.includes(marker))
+}
+
+/**
+ * 判断一个已解析的 JSON / SSE 事件负载是否为降载信号。
+ *
+ * 只看结构化错误字段（error.* / response.error.* / 顶层 message），
+ * 不扫描整个 JSON —— 用户内容可能原样回显这些短语。
+ *
+ * @param {Object} payload 已解析的对象
+ * @returns {boolean}
+ */
+function isCapacityShedEvent(payload) {
+  if (!isPlainObject(payload)) {
+    return false
+  }
+  if (CAPACITY_SHED_CODES.has(extractErrorCode(payload))) {
+    return true
+  }
+  for (const path of ['error.message', 'response.error.message', 'message']) {
+    if (isCapacityShedMessage(getStringAt(payload, path))) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * HTTP 400 专属的瞬时处理失败判定（"Selected model is at capacity…" 等）
+ * @param {number} status
+ * @param {Object|null} payload 已解析的对象，非 JSON 时传 null
+ * @param {string} rawBody 原始响应体（仅在 payload 为 null 时参与判定）
+ * @returns {boolean}
+ */
+function isTransientProcessing400(status, payload, rawBody = '') {
+  if (status !== 400) {
+    return false
+  }
+  const match = (text) => {
+    const lower = toLowerTrimmed(text)
+    if (!lower) {
+      return false
+    }
+    if (TRANSIENT_400_MARKERS.some((marker) => lower.includes(marker))) {
+      return true
+    }
+    return TRANSIENT_400_REQUEST_ID_MARKERS.every((marker) => lower.includes(marker))
+  }
+
+  if (isPlainObject(payload)) {
+    return (
+      match(getStringAt(payload, 'error.message')) ||
+      match(getStringAt(payload, 'response.error.message')) ||
+      match(getStringAt(payload, 'message'))
+    )
+  }
+  // 非 JSON 响应体（纯文本错误页）才允许整体扫描
+  return match(rawBody)
+}
+
+/**
+ * 顶层判定：一次 HTTP 响应是否为容量降载
+ *
+ * @param {Object} options
+ * @param {number} options.status HTTP 状态码
+ * @param {Object|null} options.payload 已解析的响应体对象（无法解析时传 null）
+ * @param {string} [options.rawBody] 原始响应体文本
+ * @returns {boolean}
+ */
+function isCapacityShedResponse({ status, payload, rawBody = '' }) {
+  if (isCapacityShedEvent(payload)) {
+    return true
+  }
+  if (!isPlainObject(payload) && isCapacityShedMessage(rawBody)) {
+    return true
+  }
+  return isTransientProcessing400(status, payload, rawBody)
+}
+
+/**
+ * 把降载错误码改写为客户端可重试的 server_error。
+ *
+ * 只改 `error.code` / `response.error.code`，且只在原值属于降载闭集
+ * （或缺失但消息命中降载特征）时改写。消息原样保留；
+ * rate_limit_exceeded 等其它错误码一律不动 —— 客户端依赖原码解析重试延时。
+ *
+ * @param {Object} payload
+ * @returns {{ payload: Object, changed: boolean }}
+ */
+function rewriteCapacityShedCode(payload) {
+  if (!isCapacityShedEvent(payload)) {
+    return { payload, changed: false }
+  }
+
+  let changed = false
+  let cloned = null
+  for (const parentPath of ['response.error', 'error']) {
+    const parent = getPath(payload, parentPath)
+    if (!isPlainObject(parent)) {
+      continue
+    }
+    const code = toLowerTrimmed(typeof parent.code === 'string' ? parent.code : '')
+    if (code && !CAPACITY_SHED_CODES.has(code)) {
+      continue
+    }
+    if (!cloned) {
+      cloned = JSON.parse(JSON.stringify(payload))
+    }
+    getPath(cloned, parentPath).code = RETRYABLE_CLIENT_CODE
+    changed = true
+  }
+
+  return changed ? { payload: cloned, changed: true } : { payload, changed: false }
+}
+
+/**
+ * SSE 事件是否构成「客户端已收到真实输出」。
+ *
+ * 一旦判定为已开始输出，重试就不再安全（客户端已经看到部分内容），
+ * 缓冲也必须立即下发。降载 error / response.failed 帧不算输出：
+ * 把它当首输出下发，Codex 就地终止，重试机会随之消失。
+ *
+ * @param {Object|null} data 已解析的事件负载（[DONE] 传 null）
+ * @param {string} eventType SSE event 名（缺省时回退到 data.type）
+ * @returns {boolean}
+ */
+function streamDataStartsClientOutput(data, eventType) {
+  const type =
+    (eventType && eventType.trim()) || (isPlainObject(data) ? toLowerTrimmed(data.type) : '')
+
+  // data: [DONE]
+  if (!isPlainObject(data)) {
+    return true
+  }
+
+  switch (type) {
+    case 'error':
+    case 'response.failed':
+      // 降载帧要留给重试；其它错误（内容策略、invalid_request 等）原样立即转发
+      return !isCapacityShedEvent(data)
+    case 'response.output_item.added':
+      return outputItemStartsClientOutput(data.item)
+    case 'response.content_part.added':
+    case 'response.reasoning_summary_part.added':
+      return partStartsClientOutput(data.part, type)
+    default:
+      return !PREAMBLE_EVENT_TYPES.has(type)
+  }
+}
+
+function outputItemStartsClientOutput(item) {
+  if (!isPlainObject(item)) {
+    return true
+  }
+  switch (toLowerTrimmed(item.type)) {
+    case 'reasoning':
+      if (typeof item.encrypted_content === 'string' && item.encrypted_content !== '') {
+        return true
+      }
+      if (!Array.isArray(item.summary)) {
+        return false
+      }
+      return item.summary.some(
+        (part) =>
+          !isPlainObject(part) ||
+          toLowerTrimmed(part.type) !== 'summary_text' ||
+          (typeof part.text === 'string' && part.text !== '')
+      )
+    case 'message':
+      if (!Array.isArray(item.content)) {
+        return false
+      }
+      return item.content.some((part) => {
+        if (!isPlainObject(part)) {
+          return true
+        }
+        switch (toLowerTrimmed(part.type)) {
+          case 'output_text':
+            return typeof part.text === 'string' && part.text !== ''
+          case 'refusal':
+            return typeof part.refusal === 'string' && part.refusal !== ''
+          default:
+            return true
+        }
+      })
+    case 'function_call':
+      return typeof item.arguments === 'string' && item.arguments !== ''
+    case 'custom_tool_call':
+      return typeof item.input === 'string' && item.input !== ''
+    case 'compaction':
+      return typeof item.encrypted_content === 'string' && item.encrypted_content !== ''
+    default:
+      return true
+  }
+}
+
+function partStartsClientOutput(part, eventType) {
+  if (!isPlainObject(part)) {
+    return true
+  }
+  const partType = toLowerTrimmed(part.type)
+  if (eventType === 'response.reasoning_summary_part.added') {
+    if (partType !== 'summary_text') {
+      return true
+    }
+    return typeof part.text === 'string' && part.text !== ''
+  }
+  switch (partType) {
+    case 'output_text':
+      return typeof part.text === 'string' && part.text !== ''
+    case 'refusal':
+      return typeof part.refusal === 'string' && part.refusal !== ''
+    default:
+      return true
+  }
+}
+
+/**
+ * 计算下一次重试前的等待时间
+ *
+ * @param {number} attempt 已完成的尝试次数（1 表示首次请求刚失败）
+ * @param {string|number|null} retryAfterHeader 上游 Retry-After 头
+ * @param {Object} [settings]
+ * @returns {number} 毫秒
+ */
+function computeRetryDelayMs(attempt, retryAfterHeader = null, settings = DEFAULT_SETTINGS) {
+  const { retryDelaysMs, maxDelayMs } = { ...DEFAULT_SETTINGS, ...settings }
+  const index = Math.min(Math.max(attempt, 1), retryDelaysMs.length) - 1
+  let delay = retryDelaysMs[index]
+
+  const retryAfterSeconds = Number.parseFloat(retryAfterHeader)
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+    const retryAfterMs = Math.round(retryAfterSeconds * 1000)
+    // 只在上游给出的等待时间落在预算内时采纳，避免一个头把请求挂死
+    if (retryAfterMs <= maxDelayMs) {
+      delay = Math.max(delay, retryAfterMs)
+    }
+  }
+
+  return Math.min(delay, maxDelayMs)
+}
+
+/**
+ * 解析 SSE 事件块（以空行分隔的一段文本）
+ *
+ * @param {string} block
+ * @returns {{ eventType: string, dataLines: string[], jsonStr: string, data: Object|null, isDone: boolean }}
+ */
+function parseSSEBlock(block) {
+  let eventType = ''
+  const dataLines = []
+
+  for (const rawLine of block.split('\n')) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+    if (line.startsWith('event:')) {
+      eventType = line.slice(6).trim()
+    } else if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trim())
+    }
+  }
+
+  const jsonStr = dataLines.join('\n')
+  if (!jsonStr) {
+    return { eventType, dataLines, jsonStr, data: null, isDone: false }
+  }
+  if (jsonStr === '[DONE]') {
+    return { eventType, dataLines, jsonStr, data: null, isDone: true }
+  }
+
+  let data = null
+  try {
+    data = JSON.parse(jsonStr)
+  } catch (_) {
+    data = null
+  }
+  return { eventType, dataLines, jsonStr, data, isDone: false }
+}
+
+/**
+ * 对一个 SSE 事件块中的降载错误码做改写，返回新的块文本。
+ * 未命中降载时原样返回（不重排字段、不重写空白）。
+ *
+ * @param {string} block
+ * @returns {{ block: string, changed: boolean }}
+ */
+function rewriteCapacityShedSSEBlock(block) {
+  const parsed = parseSSEBlock(block)
+  if (!parsed.data) {
+    return { block, changed: false }
+  }
+  const { payload, changed } = rewriteCapacityShedCode(parsed.data)
+  if (!changed) {
+    return { block, changed: false }
+  }
+
+  const rewrittenJson = JSON.stringify(payload)
+  const lines = block.split('\n')
+  let replaced = false
+  const out = lines.map((rawLine) => {
+    const hasCR = rawLine.endsWith('\r')
+    const line = hasCR ? rawLine.slice(0, -1) : rawLine
+    if (!line.startsWith('data:') || replaced) {
+      return rawLine
+    }
+    replaced = true
+    return `data: ${rewrittenJson}${hasCR ? '\r' : ''}`
+  })
+
+  return { block: out.join('\n'), changed: true }
+}
+
+/**
+ * 合并运行期配置与默认值
+ *
+ * @param {Object} [overrides] 来自 config.openaiCapacityShed 的覆盖项
+ * @returns {{maxAttempts:number, retryDelaysMs:number[], maxDelayMs:number, bufferLimitBytes:number}}
+ */
+function resolveSettings(overrides = null) {
+  const merged = { ...DEFAULT_SETTINGS }
+  if (!isPlainObject(overrides)) {
+    return merged
+  }
+  for (const key of ['maxAttempts', 'maxDelayMs', 'bufferLimitBytes', 'preOutputBufferMs']) {
+    const value = Number(overrides[key])
+    if (Number.isFinite(value) && value > 0) {
+      merged[key] = Math.floor(value)
+    }
+  }
+  if (Array.isArray(overrides.retryDelaysMs) && overrides.retryDelaysMs.length > 0) {
+    const delays = overrides.retryDelaysMs
+      .map((value) => Number(value))
+      .filter((value) => Number.isFinite(value) && value >= 0)
+    if (delays.length > 0) {
+      merged.retryDelaysMs = delays
+    }
+  }
+  return merged
+}
+
+module.exports = {
+  CAPACITY_SHED_CODES,
+  RETRYABLE_CLIENT_CODE,
+  DEFAULT_SETTINGS,
+  computeRetryDelayMs,
+  extractErrorCode,
+  extractErrorMessage,
+  isCapacityShedEvent,
+  isCapacityShedMessage,
+  isCapacityShedResponse,
+  isTransientProcessing400,
+  parseSSEBlock,
+  rewriteCapacityShedCode,
+  resolveSettings,
+  rewriteCapacityShedSSEBlock,
+  streamDataStartsClientOutput
+}

--- a/src/utils/openaiCapacityShedStream.js
+++ b/src/utils/openaiCapacityShedStream.js
@@ -1,0 +1,396 @@
+/**
+ * Codex / OpenAI SSE 降载缓冲转发器
+ *
+ * CRS 原先把上游 SSE chunk 立刻 `res.write()` 出去。上游降载的真实序列是
+ * HTTP 200 之后立刻推 `event: error`（code=server_is_overloaded / slow_down）
+ * 再以 `event: response.failed` 收尾 —— 只要 error 帧被写出去，Codex 就地终止，
+ * 重试机会随之消失。
+ *
+ * 因此在「客户端尚未收到真实输出」之前先把事件块攒在内存里：
+ *   - 期间命中降载 → 丢弃缓冲、断开上游，交给调用方在同账号上重试；
+ *   - 出现真实输出 → 一次性下发缓冲，之后恢复逐块透传；
+ *   - 缓冲超上限 → 放弃重试，下发缓冲并转入透传（避免大 metadata preamble 撑爆内存）。
+ *
+ * 流中途才降载（已经有真实输出）时无法再重试，只能把错误码改写成
+ * server_error 后转发，让 Codex 走内置退避而不是打印
+ * "Selected model is at capacity. Please try a different model." 后退出。
+ *
+ * @module openaiCapacityShedStream
+ */
+
+const { StringDecoder } = require('string_decoder')
+const {
+  DEFAULT_SETTINGS,
+  isCapacityShedEvent,
+  parseSSEBlock,
+  rewriteCapacityShedSSEBlock,
+  streamDataStartsClientOutput
+} = require('./openaiCapacityShed')
+
+const SSE_BLOCK_SEPARATOR = /\r?\n\r?\n/
+
+/**
+ * 缓冲式转发上游 SSE 流。
+ *
+ * 返回的 promise 在以下三种情形 resolve：
+ *   - `{ outcome: 'shed' }`      检测到降载且尚未向客户端写出任何字节，可安全重试。
+ *                               上游流已被销毁，`res` 未被写入、响应头未提交。
+ *   - `{ outcome: 'completed' }` 流正常结束，缓冲已全部下发。**不会**调用 res.end()，
+ *                               由调用方在记录用量后收尾。
+ *   - `{ outcome: 'error', error }` 上游流报错。`outputStarted` 指示是否已写出内容。
+ *
+ * @param {Object} options
+ * @param {Object} options.stream 上游可读流（axios responseType: 'stream'）
+ * @param {Object} options.res Express 响应对象
+ * @param {Function} [options.onEventText] 每收到一段解码后的文本时回调（用于 usage 统计）
+ * @param {Function} [options.commitHeaders] 首次写出前调用一次，用于惰性提交响应头
+ * @param {boolean} [options.retryEnabled=true] 是否允许因降载中断并重试
+ * @param {number} [options.bufferLimitBytes] 缓冲字节上限，超出后放弃重试
+ * @param {number} [options.preOutputBufferMs] 缓冲时间上限，超时后放弃重试
+ * @param {Function} [options.onShedRewrite] 发生错误码改写时回调
+ * @returns {Promise<{outcome: string, outputStarted: boolean, error?: Error, shedPayload?: Object}>}
+ */
+function pipeWithCapacityShedBuffer({
+  stream,
+  res,
+  onEventText = null,
+  commitHeaders = null,
+  retryEnabled = true,
+  bufferLimitBytes = DEFAULT_SETTINGS.bufferLimitBytes,
+  preOutputBufferMs = DEFAULT_SETTINGS.preOutputBufferMs,
+  onShedRewrite = null
+}) {
+  return new Promise((resolve) => {
+    const decoder = new StringDecoder('utf8')
+    let pending = ''
+    let outputStarted = false
+    let retryAllowed = retryEnabled
+    let headersCommitted = false
+    let settled = false
+    const buffered = []
+    let bufferedBytes = 0
+    let bufferTimer = null
+
+    const clearBufferTimer = () => {
+      if (bufferTimer) {
+        clearTimeout(bufferTimer)
+        bufferTimer = null
+      }
+    }
+
+    const settle = (result) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearBufferTimer()
+      resolve({ outputStarted, ...result })
+    }
+
+    const writeOut = (text) => {
+      if (!text) {
+        return
+      }
+      if (!headersCommitted) {
+        headersCommitted = true
+        if (typeof commitHeaders === 'function') {
+          commitHeaders()
+        }
+      }
+      if (!res.destroyed && res.writable) {
+        res.write(text)
+      }
+    }
+
+    const flushBuffer = () => {
+      clearBufferTimer()
+      if (buffered.length === 0) {
+        return
+      }
+      const text = buffered.join('')
+      buffered.length = 0
+      bufferedBytes = 0
+      writeOut(text)
+    }
+
+    // 缓冲期间对客户端一言不发有上限：到点就放弃重试、把 preamble 发出去
+    const armBufferTimer = () => {
+      if (bufferTimer || !(preOutputBufferMs > 0)) {
+        return
+      }
+      bufferTimer = setTimeout(() => {
+        bufferTimer = null
+        if (settled || outputStarted) {
+          return
+        }
+        retryAllowed = false
+        outputStarted = true
+        flushBuffer()
+      }, preOutputBufferMs)
+      if (typeof bufferTimer.unref === 'function') {
+        bufferTimer.unref()
+      }
+    }
+
+    const bufferBlock = (block) => {
+      buffered.push(block)
+      bufferedBytes += Buffer.byteLength(block, 'utf8')
+      armBufferTimer()
+    }
+
+    // 返回 true 表示已判定为可重试的降载，调用方应停止继续处理
+    const handleBlock = (block) => {
+      const parsed = parseSSEBlock(block)
+
+      if (parsed.data && isCapacityShedEvent(parsed.data)) {
+        if (!outputStarted && retryAllowed) {
+          buffered.length = 0
+          bufferedBytes = 0
+          settle({ outcome: 'shed', shedPayload: parsed.data })
+          return true
+        }
+        // 已经有真实输出或已放弃重试：改写错误码后转发，保留原始消息
+        const rewritten = rewriteCapacityShedSSEBlock(block)
+        if (rewritten.changed && typeof onShedRewrite === 'function') {
+          onShedRewrite({ outputStarted, payload: parsed.data })
+        }
+        if (!outputStarted) {
+          outputStarted = true
+          flushBuffer()
+        }
+        writeOut(rewritten.block)
+        return false
+      }
+
+      if (outputStarted) {
+        writeOut(block)
+        return false
+      }
+
+      // 注释行 / keepalive（`: ping`）没有 data 字段，不构成客户端输出
+      const startsOutput =
+        parsed.dataLines.length > 0 &&
+        streamDataStartsClientOutput(parsed.isDone ? null : parsed.data, parsed.eventType)
+
+      if (startsOutput) {
+        outputStarted = true
+        flushBuffer()
+        writeOut(block)
+        return false
+      }
+
+      bufferBlock(block)
+      if (bufferedBytes > bufferLimitBytes) {
+        // preamble 已经很大却仍未出现真实输出：放弃重试，转入透传
+        retryAllowed = false
+        outputStarted = true
+        flushBuffer()
+      }
+      return false
+    }
+
+    const consume = (text, { final = false } = {}) => {
+      if (text) {
+        pending += text
+        if (typeof onEventText === 'function') {
+          onEventText(text)
+        }
+      }
+
+      for (;;) {
+        const match = SSE_BLOCK_SEPARATOR.exec(pending)
+        if (!match) {
+          break
+        }
+        const end = match.index + match[0].length
+        const block = pending.slice(0, end)
+        pending = pending.slice(end)
+        if (handleBlock(block)) {
+          return true
+        }
+      }
+
+      if (final && pending) {
+        const tail = pending
+        pending = ''
+        if (tail.trim()) {
+          if (handleBlock(tail)) {
+            return true
+          }
+        } else {
+          // 纯空白尾巴：直接透传，保持字节等价
+          if (outputStarted) {
+            writeOut(tail)
+          } else {
+            bufferBlock(tail)
+          }
+        }
+      }
+
+      return false
+    }
+
+    const destroyUpstream = () => {
+      try {
+        stream.destroy()
+      } catch (_) {
+        // ignore
+      }
+    }
+
+    stream.on('data', (chunk) => {
+      if (settled) {
+        return
+      }
+      try {
+        if (consume(decoder.write(chunk))) {
+          destroyUpstream()
+        }
+      } catch (error) {
+        flushBuffer()
+        settle({ outcome: 'error', error })
+        destroyUpstream()
+      }
+    })
+
+    stream.on('end', () => {
+      if (settled) {
+        return
+      }
+      try {
+        if (consume(decoder.end(), { final: true })) {
+          destroyUpstream()
+          return
+        }
+      } catch (error) {
+        flushBuffer()
+        settle({ outcome: 'error', error })
+        return
+      }
+      // 流结束时仍无真实输出（例如只有 preamble）：把缓冲原样下发
+      if (!outputStarted) {
+        outputStarted = true
+        flushBuffer()
+      }
+      if (!headersCommitted) {
+        headersCommitted = true
+        if (typeof commitHeaders === 'function') {
+          commitHeaders()
+        }
+      }
+      settle({ outcome: 'completed' })
+    })
+
+    stream.on('error', (error) => {
+      if (settled) {
+        return
+      }
+      if (outputStarted) {
+        flushBuffer()
+      }
+      settle({ outcome: 'error', error })
+    })
+  })
+}
+
+/**
+ * 读取上游响应体用于降载判定。
+ *
+ * 流式请求（responseType: 'stream'）下错误响应也是一个流，必须先读空才能判定；
+ * 读空后 `drained` 为 true，调用方需要用 `rawBody` 而不是再去 pipe。
+ *
+ * @param {Object} upstream axios 响应
+ * @param {boolean} isStream 请求是否以流方式发起
+ * @param {number} [timeoutMs=5000] 读空超时保护
+ * @returns {Promise<{payload: Object|null, rawBody: string, drained: boolean}>}
+ */
+async function readUpstreamBody(upstream, isStream, timeoutMs = 5000) {
+  const data = upstream?.data
+
+  if (isStream && data && typeof data.on === 'function') {
+    const chunks = []
+    await new Promise((resolve) => {
+      let done = false
+      const finish = () => {
+        if (!done) {
+          done = true
+          resolve()
+        }
+      }
+      data.on('data', (chunk) => chunks.push(chunk))
+      data.on('end', finish)
+      data.on('error', finish)
+      const timer = setTimeout(finish, timeoutMs)
+      if (typeof timer.unref === 'function') {
+        timer.unref()
+      }
+    })
+    const rawBody = Buffer.concat(chunks).toString('utf8')
+    return { payload: parseErrorBody(rawBody), rawBody, drained: true }
+  }
+
+  if (isPlainObject(data)) {
+    return { payload: data, rawBody: '', drained: false }
+  }
+  const rawBody = typeof data === 'string' ? data : ''
+  return { payload: parseErrorBody(rawBody), rawBody, drained: false }
+}
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof value.pipe !== 'function'
+  )
+}
+
+/**
+ * 错误响应体可能是 JSON，也可能是一段 SSE（上游先 200 再降载的场景）
+ */
+function parseErrorBody(rawBody) {
+  const text = (rawBody || '').trim()
+  if (!text) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(text)
+    if (isPlainObject(parsed)) {
+      return parsed
+    }
+  } catch (_) {
+    // 继续按 SSE 解析
+  }
+  if (!text.includes('data:')) {
+    return null
+  }
+  for (const block of text.split(SSE_BLOCK_SEPARATOR)) {
+    const parsed = parseSSEBlock(block)
+    if (parsed.data) {
+      return parsed.data
+    }
+  }
+  return null
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function delay(ms) {
+  if (!(ms > 0)) {
+    return Promise.resolve()
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms)
+    if (typeof timer.unref === 'function') {
+      timer.unref()
+    }
+  })
+}
+
+module.exports = {
+  delay,
+  pipeWithCapacityShedBuffer,
+  readUpstreamBody
+}

--- a/tests/openaiCapacityShed.test.js
+++ b/tests/openaiCapacityShed.test.js
@@ -1,0 +1,319 @@
+// Codex/OpenAI 容量降载识别与改写的单元测试。
+//
+// 上游 error.code = server_is_overloaded / slow_down 是 Codex CLI 的致命闭集
+// （codex-rs/codex-api/src/sse/responses.rs 的 is_server_overloaded_error →
+// CodexErr::ServerOverloaded，而 CodexErr::is_retryable() 对它返回 false），
+// 命中即打印 "Selected model is at capacity. Please try a different model." 并结束回合。
+// 这里锁定：什么算降载、什么不算、改写只动这两个码。
+
+const {
+  RETRYABLE_CLIENT_CODE,
+  computeRetryDelayMs,
+  extractErrorCode,
+  extractErrorMessage,
+  isCapacityShedEvent,
+  isCapacityShedMessage,
+  isCapacityShedResponse,
+  isTransientProcessing400,
+  parseSSEBlock,
+  resolveSettings,
+  rewriteCapacityShedCode,
+  rewriteCapacityShedSSEBlock,
+  streamDataStartsClientOutput
+} = require('../src/utils/openaiCapacityShed')
+
+describe('降载错误码识别', () => {
+  it.each(['server_is_overloaded', 'slow_down'])('识别 error.code = %s', (code) => {
+    expect(isCapacityShedEvent({ type: 'error', error: { code } })).toBe(true)
+    expect(extractErrorCode({ type: 'error', error: { code } })).toBe(code)
+  })
+
+  it.each(['server_is_overloaded', 'slow_down'])('识别 response.error.code = %s', (code) => {
+    const payload = { type: 'response.failed', response: { error: { code } } }
+    expect(isCapacityShedEvent(payload)).toBe(true)
+    expect(extractErrorCode(payload)).toBe(code)
+  })
+
+  it('错误码大小写不敏感', () => {
+    expect(isCapacityShedEvent({ error: { code: 'SERVER_IS_OVERLOADED' } })).toBe(true)
+  })
+
+  it.each([
+    'server_error',
+    'rate_limit_exceeded',
+    'usage_limit_reached',
+    'context_length_exceeded',
+    'content_policy_violation',
+    'model_not_found'
+  ])('不把 %s 当降载', (code) => {
+    expect(isCapacityShedEvent({ error: { code } })).toBe(false)
+  })
+})
+
+describe('降载消息识别', () => {
+  it.each([
+    'Our servers are currently overloaded. Please try again later.',
+    'The server is overloaded, retry shortly',
+    'Our servers are overloaded'
+  ])('识别 %s', (message) => {
+    expect(isCapacityShedMessage(message)).toBe(true)
+    expect(isCapacityShedEvent({ error: { message } })).toBe(true)
+  })
+
+  it('无错误码但消息命中时仍算降载', () => {
+    const payload = {
+      type: 'error',
+      error: { type: 'service_unavailable_error', message: 'Our servers are currently overloaded.' }
+    }
+    expect(isCapacityShedEvent(payload)).toBe(true)
+  })
+
+  it('用户内容回显同样短语时不误判（只看结构化错误字段）', () => {
+    const payload = {
+      type: 'response.failed',
+      response: {
+        error: { code: 'invalid_request_error', message: 'bad input' },
+        output: [{ content: [{ text: 'Our servers are currently overloaded' }] }]
+      }
+    }
+    expect(isCapacityShedEvent(payload)).toBe(false)
+    expect(isCapacityShedResponse({ status: 400, payload, rawBody: JSON.stringify(payload) })).toBe(
+      false
+    )
+  })
+})
+
+describe('HTTP 400 瞬时处理失败', () => {
+  it('识别 "Selected model is at capacity…"', () => {
+    const payload = {
+      error: {
+        type: 'invalid_request_error',
+        message: 'Selected model is at capacity. Please try a different model.'
+      }
+    }
+    expect(isTransientProcessing400(400, payload)).toBe(true)
+    expect(isCapacityShedResponse({ status: 400, payload })).toBe(true)
+  })
+
+  it('识别 request id 三件套', () => {
+    const payload = {
+      error: {
+        message:
+          'You can retry your request, or contact us through help.openai.com if the error persists. Please include the request ID req_abc.'
+      }
+    }
+    expect(isTransientProcessing400(400, payload)).toBe(true)
+  })
+
+  it('同样的短语在 400 之外的状态码上不生效', () => {
+    const payload = { error: { message: 'Selected model is at capacity.' } }
+    expect(isTransientProcessing400(422, payload)).toBe(false)
+    expect(isCapacityShedResponse({ status: 422, payload })).toBe(false)
+  })
+
+  it('非 JSON 纯文本响应体才允许整体扫描', () => {
+    const rawBody = 'An error occurred while processing your request'
+    expect(isCapacityShedResponse({ status: 400, payload: null, rawBody })).toBe(true)
+  })
+
+  it('quota 429 保持原语义，不进降载路径', () => {
+    const payload = {
+      error: { type: 'usage_limit_reached', message: 'usage limit', resets_in_seconds: 3600 }
+    }
+    expect(isCapacityShedResponse({ status: 429, payload })).toBe(false)
+  })
+})
+
+describe('错误码改写', () => {
+  it('把 error.code 改写为 server_error 并保留消息', () => {
+    const payload = {
+      type: 'error',
+      error: {
+        type: 'service_unavailable_error',
+        code: 'server_is_overloaded',
+        message: 'Our servers are currently overloaded. Please try again later.'
+      }
+    }
+    const { payload: out, changed } = rewriteCapacityShedCode(payload)
+    expect(changed).toBe(true)
+    expect(out.error.code).toBe(RETRYABLE_CLIENT_CODE)
+    expect(out.error.message).toBe('Our servers are currently overloaded. Please try again later.')
+    expect(out.error.type).toBe('service_unavailable_error')
+    // 原对象不被就地修改
+    expect(payload.error.code).toBe('server_is_overloaded')
+  })
+
+  it('改写 response.error.code', () => {
+    const payload = {
+      type: 'response.failed',
+      response: { id: 'resp_1', status: 'failed', error: { code: 'slow_down', message: 'slow' } }
+    }
+    const { payload: out, changed } = rewriteCapacityShedCode(payload)
+    expect(changed).toBe(true)
+    expect(out.response.error.code).toBe(RETRYABLE_CLIENT_CODE)
+    expect(out.response.id).toBe('resp_1')
+  })
+
+  it('不动 rate_limit_exceeded —— 客户端依赖原码解析重试延时', () => {
+    const payload = { error: { code: 'rate_limit_exceeded', message: 'Please try again in 11.0s' } }
+    const { payload: out, changed } = rewriteCapacityShedCode(payload)
+    expect(changed).toBe(false)
+    expect(out.error.code).toBe('rate_limit_exceeded')
+  })
+
+  it('无码但消息命中降载时补上 server_error', () => {
+    const payload = {
+      error: { type: 'service_unavailable_error', message: 'Our servers are overloaded.' }
+    }
+    const { payload: out, changed } = rewriteCapacityShedCode(payload)
+    expect(changed).toBe(true)
+    expect(out.error.code).toBe(RETRYABLE_CLIENT_CODE)
+  })
+
+  it('SSE 事件块改写后仍是合法 SSE', () => {
+    const block =
+      'event: response.failed\ndata: {"type":"response.failed","response":{"error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded."}}}\n\n'
+    const { block: out, changed } = rewriteCapacityShedSSEBlock(block)
+    expect(changed).toBe(true)
+    expect(out).toContain('event: response.failed')
+    expect(out).not.toContain('server_is_overloaded')
+    expect(out).toContain('"code":"server_error"')
+    expect(out).toContain('Our servers are currently overloaded.')
+    expect(parseSSEBlock(out).data.response.error.code).toBe('server_error')
+  })
+
+  it('非降载事件块原样返回', () => {
+    const block = 'event: response.output_text.delta\ndata: {"delta":"hi"}\n\n'
+    expect(rewriteCapacityShedSSEBlock(block)).toEqual({ block, changed: false })
+  })
+})
+
+describe('客户端输出起点判定', () => {
+  const cases = [
+    // 降载帧不算输出：写出去 Codex 就地终止，重试机会随之消失
+    [{ type: 'error', error: { code: 'server_is_overloaded' } }, 'error', false],
+    [{ type: 'error', error: { code: 'slow_down' } }, 'error', false],
+    [
+      { type: 'response.failed', response: { error: { code: 'server_is_overloaded' } } },
+      'response.failed',
+      false
+    ],
+    // 非降载错误立即转发，不做重试
+    [
+      { type: 'error', error: { type: 'invalid_request_error', code: 'content_policy_violation' } },
+      'error',
+      true
+    ],
+    [{ type: 'error', error: { code: 'rate_limit_exceeded' } }, 'error', true],
+    // preamble
+    [{ type: 'response.created', response: { id: 'resp_1' } }, 'response.created', false],
+    [{ type: 'response.in_progress', response: { id: 'resp_1' } }, 'response.in_progress', false],
+    [
+      { type: 'response.output_item.added', item: { type: 'reasoning', summary: [] } },
+      'response.output_item.added',
+      false
+    ],
+    [
+      {
+        type: 'response.output_item.added',
+        item: { type: 'reasoning', encrypted_content: 'ciphertext' }
+      },
+      'response.output_item.added',
+      true
+    ],
+    [
+      {
+        type: 'response.reasoning_summary_part.added',
+        part: { type: 'summary_text', text: '' }
+      },
+      'response.reasoning_summary_part.added',
+      false
+    ],
+    [
+      {
+        type: 'response.reasoning_summary_part.added',
+        part: { type: 'summary_text', text: 'thinking' }
+      },
+      'response.reasoning_summary_part.added',
+      true
+    ],
+    [
+      { type: 'response.content_part.added', part: { type: 'output_text', text: '' } },
+      'response.content_part.added',
+      false
+    ],
+    [{ type: 'response.output_text.delta', delta: 'hi' }, 'response.output_text.delta', true],
+    // data: [DONE]
+    [null, '', true]
+  ]
+
+  it.each(cases)('%j / %s → %s', (data, eventType, expected) => {
+    expect(streamDataStartsClientOutput(data, eventType)).toBe(expected)
+  })
+
+  it('缺少 event: 行时回退到 data.type', () => {
+    expect(
+      streamDataStartsClientOutput({ type: 'response.created', response: { id: 'r' } }, '')
+    ).toBe(false)
+    expect(
+      streamDataStartsClientOutput({ type: 'response.output_text.delta', delta: 'x' }, '')
+    ).toBe(true)
+  })
+})
+
+describe('SSE 事件块解析', () => {
+  it('解析 event/data', () => {
+    const parsed = parseSSEBlock('event: error\ndata: {"type":"error"}\n\n')
+    expect(parsed.eventType).toBe('error')
+    expect(parsed.data).toEqual({ type: 'error' })
+    expect(parsed.isDone).toBe(false)
+  })
+
+  it('识别 [DONE]', () => {
+    const parsed = parseSSEBlock('data: [DONE]\n\n')
+    expect(parsed.isDone).toBe(true)
+    expect(parsed.data).toBeNull()
+  })
+
+  it('非法 JSON 不抛异常', () => {
+    expect(parseSSEBlock('data: {oops\n\n').data).toBeNull()
+  })
+})
+
+describe('退避与配置', () => {
+  it('按尝试次数递增，封顶 8s', () => {
+    expect(computeRetryDelayMs(1)).toBe(500)
+    expect(computeRetryDelayMs(2)).toBe(1000)
+    expect(computeRetryDelayMs(3)).toBe(2000)
+    expect(computeRetryDelayMs(99)).toBe(2000)
+  })
+
+  it('预算内采纳 Retry-After', () => {
+    expect(computeRetryDelayMs(1, '3')).toBe(3000)
+  })
+
+  it('超出预算的 Retry-After 不采纳，避免把请求挂死', () => {
+    expect(computeRetryDelayMs(1, '600')).toBe(500)
+  })
+
+  it('resolveSettings 合并覆盖项并忽略非法值', () => {
+    expect(resolveSettings({ maxAttempts: 5, maxDelayMs: 0, bufferLimitBytes: 'x' })).toEqual({
+      maxAttempts: 5,
+      retryDelaysMs: [500, 1000, 2000],
+      maxDelayMs: 8000,
+      bufferLimitBytes: 256 * 1024,
+      preOutputBufferMs: 15000
+    })
+    expect(resolveSettings({ preOutputBufferMs: 3000 }).preOutputBufferMs).toBe(3000)
+    expect(resolveSettings(null).maxAttempts).toBe(3)
+  })
+})
+
+describe('消息提取', () => {
+  it('按 error.message → response.error.message → message 顺序', () => {
+    expect(extractErrorMessage({ error: { message: 'a' } })).toBe('a')
+    expect(extractErrorMessage({ response: { error: { message: 'b' } } })).toBe('b')
+    expect(extractErrorMessage({ message: 'c' })).toBe('c')
+    expect(extractErrorMessage({})).toBe('')
+  })
+})

--- a/tests/openaiCapacityShedRelay.test.js
+++ b/tests/openaiCapacityShedRelay.test.js
@@ -1,0 +1,513 @@
+// Codex 容量降载在 /openai/v1/responses 主链路上的行为回归。
+//
+// 关键不变量：
+//   1. 降载先在同一账号上重试，客户端看不到 server_is_overloaded；
+//   2. 降载**绝不**触发 markAccountRateLimited / markAccountUnauthorized（换账号解决不了容量问题）；
+//   3. 重试用尽或流中途降载时，把错误码改写成 server_error，让 Codex 走内置退避
+//      而不是打印 "Selected model is at capacity. Please try a different model." 后终止；
+//   4. quota 429 走原有摘号路径，行为不变。
+
+const { EventEmitter } = require('events')
+const { Readable } = require('stream')
+
+jest.mock('axios', () => ({ post: jest.fn() }))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  api: jest.fn(),
+  security: jest.fn()
+}))
+jest.mock('../config/config', () => ({
+  requestTimeout: 1000,
+  openaiCapacityShed: {
+    maxAttempts: 3,
+    maxDelayMs: 5,
+    retryDelaysMs: [1, 1, 1],
+    bufferLimitBytes: 65536
+  }
+}))
+jest.mock('../src/middleware/auth', () => ({ authenticateApiKey: (req, res, next) => next() }))
+jest.mock('../src/models/redis', () => ({ getClientSafe: () => ({}) }))
+jest.mock('../src/utils/proxyHelper', () => ({
+  createProxyAgent: () => null,
+  getProxyDescription: () => 'none'
+}))
+jest.mock('../src/utils/rateLimitHelper', () => ({ updateRateLimitCounters: jest.fn() }))
+jest.mock('../src/utils/requestDetailHelper', () => ({
+  createRequestDetailMeta: () => ({}),
+  extractOpenAICacheReadTokens: () => 0
+}))
+jest.mock('../src/services/requestBodyRuleService', () => ({ applyRules: (body) => body }))
+jest.mock('../src/services/relay/openaiResponsesRelayService', () => ({ handleRequest: jest.fn() }))
+jest.mock('../src/services/account/openaiResponsesAccountService', () => ({
+  getAccount: jest.fn()
+}))
+jest.mock('../src/services/apiKeyService', () => ({
+  hasPermission: () => true,
+  recordUsage: jest.fn(async () => ({ total: 0 }))
+}))
+jest.mock('../src/services/account/openaiAccountService', () => ({
+  getAccount: jest.fn(async () => ({
+    id: 'acct-1',
+    name: 'acct',
+    accountId: 'chatgpt-acct-1',
+    accessToken: 'enc',
+    expiresAt: null
+  })),
+  isTokenExpired: () => false,
+  decrypt: () => 'plain-access-token',
+  updateCodexUsageSnapshot: jest.fn(async () => {})
+}))
+jest.mock('../src/services/scheduler/unifiedOpenAIScheduler', () => ({
+  selectAccountForApiKey: jest.fn(async () => ({ accountId: 'acct-1', accountType: 'openai' })),
+  isAccountRateLimited: jest.fn(async () => false),
+  removeAccountRateLimit: jest.fn(async () => {}),
+  markAccountRateLimited: jest.fn(async () => {}),
+  markAccountUnauthorized: jest.fn(async () => {}),
+  _deleteSessionMapping: jest.fn(async () => {})
+}))
+
+const axios = require('axios')
+const unifiedOpenAIScheduler = require('../src/services/scheduler/unifiedOpenAIScheduler')
+const { handleResponses } = require('../src/routes/openaiRoutes')
+
+const OVERLOAD_MESSAGE = 'Our servers are currently overloaded. Please try again later.'
+
+function sseStream(blocks) {
+  return Readable.from([blocks.join('')])
+}
+
+function sseBlock(eventType, payload) {
+  return `event: ${eventType}\ndata: ${JSON.stringify(payload)}\n\n`
+}
+
+const SHED_ERROR_BLOCK = sseBlock('error', {
+  type: 'error',
+  error: {
+    type: 'service_unavailable_error',
+    code: 'server_is_overloaded',
+    message: OVERLOAD_MESSAGE
+  },
+  sequence_number: 2
+})
+const SHED_FAILED_BLOCK = sseBlock('response.failed', {
+  type: 'response.failed',
+  response: {
+    id: 'resp_1',
+    status: 'failed',
+    error: { code: 'server_is_overloaded', message: OVERLOAD_MESSAGE }
+  },
+  sequence_number: 3
+})
+const CREATED_BLOCK = sseBlock('response.created', {
+  type: 'response.created',
+  response: { id: 'resp_1' }
+})
+const IN_PROGRESS_BLOCK = sseBlock('response.in_progress', {
+  type: 'response.in_progress',
+  response: { id: 'resp_1' }
+})
+
+function successStream() {
+  return sseStream([
+    CREATED_BLOCK,
+    sseBlock('response.output_text.delta', { type: 'response.output_text.delta', delta: 'hello' }),
+    sseBlock('response.completed', {
+      type: 'response.completed',
+      response: { id: 'resp_1', model: 'gpt-5', usage: { input_tokens: 10, output_tokens: 5 } }
+    }),
+    'data: [DONE]\n\n'
+  ])
+}
+
+function makeReq({ stream = true } = {}) {
+  const req = new EventEmitter()
+  req.headers = { 'user-agent': 'codex_cli_rs/0.50.0' }
+  req.body = { model: 'gpt-5', stream, input: [] }
+  req.apiKey = { id: 'key-1', permissions: 'all' }
+  req.path = '/v1/responses'
+  req.originalUrl = '/openai/v1/responses'
+  req.method = 'POST'
+  req.destroyed = false
+  return req
+}
+
+function makeRes() {
+  const res = new EventEmitter()
+  res.statusCode = 200
+  res.headers = {}
+  res.chunks = []
+  res.jsonBody = null
+  res.headersSent = false
+  res.destroyed = false
+  res.writable = true
+  res.ended = false
+  res.status = (code) => {
+    res.statusCode = code
+    return res
+  }
+  res.setHeader = (k, v) => {
+    res.headers[k] = v
+    return res
+  }
+  res.flushHeaders = () => {
+    res.headersSent = true
+  }
+  res.write = (chunk) => {
+    res.headersSent = true
+    res.chunks.push(chunk.toString())
+    return true
+  }
+  res.json = (body) => {
+    res.headersSent = true
+    res.jsonBody = body
+    res.ended = true
+    return res
+  }
+  res.end = () => {
+    res.ended = true
+    return res
+  }
+  res.body = () => res.chunks.join('')
+  return res
+}
+
+const noAccountPenalty = () => {
+  expect(unifiedOpenAIScheduler.markAccountRateLimited).not.toHaveBeenCalled()
+  expect(unifiedOpenAIScheduler.markAccountUnauthorized).not.toHaveBeenCalled()
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  unifiedOpenAIScheduler.selectAccountForApiKey.mockResolvedValue({
+    accountId: 'acct-1',
+    accountType: 'openai'
+  })
+  unifiedOpenAIScheduler.isAccountRateLimited.mockResolvedValue(false)
+})
+
+describe('非流式 HTTP 降载', () => {
+  it('400 "Selected model is at capacity" 后第二次尝试成功，客户端只看到 200', async () => {
+    axios.post
+      .mockResolvedValueOnce({
+        status: 400,
+        headers: {},
+        data: {
+          error: {
+            type: 'invalid_request_error',
+            message: 'Selected model is at capacity. Please try a different model.'
+          }
+        }
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        data: { model: 'gpt-5', usage: { input_tokens: 3, output_tokens: 4 } }
+      })
+
+    const res = makeRes()
+    await handleResponses(makeReq({ stream: false }), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(2)
+    expect(res.statusCode).toBe(200)
+    expect(res.jsonBody.model).toBe('gpt-5')
+    noAccountPenalty()
+  })
+
+  it('连续三次降载后返回 503 + server_error，且不摘号', async () => {
+    axios.post.mockResolvedValue({
+      status: 503,
+      headers: {},
+      data: { error: { code: 'server_is_overloaded', message: OVERLOAD_MESSAGE } }
+    })
+
+    const res = makeRes()
+    await handleResponses(makeReq({ stream: false }), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(3)
+    expect(res.statusCode).toBe(503)
+    expect(res.jsonBody).toEqual({
+      error: { type: 'server_error', code: 'server_error', message: OVERLOAD_MESSAGE }
+    })
+    noAccountPenalty()
+  })
+
+  it('非降载的 400 原样透传，不重试', async () => {
+    axios.post.mockResolvedValue({
+      status: 400,
+      headers: {},
+      data: { error: { type: 'invalid_request_error', message: 'Instructions are required' } }
+    })
+
+    const res = makeRes()
+    await handleResponses(makeReq({ stream: false }), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(400)
+    expect(res.jsonBody.error.message).toBe('Instructions are required')
+  })
+})
+
+describe('流式降载', () => {
+  it('error + response.failed 后重试成功，客户端从未看到 server_is_overloaded', async () => {
+    axios.post
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        data: sseStream([CREATED_BLOCK, IN_PROGRESS_BLOCK, SHED_ERROR_BLOCK, SHED_FAILED_BLOCK])
+      })
+      .mockResolvedValueOnce({ status: 200, headers: {}, data: successStream() })
+
+    const res = makeRes()
+    await handleResponses(makeReq(), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(2)
+    const body = res.body()
+    expect(body).not.toContain('server_is_overloaded')
+    expect(body).not.toContain('event: error')
+    expect(body).toContain('hello')
+    expect(body).toContain('[DONE]')
+    // preamble 只应出现重试成功那一次的
+    expect(body.match(/event: response\.created/g)).toHaveLength(1)
+    expect(res.statusCode).toBe(200)
+    expect(res.ended).toBe(true)
+    noAccountPenalty()
+  })
+
+  it('重试用尽后改写为 server_error 转发，保留原始消息', async () => {
+    // 每次尝试都要拿到全新的流实例
+    axios.post.mockImplementation(async () => ({
+      status: 200,
+      headers: {},
+      data: sseStream([CREATED_BLOCK, SHED_ERROR_BLOCK, SHED_FAILED_BLOCK])
+    }))
+
+    const res = makeRes()
+    await handleResponses(makeReq(), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(3)
+    const body = res.body()
+    expect(body).not.toContain('server_is_overloaded')
+    expect(body).toContain('"code":"server_error"')
+    expect(body).toContain(OVERLOAD_MESSAGE)
+    // preamble 也要一并下发，SSE 才是完整的
+    expect(body).toContain('event: response.created')
+    expect(res.statusCode).toBe(200)
+    noAccountPenalty()
+  })
+
+  it('已有真实输出后才降载：不重试，只改写错误码', async () => {
+    axios.post.mockResolvedValue({
+      status: 200,
+      headers: {},
+      data: sseStream([
+        CREATED_BLOCK,
+        sseBlock('response.output_text.delta', {
+          type: 'response.output_text.delta',
+          delta: 'partial'
+        }),
+        SHED_ERROR_BLOCK,
+        SHED_FAILED_BLOCK
+      ])
+    })
+
+    const res = makeRes()
+    await handleResponses(makeReq(), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    const body = res.body()
+    expect(body).toContain('partial')
+    expect(body).not.toContain('server_is_overloaded')
+    expect(body.match(/"code":"server_error"/g)).toHaveLength(2)
+    noAccountPenalty()
+  })
+
+  it('非降载的流内错误立即透传，不缓冲也不重试', async () => {
+    const policyBlock = sseBlock('error', {
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        code: 'content_policy_violation',
+        message: 'blocked'
+      }
+    })
+    axios.post.mockResolvedValue({
+      status: 200,
+      headers: {},
+      data: sseStream([CREATED_BLOCK, policyBlock])
+    })
+
+    const res = makeRes()
+    await handleResponses(makeReq(), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    expect(res.body()).toContain('content_policy_violation')
+  })
+
+  it('正常流按原样转发，usage 照常记账', async () => {
+    axios.post.mockResolvedValue({ status: 200, headers: {}, data: successStream() })
+
+    const apiKeyService = require('../src/services/apiKeyService')
+    const res = makeRes()
+    await handleResponses(makeReq(), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    expect(res.body()).toContain('hello')
+    expect(apiKeyService.recordUsage).toHaveBeenCalledTimes(1)
+    const [, inputTokens, outputTokens] = apiKeyService.recordUsage.mock.calls[0]
+    expect(inputTokens).toBe(10)
+    expect(outputTokens).toBe(5)
+  })
+})
+
+describe('既有行为不受影响', () => {
+  it('quota 429 仍走摘号路径', async () => {
+    axios.post.mockResolvedValue({
+      status: 429,
+      headers: {},
+      data: {
+        error: {
+          type: 'usage_limit_reached',
+          message: 'usage limit reached',
+          resets_in_seconds: 3600
+        }
+      }
+    })
+
+    const res = makeRes()
+    await handleResponses(makeReq({ stream: false }), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(429)
+    expect(unifiedOpenAIScheduler.markAccountRateLimited).toHaveBeenCalledWith(
+      'acct-1',
+      'openai',
+      null,
+      3600
+    )
+  })
+
+  it('401 仍标记账号未授权', async () => {
+    axios.post.mockResolvedValue({
+      status: 401,
+      headers: {},
+      data: { error: { message: 'invalid token' } }
+    })
+
+    const res = makeRes()
+    await handleResponses(makeReq({ stream: false }), res)
+
+    expect(res.statusCode).toBe(401)
+    expect(unifiedOpenAIScheduler.markAccountUnauthorized).toHaveBeenCalled()
+  })
+})
+
+describe('客户端断开', () => {
+  // 线上回归：Node 在请求体读完后会自动销毁 request 流，于是每个 POST 的
+  // req.destroyed 开局几毫秒内就变成 true。早期版本拿它当断线判据，结果所有降载
+  // 重试都被跳过 —— 只剩改写，日志里 stream_output_started=false 却从不重试。
+  it('req.destroyed 变为 true（Node 读完请求体的正常行为）不得当作客户端断开', async () => {
+    const req = makeReq({ stream: false })
+    axios.post
+      .mockImplementationOnce(async () => {
+        req.destroyed = true
+        return {
+          status: 503,
+          headers: {},
+          data: { error: { code: 'server_is_overloaded', message: OVERLOAD_MESSAGE } }
+        }
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        data: { model: 'gpt-5', usage: { input_tokens: 1, output_tokens: 1 } }
+      })
+
+    const res = makeRes()
+    await handleResponses(req, res)
+
+    expect(axios.post).toHaveBeenCalledTimes(2)
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('退避期间客户端断开则停止重试，且不摘号', async () => {
+    const req = makeReq({ stream: false })
+    const res = makeRes()
+    axios.post.mockImplementation(async () => {
+      // 真实的断线信号是 res 被销毁而响应尚未结束
+      res.destroyed = true
+      res.writable = false
+      return {
+        status: 503,
+        headers: {},
+        data: { error: { code: 'slow_down', message: OVERLOAD_MESSAGE } }
+      }
+    })
+
+    await handleResponses(req, res)
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(503)
+    expect(res.jsonBody.error.code).toBe('server_error')
+    noAccountPenalty()
+  })
+})
+
+describe('预输出缓冲的边界', () => {
+  it('keepalive 注释不算客户端输出，降载仍可重试', async () => {
+    axios.post
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        data: sseStream([CREATED_BLOCK, ': ping\n\n', SHED_ERROR_BLOCK])
+      })
+      .mockResolvedValueOnce({ status: 200, headers: {}, data: successStream() })
+
+    const res = makeRes()
+    await handleResponses(makeReq(), res)
+
+    expect(axios.post).toHaveBeenCalledTimes(2)
+    expect(res.body()).not.toContain('server_is_overloaded')
+    expect(res.body()).toContain('hello')
+  })
+
+  it('缓冲超时后放弃重试并下发 preamble，避免长时间对客户端沉默', async () => {
+    jest.resetModules()
+    jest.doMock('../config/config', () => ({
+      requestTimeout: 1000,
+      openaiCapacityShed: {
+        maxAttempts: 3,
+        maxDelayMs: 5,
+        retryDelaysMs: [1, 1, 1],
+        bufferLimitBytes: 65536,
+        preOutputBufferMs: 20
+      }
+    }))
+    const freshAxios = require('axios')
+    const { handleResponses: freshHandle } = require('../src/routes/openaiRoutes')
+
+    // preamble 之后长时间无事件：缓冲窗口到点应把 preamble 发出去
+    const slow = new Readable({ read() {} })
+    slow.push(CREATED_BLOCK)
+    freshAxios.post.mockResolvedValue({ status: 200, headers: {}, data: slow })
+
+    const res = makeRes()
+    const pending = freshHandle(makeReq(), res)
+    await new Promise((resolve) => setTimeout(resolve, 60))
+    expect(res.body()).toContain('event: response.created')
+
+    // 超时后到达的降载帧不再触发重试，只做错误码改写
+    slow.push(SHED_ERROR_BLOCK)
+    slow.push(null)
+    await pending
+
+    expect(freshAxios.post).toHaveBeenCalledTimes(1)
+    expect(res.body()).not.toContain('server_is_overloaded')
+    expect(res.body()).toContain('"code":"server_error"')
+
+    jest.dontMock('../config/config')
+    jest.resetModules()
+  })
+})

--- a/tests/openaiCapacityShedResponsesRelay.test.js
+++ b/tests/openaiCapacityShedResponsesRelay.test.js
@@ -1,0 +1,232 @@
+// openai-responses 中继路径上的容量降载回归。
+//
+// 这条链路原先有个更严重的副作用：任何 >= 500 的上游响应都会调用
+// markTempUnavailable 把账号临时摘掉。容量降载常以 503 出现，于是一个被降载的
+// 请求会顺着 failover 把整池账号逐个封禁，而每个账号都会以同一个错误失败。
+
+const { EventEmitter } = require('events')
+const { Readable } = require('stream')
+
+jest.mock('axios', () => jest.fn())
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  api: jest.fn()
+}))
+jest.mock('../config/config', () => ({
+  requestTimeout: 1000,
+  openaiCapacityShed: {
+    maxAttempts: 3,
+    maxDelayMs: 5,
+    retryDelaysMs: [1, 1, 1],
+    bufferLimitBytes: 65536
+  }
+}))
+jest.mock('../src/utils/proxyHelper', () => ({
+  createProxyAgent: () => null,
+  getProxyDescription: () => 'none'
+}))
+jest.mock('../src/utils/headerFilter', () => ({ filterForOpenAI: () => ({}) }))
+jest.mock('../src/utils/requestDetailHelper', () => ({
+  createRequestDetailMeta: () => ({}),
+  extractOpenAICacheReadTokens: () => 0
+}))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({
+  markTempUnavailable: jest.fn(async () => {}),
+  parseRetryAfter: () => null,
+  sanitizeErrorForClient: (data) => data
+}))
+jest.mock('../src/services/apiKeyService', () => ({ recordUsage: jest.fn(async () => ({})) }))
+jest.mock('../src/services/scheduler/unifiedOpenAIScheduler', () => ({
+  markAccountRateLimited: jest.fn(async () => {}),
+  _deleteSessionMapping: jest.fn(async () => {})
+}))
+jest.mock('../src/services/account/openaiResponsesAccountService', () => ({
+  getAccount: jest.fn(async () => ({
+    id: 'resp-1',
+    name: 'resp',
+    apiKey: 'sk-test',
+    baseApi: 'https://upstream.example.com/v1'
+  })),
+  updateAccount: jest.fn(async () => {}),
+  updateAccountUsage: jest.fn(async () => {}),
+  updateUsageQuota: jest.fn(async () => {})
+}))
+
+const axios = require('axios')
+const upstreamErrorHelper = require('../src/utils/upstreamErrorHelper')
+const relay = require('../src/services/relay/openaiResponsesRelayService')
+
+const OVERLOAD_MESSAGE = 'Our servers are currently overloaded. Please try again later.'
+const ACCOUNT = { id: 'resp-1', name: 'resp' }
+const API_KEY = { id: 'key-1' }
+
+function sseBlock(eventType, payload) {
+  return `event: ${eventType}\ndata: ${JSON.stringify(payload)}\n\n`
+}
+
+function makeReq({ stream = false } = {}) {
+  const req = new EventEmitter()
+  req.method = 'POST'
+  req.path = '/v1/responses'
+  req.headers = {}
+  req.body = { model: 'gpt-5', stream }
+  req.destroyed = false
+  return req
+}
+
+function makeRes() {
+  const res = new EventEmitter()
+  res.statusCode = 200
+  res.headers = {}
+  res.chunks = []
+  res.jsonBody = null
+  res.headersSent = false
+  res.destroyed = false
+  res.writable = true
+  res.status = (code) => {
+    res.statusCode = code
+    return res
+  }
+  res.setHeader = (k, v) => {
+    res.headers[k] = v
+    return res
+  }
+  res.write = (chunk) => {
+    res.headersSent = true
+    res.chunks.push(chunk.toString())
+    return true
+  }
+  res.json = (body) => {
+    res.headersSent = true
+    res.jsonBody = body
+    return res
+  }
+  res.end = () => res
+  res.body = () => res.chunks.join('')
+  return res
+}
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('openai-responses 中继降载', () => {
+  it('503 降载后重试成功，且不摘号', async () => {
+    axios
+      .mockResolvedValueOnce({
+        status: 503,
+        headers: {},
+        data: { error: { code: 'server_is_overloaded', message: OVERLOAD_MESSAGE } }
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        data: { model: 'gpt-5', usage: { input_tokens: 4, output_tokens: 2 } }
+      })
+
+    const res = makeRes()
+    await relay.handleRequest(makeReq(), res, ACCOUNT, API_KEY)
+
+    expect(axios).toHaveBeenCalledTimes(2)
+    expect(res.statusCode).toBe(200)
+    expect(upstreamErrorHelper.markTempUnavailable).not.toHaveBeenCalled()
+  })
+
+  it('重试用尽返回 503 + server_error，仍然不摘号', async () => {
+    axios.mockResolvedValue({
+      status: 503,
+      headers: {},
+      data: { error: { code: 'server_is_overloaded', message: OVERLOAD_MESSAGE } }
+    })
+
+    const res = makeRes()
+    await relay.handleRequest(makeReq(), res, ACCOUNT, API_KEY)
+
+    expect(axios).toHaveBeenCalledTimes(3)
+    expect(res.statusCode).toBe(503)
+    expect(res.jsonBody.error.code).toBe('server_error')
+    expect(res.jsonBody.error.message).toBe(OVERLOAD_MESSAGE)
+    expect(upstreamErrorHelper.markTempUnavailable).not.toHaveBeenCalled()
+  })
+
+  it('普通 500 仍按原逻辑临时摘号', async () => {
+    axios.mockResolvedValue({
+      status: 500,
+      headers: {},
+      data: { error: { message: 'boom' } }
+    })
+
+    const res = makeRes()
+    await relay.handleRequest(makeReq(), res, ACCOUNT, API_KEY)
+
+    expect(axios).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(500)
+    expect(upstreamErrorHelper.markTempUnavailable).toHaveBeenCalledWith(
+      'resp-1',
+      'openai-responses',
+      500
+    )
+  })
+
+  it('流内降载先重试，客户端看不到 server_is_overloaded', async () => {
+    const shedStream = () =>
+      Readable.from([
+        [
+          sseBlock('response.created', { type: 'response.created', response: { id: 'r' } }),
+          sseBlock('error', {
+            type: 'error',
+            error: { code: 'server_is_overloaded', message: OVERLOAD_MESSAGE }
+          })
+        ].join('')
+      ])
+    const okStream = () =>
+      Readable.from([
+        [
+          sseBlock('response.created', { type: 'response.created', response: { id: 'r' } }),
+          sseBlock('response.output_text.delta', {
+            type: 'response.output_text.delta',
+            delta: 'hi'
+          }),
+          'data: [DONE]\n\n'
+        ].join('')
+      ])
+
+    axios
+      .mockResolvedValueOnce({ status: 200, headers: {}, data: shedStream() })
+      .mockResolvedValueOnce({ status: 200, headers: {}, data: okStream() })
+
+    const res = makeRes()
+    await relay.handleRequest(makeReq({ stream: true }), res, ACCOUNT, API_KEY)
+
+    expect(axios).toHaveBeenCalledTimes(2)
+    expect(res.body()).not.toContain('server_is_overloaded')
+    expect(res.body()).toContain('hi')
+    expect(upstreamErrorHelper.markTempUnavailable).not.toHaveBeenCalled()
+  })
+
+  it('流内降载重试用尽时改写错误码转发', async () => {
+    axios.mockImplementation(async () => ({
+      status: 200,
+      headers: {},
+      data: Readable.from([
+        [
+          sseBlock('response.created', { type: 'response.created', response: { id: 'r' } }),
+          sseBlock('response.failed', {
+            type: 'response.failed',
+            response: { error: { code: 'slow_down', message: OVERLOAD_MESSAGE } }
+          })
+        ].join('')
+      ])
+    }))
+
+    const res = makeRes()
+    await relay.handleRequest(makeReq({ stream: true }), res, ACCOUNT, API_KEY)
+
+    expect(axios).toHaveBeenCalledTimes(3)
+    expect(res.body()).not.toContain('slow_down')
+    expect(res.body()).toContain('"code":"server_error"')
+    expect(res.body()).toContain(OVERLOAD_MESSAGE)
+    expect(upstreamErrorHelper.markTempUnavailable).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 问题

Codex CLI 用户经常在毫无征兆的情况下会话直接结束，并打印：

```
Selected model is at capacity. Please try a different model.
```

这句话由 **Codex CLI 打印**，不是 CRS 生成的。Codex 按**错误码闭集**分类上游错误
（`codex-rs/codex-api/src/sse/responses.rs` 的 `is_server_overloaded_error`）：

| 上游 `error.code` | Codex CLI 行为 |
|---|---|
| `server_is_overloaded` / `slow_down` | 映射为 `CodexErr::ServerOverloaded`，`is_retryable()` 返回 **false** → 打印上面这句并结束当前回合 |
| `server_error` 等其它码 | 走客户端内置退避重试 |
| `rate_limit_exceeded` | 从消息里解析延时后重试 |

ChatGPT / Codex 后端在模型容量紧张时会把请求丢进「降载（capacity shed）」路径，常见三种形态：

1. HTTP **400** JSON，`type: invalid_request_error`，消息为 “Selected model is at capacity…” 或 “Our servers are currently overloaded…”
2. HTTP **200** SSE，紧接着推 `event: error`（code=`server_is_overloaded` / `slow_down`）再以 `event: response.failed` 收尾
3. HTTP **503**，携带同样的错误码

这**不是**配额 429（`usage_limit_reached` / `resets_in_seconds`）。换 ChatGPT 账号通常也没用：降载取决于模型容量和后端负载，与是哪个账号无关。

### CRS 现状

`src/routes/openaiRoutes.js` 的 `handleResponses`：

- 只对 HTTP **429** 做特判，其余状态码原样透传；
- 流式响应每个 chunk 立刻 `res.write(chunk)`，`event: error` 一旦写出去，Codex 就地终止；
- 没有任何同账号重试，也没有错误码改写。

于是**首次降载就会直接杀掉用户的会话**，CRS 连重试的机会都没有。

`src/services/relay/openaiResponsesRelayService.js` 还多一个副作用：任何 `>= 500` 的上游响应都会 `markTempUnavailable` 把账号临时摘掉。降载常以 503 出现，因此一个被降载的请求会顺着 failover 把**整池账号逐个封禁**，而每个账号都会以同一个错误失败。

## 方案

行为参考 **sub2api**（同作者项目）的容量降载路径，**只移植这一条链路**：

- 识别：`internal/service/openai_gateway_upstream_errors.go` 的 `isOpenAITransientProcessingError`、`isOpenAICapacityShedMessage`、`isOpenAIRequestScopedCapacityShed`
- 流内事件与改写：`internal/service/openai_gateway_passthrough.go` 的 `isOpenAIUpstreamCapacityShedEvent`、`sanitizeOpenAICapacityShedErrorCodeForClient`、`openAIStreamDataStartsClientOutput`、`openAIStreamFailedEventRetryableOnSameAccount`

分四步：

### 1. 识别（`src/utils/openaiCapacityShed.js`，纯函数）

- `error.code` / `response.error.code` 命中 `server_is_overloaded` / `slow_down`
- `error.message` / `response.error.message` 命中 overloaded 系列短语
- 仅 HTTP 400：命中 `selected model is at capacity` / `an error occurred while processing your request` / `you can retry your request` + `help.openai.com` + `request id`

**只看结构化错误字段，绝不整体扫描 JSON** —— 用户内容可能原样回显这些短语（已有对应用例）。

配额 429、`rate_limit_exceeded`、401/402、上下文超限、内容策略、`model_not_found` 一律不算降载，行为保持不变。

### 2. 同账号有界重试

默认 3 次（首次 + 2 次重试），退避 500ms / 1s / 2s，上限 8s，预算内采纳 `Retry-After`；客户端断开即停止。

全程**不**调用 `markAccountRateLimited` / `markTempUnavailable` / `markAccountUnauthorized`。v1 **不做换号**：容量不是账号局部属性，换号只会清空整池。`unifiedOpenAIScheduler.js` 一行未动。

### 3. SSE 缓冲（`src/utils/openaiCapacityShedStream.js`）

在客户端收到第一份**真实输出**之前，把事件块攒在内存里：

| 事件 | 算真实输出？ |
|---|---|
| `error`（降载）/ `response.failed`（降载） | 否 |
| `response.created` / `response.in_progress` | 否 |
| `response.output_item.added`，reasoning summary 为空 | 否 |
| `response.output_item.added`，带 `encrypted_content` | 是 |
| `response.reasoning_summary_part.added`，text 非空 | 是 |
| `response.content_part.added`，`output_text` 为空 | 否 |
| `response.output_text.delta`，delta 非空 | 是 |
| `[DONE]` | 是 |
| 非降载 `error`（如 `content_policy_violation`、`rate_limit_exceeded`） | 是（立即原样转发，不重试） |
| 注释 / keepalive（`: ping`，无 data 字段） | 否 |

期间命中降载就丢弃缓冲、断开上游、重试；出现真实输出就一次性下发缓冲并转入透传。

缓冲有**字节上限（256 KiB）**和**时间上限（15s）**两道闸，任一触发就放弃重试、下发缓冲：既避免大 metadata preamble 撑爆内存，也避免 CRS 长时间对客户端一言不发（nginx `proxy_read_timeout` 默认只有 60s；Codex 自身的 `stream_idle_timeout` 是 300s）。

配套地，响应头改为**惰性提交**：重试期间不能先把状态码和 SSE 头写出去，否则重试成功也没法再改响应状态。

### 4. 改写

重试用尽，或流中途才降载（已有真实输出，重试不再安全）时，把 `error.code` / `response.error.code` 从 `server_is_overloaded` / `slow_down` 改写为 **`server_error`**，**消息原样保留**。

非流式降载耗尽时返回 **503** + `{ error: { type: "server_error", code: "server_error", message: <原消息> } }`。

`rate_limit_exceeded` 一律不动 —— 客户端依赖原码解析重试延时。

## 明确不做（v1 范围外）

不移植 sub2api 的其余 OpenAI 429 / pool-mode / 换号策略：pool-mode 的 401/403/429 同账号重试、`maxAccountSwitches` / 换号 failover、OAuth 429 的 2 分钟窗口与 5h/7d 配额分类、WebSocket 链路、Claude 529、images 接口。把它们混进来会让账号因为**模型容量**问题被摘号，反而更糟。

## 配置

**无需改配置即可工作**，默认值就是上面的行为。可选环境变量（已补进 `.env.example` 与 `config/config.example.js`）：

- `OPENAI_CAPACITY_SHED_MAX_ATTEMPTS`（默认 3）
- `OPENAI_CAPACITY_SHED_MAX_DELAY_MS`（默认 8000）
- `OPENAI_CAPACITY_SHED_BUFFER_BYTES`（默认 262144）
- `OPENAI_CAPACITY_SHED_BUFFER_MS`（默认 15000）

老配置文件没有这个键时自动回落到默认值，向后兼容。

## 日志

每请求 warn 一次，不打请求体：

- `codex.capacity_shed_retry` —— 账号、第几次 / 共几次、上游状态码、退避、上游 request id、错误码
- `codex.capacity_shed_rewrite` —— 改写后的码、流是否已开始输出
- `codex.capacity_shed_suppressed_after_output` —— 因已有输出而跳过重试

## 测试

`npm test` 全绿（29 个套件）。新增 70 条用例：

- `tests/openaiCapacityShed.test.js`（51 条）—— 识别 / 不误判 / 改写 / 输出起点判定 / 退避
- `tests/openaiCapacityShedRelay.test.js`（14 条）—— `handleResponses` 主链路：400 降载后重试成功、三次降载后改写、流内 `error`+`response.failed` 后重试、已有输出后只改写不重试、配额 429 与 401 行为不变、keepalive 不算输出、缓冲超时后放弃重试
- `tests/openaiCapacityShedResponsesRelay.test.js`（5 条）—— openai-responses 链路，重点回归「降载不得摘号」，同时确认普通 500 仍按原逻辑临时摘号

### 一条值得单独说明的回归用例

**不能用 `req.destroyed` 判断客户端是否断开。** Node 在请求体读完后会自动销毁 request 流，于是每个 POST 的 `req.destroyed` 在开局几毫秒内就变成 `true`（`req` 的 `'close'` 同理）。第一版拿它当断线判据，单测里 `req` 是手写对象所以全绿，**实机上所有重试都被静默跳过**，只剩改写。断线判据只能看 `res`：`res.writableEnded !== true && (res.destroyed || !res.writable)`。

## 实机验证

在一台真实部署上做过端到端验证（用一个临时的 `openai-responses` 账号指向本地桩上游）：

| 场景 | 上游收到的请求数 | 客户端看到的结果 |
|---|---|---|
| SSE 降载 1 次后成功 | 2 | 完整正常流，从未出现 `server_is_overloaded` 或 `event: error` |
| SSE 持续降载 | 3 | 完整 SSE，错误码已改写为 `server_error`，原消息保留 |
| HTTP 503 持续降载 | 3 | `503` + `server_error`，原消息保留 |

三种场景下账号均保持 `schedulable=true`，无任何 `temp_unavailable` 键。日志按预期打出 `attempt=1/3 delay=500ms` → `attempt=2/3 delay=1000ms` → `rewrite`。

真实 ChatGPT 上游的正常流式请求同样验证过：事件序列完整、所有 `data:` 行 JSON 合法、TTFT 无额外延迟（缓冲在第一份真实输出到达时即下发）。

## 验收

- Codex 不再仅仅因为上游一次 `server_is_overloaded` / `slow_down` / “at capacity” 就结束会话
- 短暂降载被 1–2 次同账号重试吸收
- 确实要失败时，客户端拿到 `code: "server_error"`，可以自己退避
- OpenAI 账号**不会**因为容量降载被摘号 / 置为不可调度
- 配额 429 行为完全不变
