### PR TITLE
feat(accounts): 支持 OpenAI OAuth 账号手动与定时测试

### DIFF
--- a/src/routes/admin/openaiAccountTests.js
+++ b/src/routes/admin/openaiAccountTests.js
@@ -1,0 +1,122 @@
+const express = require('express')
+const { authenticateAdmin } = require('../../middleware/auth')
+const accounts = require('../../services/account/openaiAccountService')
+const scheduler = require('../../services/accountTestSchedulerService')
+const { DEFAULT_MODEL } = require('../../services/openaiAccountTestService')
+
+const router = express.Router()
+const base = '/:accountId'
+const validModel = (model) =>
+  typeof model === 'string' && /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$/.test(model)
+
+router.use(
+  ['test', 'test-sync', 'test-config', 'test-history'].map((path) => `${base}/${path}`),
+  authenticateAdmin,
+  async (req, res, next) => {
+    try {
+      const account = await accounts.getAccount(req.params.accountId)
+      if (!account) {
+        return res.status(404).json({ success: false, code: 'ACCOUNT_NOT_FOUND' })
+      }
+      next()
+    } catch {
+      res.status(500).json({ success: false, code: 'ACCOUNT_LOOKUP_FAILED' })
+    }
+  }
+)
+
+router.get(`${base}/test-config`, async (req, res) => {
+  try {
+    const config = await scheduler.getTestConfig(req.params.accountId, 'openai')
+    res.json({
+      success: true,
+      data: {
+        config: config || {
+          enabled: false,
+          cronExpression: '0 */6 * * *',
+          model: DEFAULT_MODEL
+        }
+      }
+    })
+  } catch {
+    res.status(500).json({ success: false, code: 'CONFIG_READ_FAILED' })
+  }
+})
+
+router.put(`${base}/test-config`, async (req, res) => {
+  const { enabled, cronExpression, model } = req.body || {}
+  if (
+    typeof enabled !== 'boolean' ||
+    typeof cronExpression !== 'string' ||
+    cronExpression.trim().split(/\s+/).length !== 5 ||
+    !scheduler.validateCronExpression(cronExpression) ||
+    !validModel(model)
+  ) {
+    return res.status(400).json({
+      success: false,
+      code: 'INVALID_TEST_CONFIG',
+      message: '请检查测试开关、五段 cron 表达式和模型名称'
+    })
+  }
+  try {
+    const config = { enabled, cronExpression, model }
+    await scheduler.setTestConfig(req.params.accountId, 'openai', config)
+    const saved = await scheduler.getTestConfig(req.params.accountId, 'openai')
+    if (
+      !saved ||
+      saved.enabled !== enabled ||
+      saved.cronExpression !== cronExpression ||
+      saved.model !== model
+    ) {
+      throw new Error('CONFIG_WRITE_FAILED')
+    }
+    res.json({ success: true, data: { config } })
+  } catch {
+    res.status(500).json({ success: false, code: 'CONFIG_WRITE_FAILED' })
+  }
+})
+
+router.get(`${base}/test-history`, async (req, res) => {
+  try {
+    const history = await scheduler.getTestHistory(req.params.accountId, 'openai')
+    res.json({ success: true, data: { history } })
+  } catch {
+    res.status(500).json({ success: false, code: 'HISTORY_READ_FAILED' })
+  }
+})
+
+router.post([`${base}/test`, `${base}/test-sync`], async (req, res) => {
+  const requestedModel = req.body?.model
+  if (requestedModel !== undefined && !validModel(requestedModel)) {
+    return res.status(400).json({ success: false, code: 'INVALID_MODEL' })
+  }
+  try {
+    const saved =
+      requestedModel === undefined
+        ? await scheduler.getTestConfig(req.params.accountId, 'openai')
+        : null
+    const model = requestedModel ?? saved?.model ?? DEFAULT_MODEL
+    const result = await scheduler.triggerTest(req.params.accountId, 'openai', model)
+    if (!result) {
+      return res
+        .status(409)
+        .json({ success: false, code: 'TEST_IN_PROGRESS', message: '该账号正在测试，请稍后重试' })
+    }
+    res.json({
+      success: result.success,
+      message: result.error,
+      code: result.code,
+      data: {
+        accountId: req.params.accountId,
+        model,
+        latency: result.latencyMs,
+        responseText: result.message,
+        result
+      }
+    })
+  } catch {
+    res.status(500).json({ success: false, code: 'TEST_FAILED' })
+  }
+})
+
+module.exports = router

--- a/src/routes/admin/openaiAccounts.js
+++ b/src/routes/admin/openaiAccounts.js
@@ -17,6 +17,7 @@ const webhookNotifier = require('../../utils/webhookNotifier')
 const { formatAccountExpiry, mapExpiryField } = require('./utils')
 
 const router = express.Router()
+router.use(require('./openaiAccountTests'))
 
 // OpenAI OAuth 配置
 const OPENAI_CONFIG = {

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -12,6 +12,7 @@ const apiKeyService = require('../services/apiKeyService')
 const redis = require('../models/redis')
 const crypto = require('crypto')
 const ProxyHelper = require('../utils/proxyHelper')
+const { extractCodexUsageHeaders } = require('../utils/codexUsage')
 const { updateRateLimitCounters } = require('../utils/rateLimitHelper')
 const { IncrementalSSEParser } = require('../utils/sseParser')
 const { getSafeMessage } = require('../utils/errorSanitizer')
@@ -33,50 +34,6 @@ function createProxyAgent(proxy) {
 // 检查 API Key 是否具备 OpenAI 权限
 function checkOpenAIPermissions(apiKeyData) {
   return apiKeyService.hasPermission(apiKeyData?.permissions, 'openai')
-}
-
-function normalizeHeaders(headers = {}) {
-  if (!headers || typeof headers !== 'object') {
-    return {}
-  }
-  const normalized = {}
-  for (const [key, value] of Object.entries(headers)) {
-    if (!key) {
-      continue
-    }
-    normalized[key.toLowerCase()] = Array.isArray(value) ? value[0] : value
-  }
-  return normalized
-}
-
-function toNumberSafe(value) {
-  if (value === undefined || value === null || value === '') {
-    return null
-  }
-  const num = Number(value)
-  return Number.isFinite(num) ? num : null
-}
-
-function extractCodexUsageHeaders(headers) {
-  const normalized = normalizeHeaders(headers)
-  if (!normalized || Object.keys(normalized).length === 0) {
-    return null
-  }
-
-  const snapshot = {
-    primaryUsedPercent: toNumberSafe(normalized['x-codex-primary-used-percent']),
-    primaryResetAfterSeconds: toNumberSafe(normalized['x-codex-primary-reset-after-seconds']),
-    primaryWindowMinutes: toNumberSafe(normalized['x-codex-primary-window-minutes']),
-    secondaryUsedPercent: toNumberSafe(normalized['x-codex-secondary-used-percent']),
-    secondaryResetAfterSeconds: toNumberSafe(normalized['x-codex-secondary-reset-after-seconds']),
-    secondaryWindowMinutes: toNumberSafe(normalized['x-codex-secondary-window-minutes']),
-    primaryOverSecondaryPercent: toNumberSafe(
-      normalized['x-codex-primary-over-secondary-limit-percent']
-    )
-  }
-
-  const hasData = Object.values(snapshot).some((value) => value !== null)
-  return hasData ? snapshot : null
 }
 
 function isCompactResponsesRoute(req) {

--- a/src/services/account/openaiAccountService.js
+++ b/src/services/account/openaiAccountService.js
@@ -114,7 +114,7 @@ function buildCodexUsageSnapshot(accountData) {
 }
 
 // 刷新访问令牌
-async function refreshAccessToken(refreshToken, proxy = null) {
+async function refreshAccessToken(refreshToken, proxy = null, signal) {
   try {
     // Codex CLI 的官方 CLIENT_ID
     const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
@@ -136,7 +136,8 @@ async function refreshAccessToken(refreshToken, proxy = null) {
         'Content-Length': requestData.length
       },
       data: requestData,
-      timeout: config.requestTimeout || 600000 // 使用统一的请求超时配置
+      timeout: config.requestTimeout || 600000, // 使用统一的请求超时配置
+      signal
     }
 
     // 配置代理（如果有）
@@ -268,7 +269,7 @@ function isSubscriptionExpired(account) {
 }
 
 // 刷新账户的 access token（带分布式锁）
-async function refreshAccountToken(accountId) {
+async function refreshAccountToken(accountId, options = {}) {
   let lockAcquired = false
   let account = null
   let accountName = accountId
@@ -332,7 +333,7 @@ async function refreshAccountToken(accountId) {
       }
     }
 
-    const newTokens = await refreshAccessToken(refreshToken, proxy)
+    const newTokens = await refreshAccessToken(refreshToken, proxy, options.signal)
     if (!newTokens) {
       throw new Error('Failed to refresh token')
     }

--- a/src/services/accountTestSchedulerService.js
+++ b/src/services/accountTestSchedulerService.js
@@ -295,12 +295,8 @@ class AccountTestSchedulerService {
    * @private
    */
   async _testOpenAIAccount(_accountId, _model) {
-    // OpenAI 测试暂时返回未实现
-    return {
-      success: false,
-      error: 'OpenAI scheduled test not implemented yet',
-      timestamp: new Date().toISOString()
-    }
+    const { testAccount } = require('./openaiAccountTestService')
+    return await testAccount(_accountId, _model)
   }
 
   /**

--- a/src/services/openaiAccountTestService.js
+++ b/src/services/openaiAccountTestService.js
@@ -1,0 +1,205 @@
+const axios = require('axios')
+const { StringDecoder } = require('string_decoder')
+const accounts = require('./account/openaiAccountService')
+const ProxyHelper = require('../utils/proxyHelper')
+
+const DEFAULT_MODEL = 'gpt-5.5'
+const errors = {
+  ACCOUNT_NOT_FOUND: '账号不存在',
+  TOKEN_REFRESH_FAILED: '令牌刷新失败，请检查账号授权',
+  AUTH_ERROR: '账号认证失败，请重新授权',
+  RATE_LIMITED: '账号被限流，请稍后重试',
+  UPSTREAM_ERROR: '模型服务返回错误',
+  INCOMPLETE_RESPONSE: '模型响应未正常完成',
+  INVALID_RESPONSE: '模型响应格式无效或没有文本',
+  TIMEOUT: '账号测试超时',
+  NETWORK_ERROR: '无法连接模型服务',
+  INVALID_PROXY: '账号代理配置无效'
+}
+
+function failure(code) {
+  return { success: false, code, error: errors[code] }
+}
+
+function statusFailure(status) {
+  if (status === 401 || status === 403) {
+    return failure('AUTH_ERROR')
+  }
+  if (status === 429) {
+    return failure('RATE_LIMITED')
+  }
+  return failure('UPSTREAM_ERROR')
+}
+
+function evaluateEvent(event, streamedText) {
+  if (['error', 'response.failed'].includes(event.type)) {
+    const code = event.error?.code || event.response?.error?.code || event.code
+    if (['rate_limit_exceeded', 'usage_limit_reached'].includes(code)) {
+      return failure('RATE_LIMITED')
+    }
+    if (['invalid_api_key', 'token_expired', 'authentication_error'].includes(code)) {
+      return failure('AUTH_ERROR')
+    }
+    return failure('UPSTREAM_ERROR')
+  }
+  if (event.type === 'response.incomplete') {
+    return failure('INCOMPLETE_RESPONSE')
+  }
+  if (event.type !== 'response.completed') {
+    return null
+  }
+  const { response } = event
+  if (!response || response.error || response.status !== 'completed') {
+    return failure('INVALID_RESPONSE')
+  }
+  const hasText = response.output?.some(
+    (item) =>
+      item.type === 'message' &&
+      item.content?.some(
+        (part) => part.type === 'output_text' && typeof part.text === 'string' && part.text.trim()
+      )
+  )
+  return hasText || streamedText
+    ? { success: true, message: '收到有效模型回复' }
+    : failure('INVALID_RESPONSE')
+}
+
+async function readResult(stream) {
+  const decoder = new StringDecoder('utf8')
+  let buffer = ''
+  let bytes = 0
+  let streamedText = false
+  for await (const chunk of stream) {
+    bytes += Buffer.byteLength(chunk)
+    if (bytes > 1024 * 1024) {
+      return failure('INVALID_RESPONSE')
+    }
+    buffer += typeof chunk === 'string' ? chunk : decoder.write(chunk)
+    buffer = buffer.replace(/\r\n/g, '\n')
+    let end
+    while ((end = buffer.indexOf('\n\n')) !== -1) {
+      const block = buffer.slice(0, end)
+      buffer = buffer.slice(end + 2)
+      const data = block
+        .split('\n')
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice(5).trimStart())
+        .join('\n')
+      if (!data || data === '[DONE]') {
+        continue
+      }
+      let event
+      try {
+        event = JSON.parse(data)
+      } catch {
+        return failure('INVALID_RESPONSE')
+      }
+      const text =
+        event.type === 'response.output_text.delta'
+          ? event.delta
+          : event.type === 'response.output_text.done'
+            ? event.text
+            : null
+      if (typeof text === 'string' && text.trim()) {
+        streamedText = true
+      }
+      const result = evaluateEvent(event, streamedText)
+      if (result) {
+        return result
+      }
+    }
+  }
+  return failure('INCOMPLETE_RESPONSE')
+}
+
+async function testAccount(accountId, model = DEFAULT_MODEL) {
+  const startedAt = Date.now()
+  const finish = (result) => ({
+    ...result,
+    model,
+    latencyMs: Date.now() - startedAt,
+    timestamp: new Date().toISOString()
+  })
+  let stream
+  let timedOut = false
+  const controller = new AbortController()
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+    stream?.destroy()
+  }, 60000)
+  try {
+    let account = await accounts.getAccount(accountId)
+    if (!account) {
+      return finish(failure('ACCOUNT_NOT_FOUND'))
+    }
+    if (accounts.isTokenExpired(account)) {
+      try {
+        await Promise.race([
+          accounts.refreshAccountToken(accountId, { signal: controller.signal }),
+          new Promise((_, reject) =>
+            controller.signal.addEventListener('abort', () => reject(new Error('TIMEOUT')), {
+              once: true
+            })
+          )
+        ])
+        account = await accounts.getAccount(accountId)
+      } catch {
+        return finish(failure(timedOut ? 'TIMEOUT' : 'TOKEN_REFRESH_FAILED'))
+      }
+    }
+    const token = account?.accessToken && accounts.decrypt(account.accessToken)
+    const chatgptAccountId = account?.accountId || account?.chatgptUserId
+    if (!token || !chatgptAccountId) {
+      return finish(failure('AUTH_ERROR'))
+    }
+    const agent = ProxyHelper.createProxyAgent(account.proxy)
+    if (account.proxy && !agent) {
+      return finish(failure('INVALID_PROXY'))
+    }
+    const response = await axios.post(
+      'https://chatgpt.com/backend-api/codex/responses',
+      {
+        model,
+        instructions: 'Reply briefly.',
+        input: [{ role: 'user', content: [{ type: 'input_text', text: 'Reply with OK.' }] }],
+        stream: true,
+        store: false
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'chatgpt-account-id': chatgptAccountId,
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+          originator: 'codex_cli_rs'
+        },
+        responseType: 'stream',
+        timeout: 60000,
+        signal: controller.signal,
+        validateStatus: () => true,
+        ...(agent ? { httpAgent: agent, httpsAgent: agent, proxy: false } : {})
+      }
+    )
+    stream = response.data
+    if (response.status !== 200) {
+      return finish(statusFailure(response.status))
+    }
+    const result = await readResult(stream)
+    return finish(timedOut ? failure('TIMEOUT') : result)
+  } catch (error) {
+    if (timedOut || ['ECONNABORTED', 'ETIMEDOUT'].includes(error.code)) {
+      return finish(failure('TIMEOUT'))
+    }
+    if (error.response?.status) {
+      return finish(statusFailure(error.response.status))
+    }
+    return finish(failure('NETWORK_ERROR'))
+  } finally {
+    clearTimeout(timer)
+    stream?.destroy?.()
+    controller.abort()
+  }
+}
+
+module.exports = { testAccount, DEFAULT_MODEL }

--- a/src/services/openaiAccountTestService.js
+++ b/src/services/openaiAccountTestService.js
@@ -5,7 +5,7 @@ const ProxyHelper = require('../utils/proxyHelper')
 const { extractCodexUsageHeaders } = require('../utils/codexUsage')
 const { createOpenAITestPayload } = require('../utils/testPayloadHelper')
 
-const DEFAULT_MODEL = 'gpt-5.5'
+const DEFAULT_MODEL = 'gpt-6-astra'
 const errors = {
   ACCOUNT_NOT_FOUND: '账号不存在',
   TOKEN_REFRESH_FAILED: '令牌刷新失败，请检查账号授权',

--- a/src/services/openaiAccountTestService.js
+++ b/src/services/openaiAccountTestService.js
@@ -3,6 +3,7 @@ const { StringDecoder } = require('string_decoder')
 const accounts = require('./account/openaiAccountService')
 const ProxyHelper = require('../utils/proxyHelper')
 const { extractCodexUsageHeaders } = require('../utils/codexUsage')
+const { createOpenAITestPayload } = require('../utils/testPayloadHelper')
 
 const DEFAULT_MODEL = 'gpt-5.5'
 const errors = {
@@ -178,8 +179,8 @@ async function testAccount(accountId, model = DEFAULT_MODEL) {
       'https://chatgpt.com/backend-api/codex/responses',
       {
         model,
-        instructions: 'Reply briefly.',
-        input: [{ role: 'user', content: [{ type: 'input_text', text: 'Reply with OK.' }] }],
+        instructions: '',
+        input: createOpenAITestPayload(model).input,
         stream: true,
         store: false
       },

--- a/src/services/openaiAccountTestService.js
+++ b/src/services/openaiAccountTestService.js
@@ -2,6 +2,7 @@ const axios = require('axios')
 const { StringDecoder } = require('string_decoder')
 const accounts = require('./account/openaiAccountService')
 const ProxyHelper = require('../utils/proxyHelper')
+const { extractCodexUsageHeaders } = require('../utils/codexUsage')
 
 const DEFAULT_MODEL = 'gpt-5.5'
 const errors = {
@@ -114,9 +115,25 @@ async function readResult(stream) {
 
 async function testAccount(accountId, model = DEFAULT_MODEL) {
   const startedAt = Date.now()
+  let quotaUpdated = false
+  let quotaError
+  const updateQuota = async (headers) => {
+    const snapshot = extractCodexUsageHeaders(headers)
+    if (!snapshot) {
+      return
+    }
+    try {
+      await accounts.updateCodexUsageSnapshot(accountId, snapshot)
+      quotaUpdated = true
+    } catch {
+      quotaError = 'QUOTA_SAVE_FAILED'
+    }
+  }
   const finish = (result) => ({
     ...result,
     model,
+    quotaUpdated,
+    ...(quotaError ? { quotaError } : {}),
     latencyMs: Date.now() - startedAt,
     timestamp: new Date().toISOString()
   })
@@ -182,12 +199,17 @@ async function testAccount(accountId, model = DEFAULT_MODEL) {
       }
     )
     stream = response.data
+    await updateQuota(response.headers)
     if (response.status !== 200) {
       return finish(statusFailure(response.status))
     }
     const result = await readResult(stream)
     return finish(timedOut ? failure('TIMEOUT') : result)
   } catch (error) {
+    if (error.response) {
+      stream = error.response.data
+      await updateQuota(error.response.headers)
+    }
     if (timedOut || ['ECONNABORTED', 'ETIMEDOUT'].includes(error.code)) {
       return finish(failure('TIMEOUT'))
     }

--- a/src/utils/codexUsage.js
+++ b/src/utils/codexUsage.js
@@ -1,0 +1,45 @@
+function normalizeHeaders(headers = {}) {
+  if (!headers || typeof headers !== 'object') {
+    return {}
+  }
+  const normalized = {}
+  for (const [key, value] of Object.entries(headers)) {
+    if (!key) {
+      continue
+    }
+    normalized[key.toLowerCase()] = Array.isArray(value) ? value[0] : value
+  }
+  return normalized
+}
+
+function toNumberSafe(value) {
+  if (value === undefined || value === null || value === '') {
+    return null
+  }
+  const num = Number(value)
+  return Number.isFinite(num) ? num : null
+}
+
+function extractCodexUsageHeaders(headers) {
+  const normalized = normalizeHeaders(headers)
+  if (!normalized || Object.keys(normalized).length === 0) {
+    return null
+  }
+
+  const snapshot = {
+    primaryUsedPercent: toNumberSafe(normalized['x-codex-primary-used-percent']),
+    primaryResetAfterSeconds: toNumberSafe(normalized['x-codex-primary-reset-after-seconds']),
+    primaryWindowMinutes: toNumberSafe(normalized['x-codex-primary-window-minutes']),
+    secondaryUsedPercent: toNumberSafe(normalized['x-codex-secondary-used-percent']),
+    secondaryResetAfterSeconds: toNumberSafe(normalized['x-codex-secondary-reset-after-seconds']),
+    secondaryWindowMinutes: toNumberSafe(normalized['x-codex-secondary-window-minutes']),
+    primaryOverSecondaryPercent: toNumberSafe(
+      normalized['x-codex-primary-over-secondary-limit-percent']
+    )
+  }
+
+  const hasData = Object.values(snapshot).some((value) => value !== null)
+  return hasData ? snapshot : null
+}
+
+module.exports = { extractCodexUsageHeaders }

--- a/tests/codexUsage.test.js
+++ b/tests/codexUsage.test.js
@@ -1,0 +1,43 @@
+const { extractCodexUsageHeaders } = require('../src/utils/codexUsage')
+
+describe('Codex usage response headers', () => {
+  test('retains zero usage and zero-duration windows instead of treating them as absent', () => {
+    expect(
+      extractCodexUsageHeaders({
+        'x-codex-primary-used-percent': '0',
+        'x-codex-primary-window-minutes': '10080',
+        'x-codex-primary-reset-after-seconds': '602505',
+        'x-codex-secondary-used-percent': 0,
+        'x-codex-secondary-window-minutes': '0',
+        'x-codex-secondary-reset-after-seconds': '0'
+      })
+    ).toEqual({
+      primaryUsedPercent: 0,
+      primaryWindowMinutes: 10080,
+      primaryResetAfterSeconds: 602505,
+      secondaryUsedPercent: 0,
+      secondaryWindowMinutes: 0,
+      secondaryResetAfterSeconds: 0,
+      primaryOverSecondaryPercent: null
+    })
+  })
+
+  test('accepts case-insensitive header names and the first array value', () => {
+    expect(
+      extractCodexUsageHeaders({ 'X-Codex-Primary-Used-Percent': ['12.5', '20'] })
+    ).toMatchObject({ primaryUsedPercent: 12.5 })
+  })
+
+  test.each([
+    undefined,
+    null,
+    {},
+    { 'content-type': 'text/event-stream' },
+    {
+      'x-codex-primary-used-percent': 'NaN',
+      'x-codex-secondary-used-percent': ''
+    }
+  ])('does not create a quota snapshot without numeric quota data: %p', (headers) => {
+    expect(extractCodexUsageHeaders(headers)).toBeNull()
+  })
+})

--- a/tests/openaiAccountTestScheduler.test.js
+++ b/tests/openaiAccountTestScheduler.test.js
@@ -1,0 +1,81 @@
+jest.mock('../src/services/openaiAccountTestService', () => ({ testAccount: jest.fn() }), {
+  virtual: true
+})
+jest.mock('../src/models/redis', () => ({
+  saveAccountTestResult: jest.fn(),
+  setAccountLastTestTime: jest.fn(),
+  getAccountTestHistory: jest.fn(),
+  getAccountTestConfig: jest.fn(),
+  saveAccountTestConfig: jest.fn(),
+  getEnabledTestAccounts: jest.fn()
+}))
+jest.mock('node-cron', () => ({ validate: jest.fn(), schedule: jest.fn() }))
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn()
+}))
+
+const probe = require('../src/services/openaiAccountTestService')
+const redis = require('../src/models/redis')
+const cron = require('node-cron')
+const scheduler = require('../src/services/accountTestSchedulerService')
+
+describe('OpenAI scheduler integration', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    cron.validate.mockReturnValue(true)
+    cron.schedule.mockReturnValue({ stop: jest.fn() })
+    redis.getEnabledTestAccounts.mockResolvedValue([])
+  })
+  afterEach(() => scheduler.stop())
+
+  test.each([true, false])(
+    'manual probe persists actual success=%s and updates last test time',
+    async (success) => {
+      const result = {
+        success,
+        model: 'gpt-5.5',
+        latencyMs: 17,
+        timestamp: new Date().toISOString()
+      }
+      probe.testAccount.mockResolvedValue(result)
+      expect(await scheduler.triggerTest('account-1', 'openai', 'gpt-5.5')).toEqual(result)
+      expect(probe.testAccount).toHaveBeenCalledWith('account-1', 'gpt-5.5')
+      expect(redis.saveAccountTestResult).toHaveBeenCalledWith('account-1', 'openai', result)
+      expect(redis.setAccountLastTestTime).toHaveBeenCalledWith('account-1', 'openai')
+    }
+  )
+
+  test('scheduled callback tests the configured OpenAI account and model', async () => {
+    redis.getEnabledTestAccounts.mockImplementation(async (platform) =>
+      platform === 'openai'
+        ? [{ accountId: 'scheduled-account', cronExpression: '*/5 * * * *', model: 'gpt-5.5' }]
+        : []
+    )
+    probe.testAccount.mockResolvedValue({ success: true })
+    await scheduler.start()
+    expect(cron.schedule).toHaveBeenCalledTimes(1)
+    await cron.schedule.mock.calls[0][1]()
+    expect(probe.testAccount).toHaveBeenCalledWith('scheduled-account', 'gpt-5.5')
+    expect(redis.saveAccountTestResult).toHaveBeenCalledWith('scheduled-account', 'openai', {
+      success: true
+    })
+  })
+
+  test('overlapping triggers send only one upstream request', async () => {
+    let finish
+    probe.testAccount.mockReturnValue(
+      new Promise((resolve) => {
+        finish = resolve
+      })
+    )
+    const first = scheduler.triggerTest('account-1', 'openai', 'gpt-5.5')
+    await scheduler.triggerTest('account-1', 'openai', 'gpt-5.5')
+    expect(probe.testAccount).toHaveBeenCalledTimes(1)
+    finish({ success: true })
+    await first
+    expect(redis.saveAccountTestResult).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/openaiAccountTestService.test.js
+++ b/tests/openaiAccountTestService.test.js
@@ -55,7 +55,7 @@ const respond = (...events) => {
   })
 }
 const expectSafeFailure = (result, code) => {
-  expect(result).toMatchObject({ success: false, code, model: 'gpt-5.5' })
+  expect(result).toMatchObject({ success: false, code, model: 'gpt-6-astra' })
   expect(typeof result.error).toBe('string')
   expect(JSON.stringify(result)).not.toContain('secret-token')
   expect(JSON.stringify(result)).not.toContain('private-upstream-payload')
@@ -137,13 +137,13 @@ describe('OpenAI OAuth account tests', () => {
   test('tests the selected OAuth account and accepts completed text across SSE chunks', async () => {
     respond(completed())
     const result = await testAccount('selected-account')
-    expect(result).toMatchObject({ success: true, model: 'gpt-5.5' })
+    expect(result).toMatchObject({ success: true, model: 'gpt-6-astra' })
     expect(result.latencyMs).toBeGreaterThanOrEqual(0)
     expect(Number.isNaN(Date.parse(result.timestamp))).toBe(false)
     expect(accounts.getAccount).toHaveBeenCalledWith('selected-account')
     expect(axios.post).toHaveBeenCalledWith(
       'https://chatgpt.com/backend-api/codex/responses',
-      expect.objectContaining({ model: 'gpt-5.5', stream: true, store: false }),
+      expect.objectContaining({ model: 'gpt-6-astra', stream: true, store: false }),
       expect.objectContaining({
         responseType: 'stream',
         headers: expect.objectContaining({

--- a/tests/openaiAccountTestService.test.js
+++ b/tests/openaiAccountTestService.test.js
@@ -20,6 +20,7 @@ const axios = require('axios')
 const accounts = require('../src/services/account/openaiAccountService')
 const proxyHelper = require('../src/utils/proxyHelper')
 const { testAccount } = require('../src/services/openaiAccountTestService')
+const { createOpenAITestPayload } = require('../src/utils/testPayloadHelper')
 
 const completed = (text = 'OK') => ({
   type: 'response.completed',
@@ -125,7 +126,9 @@ describe('OpenAI OAuth account tests', () => {
         quotaUpdated: false,
         quotaError: 'QUOTA_SAVE_FAILED'
       })
-      if (status === 429) expectSafeFailure(result, 'RATE_LIMITED')
+      if (status === 429) {
+        expectSafeFailure(result, 'RATE_LIMITED')
+      }
       expect(JSON.stringify(result)).not.toContain('secret-token')
       expect(JSON.stringify(result)).not.toContain('private-upstream-payload')
     }
@@ -150,6 +153,15 @@ describe('OpenAI OAuth account tests', () => {
       })
     )
     expect(JSON.stringify(result)).not.toContain('secret-token')
+  })
+
+  test('uses the shared probe input with Codex-compatible request fields', async () => {
+    respond(completed())
+    await testAccount('selected-account', 'gpt-5.5')
+    const payload = axios.post.mock.calls[0][1]
+    expect(payload.input).toEqual(createOpenAITestPayload('gpt-5.5').input)
+    expect(payload).toMatchObject({ instructions: '', stream: true, store: false })
+    expect(payload).not.toHaveProperty('max_output_tokens')
   })
 
   test.each(['response.failed', 'error'])('rejects HTTP 200 SSE %s safely', async (type) => {

--- a/tests/openaiAccountTestService.test.js
+++ b/tests/openaiAccountTestService.test.js
@@ -5,7 +5,8 @@ jest.mock('../src/services/account/openaiAccountService', () => ({
   getAccount: jest.fn(),
   isTokenExpired: jest.fn(),
   refreshAccountToken: jest.fn(),
-  decrypt: jest.fn()
+  decrypt: jest.fn(),
+  updateCodexUsageSnapshot: jest.fn()
 }))
 jest.mock('../src/utils/proxyHelper', () => ({ createProxyAgent: jest.fn() }))
 jest.mock('../src/utils/logger', () => ({
@@ -28,6 +29,23 @@ const completed = (text = 'OK') => ({
   }
 })
 const encode = (event) => `data: ${JSON.stringify(event)}\n\n`
+const quotaHeaders = {
+  'x-codex-primary-used-percent': '0',
+  'x-codex-primary-window-minutes': '10080',
+  'x-codex-primary-reset-after-seconds': '602505',
+  'x-codex-secondary-used-percent': '0',
+  'x-codex-secondary-window-minutes': '0',
+  'x-codex-secondary-reset-after-seconds': '0'
+}
+const quotaSnapshot = {
+  primaryUsedPercent: 0,
+  primaryWindowMinutes: 10080,
+  primaryResetAfterSeconds: 602505,
+  secondaryUsedPercent: 0,
+  secondaryWindowMinutes: 0,
+  secondaryResetAfterSeconds: 0,
+  primaryOverSecondaryPercent: null
+}
 const respond = (...events) => {
   const wire = events.map(encode).join('')
   axios.post.mockResolvedValue({
@@ -52,8 +70,66 @@ describe('OpenAI OAuth account tests', () => {
     })
     accounts.isTokenExpired.mockReturnValue(false)
     accounts.decrypt.mockReturnValue('secret-token')
+    accounts.updateCodexUsageSnapshot.mockResolvedValue(undefined)
     proxyHelper.createProxyAgent.mockReturnValue(null)
   })
+
+  test('saves zero usage and weekly quota from a successful OAuth probe', async () => {
+    axios.post.mockResolvedValue({
+      status: 200,
+      headers: quotaHeaders,
+      data: Readable.from([encode(completed())])
+    })
+    const result = await testAccount('selected-account')
+    expect(result).toMatchObject({ success: true, quotaUpdated: true })
+    expect(accounts.updateCodexUsageSnapshot).toHaveBeenCalledWith(
+      'selected-account',
+      quotaSnapshot
+    )
+  })
+
+  test('does not overwrite quota when the response has no quota headers', async () => {
+    respond(completed())
+    expect(await testAccount('selected-account')).toMatchObject({
+      success: true,
+      quotaUpdated: false
+    })
+    expect(accounts.updateCodexUsageSnapshot).not.toHaveBeenCalled()
+  })
+
+  test('saves quota on a rejected rate-limited request without reporting generation success', async () => {
+    axios.post.mockRejectedValue({ response: { status: 429, headers: quotaHeaders } })
+    const result = await testAccount('selected-account')
+    expectSafeFailure(result, 'RATE_LIMITED')
+    expect(result.quotaUpdated).toBe(true)
+    expect(accounts.updateCodexUsageSnapshot).toHaveBeenCalledWith(
+      'selected-account',
+      quotaSnapshot
+    )
+  })
+
+  test.each([200, 429])(
+    'quota persistence failure preserves the HTTP %s generation result',
+    async (status) => {
+      accounts.updateCodexUsageSnapshot.mockRejectedValue(
+        new Error('private-upstream-payload secret-token')
+      )
+      axios.post.mockResolvedValue({
+        status,
+        headers: quotaHeaders,
+        data: Readable.from([encode(completed())])
+      })
+      const result = await testAccount('selected-account')
+      expect(result).toMatchObject({
+        success: status === 200,
+        quotaUpdated: false,
+        quotaError: 'QUOTA_SAVE_FAILED'
+      })
+      if (status === 429) expectSafeFailure(result, 'RATE_LIMITED')
+      expect(JSON.stringify(result)).not.toContain('secret-token')
+      expect(JSON.stringify(result)).not.toContain('private-upstream-payload')
+    }
+  )
 
   test('tests the selected OAuth account and accepts completed text across SSE chunks', async () => {
     respond(completed())

--- a/tests/openaiAccountTestService.test.js
+++ b/tests/openaiAccountTestService.test.js
@@ -1,0 +1,234 @@
+const { Readable } = require('stream')
+
+jest.mock('axios', () => ({ post: jest.fn() }))
+jest.mock('../src/services/account/openaiAccountService', () => ({
+  getAccount: jest.fn(),
+  isTokenExpired: jest.fn(),
+  refreshAccountToken: jest.fn(),
+  decrypt: jest.fn()
+}))
+jest.mock('../src/utils/proxyHelper', () => ({ createProxyAgent: jest.fn() }))
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn()
+}))
+
+const axios = require('axios')
+const accounts = require('../src/services/account/openaiAccountService')
+const proxyHelper = require('../src/utils/proxyHelper')
+const { testAccount } = require('../src/services/openaiAccountTestService')
+
+const completed = (text = 'OK') => ({
+  type: 'response.completed',
+  response: {
+    status: 'completed',
+    output: [{ type: 'message', content: [{ type: 'output_text', text }] }]
+  }
+})
+const encode = (event) => `data: ${JSON.stringify(event)}\n\n`
+const respond = (...events) => {
+  const wire = events.map(encode).join('')
+  axios.post.mockResolvedValue({
+    status: 200,
+    data: Readable.from([wire.slice(0, 9), wire.slice(9)])
+  })
+}
+const expectSafeFailure = (result, code) => {
+  expect(result).toMatchObject({ success: false, code, model: 'gpt-5.5' })
+  expect(typeof result.error).toBe('string')
+  expect(JSON.stringify(result)).not.toContain('secret-token')
+  expect(JSON.stringify(result)).not.toContain('private-upstream-payload')
+}
+
+describe('OpenAI OAuth account tests', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    accounts.getAccount.mockResolvedValue({
+      id: 'selected-account',
+      accountId: 'chatgpt-account',
+      accessToken: 'encrypted-token'
+    })
+    accounts.isTokenExpired.mockReturnValue(false)
+    accounts.decrypt.mockReturnValue('secret-token')
+    proxyHelper.createProxyAgent.mockReturnValue(null)
+  })
+
+  test('tests the selected OAuth account and accepts completed text across SSE chunks', async () => {
+    respond(completed())
+    const result = await testAccount('selected-account')
+    expect(result).toMatchObject({ success: true, model: 'gpt-5.5' })
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0)
+    expect(Number.isNaN(Date.parse(result.timestamp))).toBe(false)
+    expect(accounts.getAccount).toHaveBeenCalledWith('selected-account')
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://chatgpt.com/backend-api/codex/responses',
+      expect.objectContaining({ model: 'gpt-5.5', stream: true, store: false }),
+      expect.objectContaining({
+        responseType: 'stream',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer secret-token',
+          'chatgpt-account-id': 'chatgpt-account'
+        })
+      })
+    )
+    expect(JSON.stringify(result)).not.toContain('secret-token')
+  })
+
+  test.each(['response.failed', 'error'])('rejects HTTP 200 SSE %s safely', async (type) => {
+    respond({
+      type,
+      error: { message: 'private-upstream-payload secret-token' },
+      response: { error: { message: 'private-upstream-payload' } }
+    })
+    expectSafeFailure(await testAccount('selected-account'), 'UPSTREAM_ERROR')
+  })
+
+  test('does not treat partial text as a completed response', async () => {
+    respond({ type: 'response.output_text.delta', delta: 'partial' })
+    expectSafeFailure(await testAccount('selected-account'), 'INCOMPLETE_RESPONSE')
+  })
+
+  test.each([
+    { type: 'response.output_text.delta', delta: 'OK' },
+    { type: 'response.output_text.done', text: 'OK' }
+  ])(
+    'accepts streamed text followed by completion with an empty output array: $type',
+    async (event) => {
+      respond(event, { type: 'response.completed', response: { status: 'completed', output: [] } })
+      expect((await testAccount('selected-account')).success).toBe(true)
+    }
+  )
+
+  test('a failure after streamed text does not become a successful test', async () => {
+    respond(
+      { type: 'response.output_text.delta', delta: 'OK' },
+      {
+        type: 'response.failed',
+        response: { status: 'failed', error: { message: 'private-upstream-payload' } }
+      }
+    )
+    expectSafeFailure(await testAccount('selected-account'), 'UPSTREAM_ERROR')
+  })
+
+  test('decodes UTF-8 and CRLF boundaries split across network chunks', async () => {
+    const wire = Buffer.from(encode(completed('有效回复')).replace(/\n/g, '\r\n'))
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: Readable.from(Array.from(wire, (byte) => Buffer.from([byte])))
+    })
+    expect((await testAccount('selected-account')).success).toBe(true)
+  })
+
+  test('aborts a stream that never completes within the request deadline', async () => {
+    jest.useFakeTimers()
+    const stream = new Readable({ read() {} })
+    axios.post.mockResolvedValue({ status: 200, data: stream })
+    try {
+      const pending = testAccount('selected-account')
+      await jest.advanceTimersByTimeAsync(61000)
+      expectSafeFailure(await pending, 'TIMEOUT')
+      expect(stream.destroyed).toBe(true)
+      expect(axios.post.mock.calls[0][2].signal.aborted).toBe(true)
+    } finally {
+      stream.destroy()
+      jest.useRealTimers()
+    }
+  })
+
+  test('rejects completion without usable output text', async () => {
+    respond(completed('  '))
+    expectSafeFailure(await testAccount('selected-account'), 'INVALID_RESPONSE')
+  })
+
+  test('does not send requests for an unknown account', async () => {
+    accounts.getAccount.mockResolvedValue(null)
+    expectSafeFailure(await testAccount('missing'), 'ACCOUNT_NOT_FOUND')
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  test('refreshes expired credentials and uses the newly persisted token', async () => {
+    accounts.isTokenExpired.mockReturnValueOnce(true).mockReturnValue(false)
+    accounts.getAccount
+      .mockResolvedValueOnce({ id: 'selected-account', accessToken: 'old-cipher' })
+      .mockResolvedValue({
+        id: 'selected-account',
+        accountId: 'chatgpt-account',
+        accessToken: 'new-cipher'
+      })
+    accounts.decrypt.mockImplementation((cipher) =>
+      cipher === 'new-cipher' ? 'fresh-token' : 'stale-token'
+    )
+    respond(completed())
+    expect((await testAccount('selected-account')).success).toBe(true)
+    expect(accounts.refreshAccountToken.mock.calls[0][0]).toBe('selected-account')
+    expect(accounts.getAccount).toHaveBeenCalledTimes(2)
+    expect(axios.post.mock.calls[0][2].headers.Authorization).toBe('Bearer fresh-token')
+  })
+
+  test('reports refresh failures without leaking exception content', async () => {
+    accounts.isTokenExpired.mockReturnValue(true)
+    accounts.refreshAccountToken.mockRejectedValue(
+      new Error('private-upstream-payload secret-token')
+    )
+    expectSafeFailure(await testAccount('selected-account'), 'TOKEN_REFRESH_FAILED')
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  test('applies the same deadline to an expired-token refresh that hangs', async () => {
+    jest.useFakeTimers()
+    accounts.isTokenExpired.mockReturnValue(true)
+    accounts.refreshAccountToken.mockReturnValue(new Promise(() => {}))
+    try {
+      const pending = testAccount('selected-account')
+      await jest.advanceTimersByTimeAsync(61000)
+      expectSafeFailure(await pending, 'TIMEOUT')
+      expect(axios.post).not.toHaveBeenCalled()
+      expect(accounts.refreshAccountToken.mock.calls[0][1].signal.aborted).toBe(true)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  test('routes the OAuth probe through the configured account proxy', async () => {
+    const proxy = { type: 'socks5', host: 'localhost', port: 1080 }
+    const agent = { marker: 'proxy-agent' }
+    accounts.getAccount.mockResolvedValue({
+      id: 'selected-account',
+      accountId: 'chatgpt-account',
+      accessToken: 'encrypted-token',
+      proxy
+    })
+    proxyHelper.createProxyAgent.mockReturnValue(agent)
+    respond(completed())
+    expect((await testAccount('selected-account')).success).toBe(true)
+    expect(proxyHelper.createProxyAgent.mock.calls[0][0]).toEqual(proxy)
+    expect(axios.post.mock.calls[0][2]).toMatchObject({ httpsAgent: agent, proxy: false })
+  })
+
+  test.each([
+    [401, 'AUTH_ERROR'],
+    [403, 'AUTH_ERROR'],
+    [429, 'RATE_LIMITED'],
+    [503, 'UPSTREAM_ERROR']
+  ])('classifies HTTP %s without returning raw errors', async (status, code) => {
+    axios.post.mockRejectedValue(
+      Object.assign(new Error('secret-token'), {
+        response: { status, data: { error: 'private-upstream-payload' } }
+      })
+    )
+    expectSafeFailure(await testAccount('selected-account'), code)
+  })
+
+  test.each([
+    ['ECONNABORTED', 'TIMEOUT'],
+    ['ETIMEDOUT', 'TIMEOUT'],
+    ['ECONNRESET', 'NETWORK_ERROR']
+  ])('classifies transport failure %s safely', async (transportCode, code) => {
+    axios.post.mockRejectedValue(
+      Object.assign(new Error('private-upstream-payload secret-token'), { code: transportCode })
+    )
+    expectSafeFailure(await testAccount('selected-account'), code)
+  })
+})

--- a/tests/openaiAccountTestsRoute.test.js
+++ b/tests/openaiAccountTestsRoute.test.js
@@ -1,0 +1,162 @@
+jest.mock('../src/middleware/auth', () => ({
+  authenticateAdmin: (req, res, next) =>
+    req.headers['x-test-admin'] === 'yes' ? next() : res.status(401).json({ success: false })
+}))
+jest.mock('../src/services/account/openaiAccountService', () => ({ getAccount: jest.fn() }))
+jest.mock('../src/services/accountTestSchedulerService', () => ({
+  triggerTest: jest.fn(),
+  getTestHistory: jest.fn(),
+  getTestConfig: jest.fn(),
+  setTestConfig: jest.fn(),
+  validateCronExpression: jest.fn(),
+  getStatus: jest.fn(),
+  testingAccounts: new Set()
+}))
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn()
+}))
+jest.mock('../src/utils/proxyHelper', () => ({ createProxyAgent: jest.fn() }))
+jest.mock('../src/services/accountGroupService', () => ({}))
+jest.mock('../src/services/apiKeyService', () => ({}))
+jest.mock('../src/models/redis', () => ({}))
+jest.mock('../src/utils/webhookNotifier', () => ({}))
+
+const express = require('express')
+const request = require('supertest')
+const accounts = require('../src/services/account/openaiAccountService')
+const scheduler = require('../src/services/accountTestSchedulerService')
+const router = require('../src/routes/admin/openaiAccounts')
+const app = express()
+app.use(express.json())
+app.use('/admin/openai-accounts', router)
+const base = '/admin/openai-accounts/account-1'
+const admin = (req) => req.set('x-test-admin', 'yes')
+
+describe('OpenAI admin test routes', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    scheduler.testingAccounts.clear()
+    accounts.getAccount.mockResolvedValue({ id: 'account-1' })
+    scheduler.validateCronExpression.mockReturnValue(true)
+    scheduler.getStatus.mockReturnValue({ currentlyTesting: [] })
+    scheduler.getTestConfig.mockResolvedValue(null)
+    scheduler.triggerTest.mockResolvedValue({ success: true, model: 'gpt-5.5', message: 'OK' })
+  })
+
+  test.each(['test', 'test-sync'])(
+    '%s rejects non-admin requests before probing',
+    async (endpoint) => {
+      const res = await request(app).post(`${base}/${endpoint}`).send({})
+      expect([401, 403]).toContain(res.status)
+      expect(scheduler.triggerTest).not.toHaveBeenCalled()
+    }
+  )
+
+  test.each(['test', 'test-sync'])(
+    '%s returns actual probe result and uses default model',
+    async (endpoint) => {
+      const res = await admin(request(app).post(`${base}/${endpoint}`)).send({})
+      expect(res.status).toBe(200)
+      expect(res.body.success).toBe(true)
+      expect(res.body.data.result.success).toBe(true)
+      expect(scheduler.triggerTest).toHaveBeenCalledWith('account-1', 'openai', 'gpt-5.5')
+    }
+  )
+
+  test.each(['test', 'test-sync'])(
+    '%s restores the saved account model when omitted',
+    async (endpoint) => {
+      scheduler.getTestConfig.mockResolvedValue({ enabled: true, model: 'gpt-5.6-luna' })
+      const res = await admin(request(app).post(`${base}/${endpoint}`)).send({})
+      expect(res.status).toBe(200)
+      expect(scheduler.triggerTest).toHaveBeenCalledWith('account-1', 'openai', 'gpt-5.6-luna')
+      expect(res.body.data.model).toBe('gpt-5.6-luna')
+    }
+  )
+
+  test('an explicit model overrides the saved account model', async () => {
+    scheduler.getTestConfig.mockResolvedValue({ enabled: true, model: 'gpt-5.6-luna' })
+    const res = await admin(request(app).post(`${base}/test`)).send({ model: 'gpt-5.5' })
+    expect(res.status).toBe(200)
+    expect(scheduler.triggerTest).toHaveBeenCalledWith('account-1', 'openai', 'gpt-5.5')
+    expect(res.body.data.model).toBe('gpt-5.5')
+  })
+
+  test('upstream failure remains a failure in the top-level JSON response', async () => {
+    scheduler.triggerTest.mockResolvedValue({
+      success: false,
+      code: 'RATE_LIMITED',
+      error: 'safe-error'
+    })
+    const res = await admin(request(app).post(`${base}/test`)).send({ model: 'gpt-5.5' })
+    expect(res.body.success).toBe(false)
+    expect(res.body.data.result.code).toBe('RATE_LIMITED')
+  })
+
+  test('unknown account returns 404 without probing', async () => {
+    accounts.getAccount.mockResolvedValue(null)
+    const res = await admin(request(app).post(`${base}/test`)).send({})
+    expect(res.status).toBe(404)
+    expect(scheduler.triggerTest).not.toHaveBeenCalled()
+  })
+
+  test('invalid model returns 400 without probing', async () => {
+    const res = await admin(request(app).post(`${base}/test`)).send({ model: { injected: true } })
+    expect(res.status).toBe(400)
+    expect(scheduler.triggerTest).not.toHaveBeenCalled()
+  })
+
+  test('duplicate test returns 409', async () => {
+    scheduler.testingAccounts.add('openai:account-1')
+    scheduler.getStatus.mockReturnValue({ currentlyTesting: ['openai:account-1'] })
+    scheduler.triggerTest.mockResolvedValue(undefined)
+    const res = await admin(request(app).post(`${base}/test`)).send({})
+    expect(res.status).toBe(409)
+  })
+
+  test('configuration updates use the OpenAI platform', async () => {
+    const config = { enabled: true, cronExpression: '*/5 * * * *', model: 'gpt-5.5' }
+    scheduler.getTestConfig.mockResolvedValue(config)
+    const res = await admin(request(app).put(`${base}/test-config`)).send(config)
+    expect(res.status).toBe(200)
+    expect(scheduler.setTestConfig).toHaveBeenCalledWith('account-1', 'openai', config)
+  })
+
+  test('failed persistence does not report a successful configuration update', async () => {
+    scheduler.getTestConfig.mockResolvedValue(null)
+    const res = await admin(request(app).put(`${base}/test-config`)).send({
+      enabled: true,
+      cronExpression: '*/5 * * * *',
+      model: 'gpt-5.5'
+    })
+    expect(res.status).toBe(500)
+    expect(res.body.success).toBe(false)
+    expect(res.body.code).toBe('CONFIG_WRITE_FAILED')
+  })
+
+  test('invalid cron is rejected before persistence', async () => {
+    scheduler.validateCronExpression.mockReturnValue(false)
+    const res = await admin(request(app).put(`${base}/test-config`)).send({
+      enabled: true,
+      cronExpression: 'invalid',
+      model: 'gpt-5.5'
+    })
+    expect(res.status).toBe(400)
+    expect(scheduler.setTestConfig).not.toHaveBeenCalled()
+  })
+
+  test('configuration and history read the requested account namespace', async () => {
+    scheduler.getTestConfig.mockResolvedValue({ enabled: false, model: 'gpt-5.5' })
+    scheduler.getTestHistory.mockResolvedValue([{ success: false, code: 'TIMEOUT' }])
+    const config = await admin(request(app).get(`${base}/test-config`))
+    const history = await admin(request(app).get(`${base}/test-history`))
+    expect(config.status).toBe(200)
+    expect(history.status).toBe(200)
+    expect(scheduler.getTestConfig).toHaveBeenCalledWith('account-1', 'openai')
+    expect(scheduler.getTestHistory).toHaveBeenCalledWith('account-1', 'openai')
+    expect(JSON.stringify(history.body)).toContain('TIMEOUT')
+  })
+})

--- a/tests/openaiAccountTestsRoute.test.js
+++ b/tests/openaiAccountTestsRoute.test.js
@@ -62,7 +62,7 @@ describe('OpenAI admin test routes', () => {
       expect(res.status).toBe(200)
       expect(res.body.success).toBe(true)
       expect(res.body.data.result.success).toBe(true)
-      expect(scheduler.triggerTest).toHaveBeenCalledWith('account-1', 'openai', 'gpt-5.5')
+      expect(scheduler.triggerTest).toHaveBeenCalledWith('account-1', 'openai', 'gpt-6-astra')
     }
   )
 
@@ -115,6 +115,17 @@ describe('OpenAI admin test routes', () => {
     scheduler.triggerTest.mockResolvedValue(undefined)
     const res = await admin(request(app).post(`${base}/test`)).send({})
     expect(res.status).toBe(409)
+  })
+
+  test('an unconfigured account receives the default test model', async () => {
+    const res = await admin(request(app).get(`${base}/test-config`))
+    expect(res.status).toBe(200)
+    expect(res.body.data.config).toEqual({
+      enabled: false,
+      cronExpression: '0 */6 * * *',
+      model: 'gpt-6-astra'
+    })
+    expect(scheduler.setTestConfig).not.toHaveBeenCalled()
   })
 
   test('configuration updates use the OpenAI platform', async () => {

--- a/web/admin-spa/src/components/accounts/AccountScheduledTestModal.vue
+++ b/web/admin-spa/src/components/accounts/AccountScheduledTestModal.vue
@@ -241,7 +241,7 @@ const cronPresets = [
 ]
 
 const defaultModel = () =>
-  props.account?.platform === 'openai' ? 'gpt-5.5' : 'claude-sonnet-4-5-20250929'
+  props.account?.platform === 'openai' ? 'gpt-6-astra' : 'claude-sonnet-4-5-20250929'
 
 // 模型选项（从 API 动态获取）
 const modelOptions = ref([])

--- a/web/admin-spa/src/components/accounts/AccountScheduledTestModal.vue
+++ b/web/admin-spa/src/components/accounts/AccountScheduledTestModal.vue
@@ -240,6 +240,9 @@ const cronPresets = [
   { label: '工作日 9:00', value: '0 9 * * 1-5' }
 ]
 
+const defaultModel = () =>
+  props.account?.platform === 'openai' ? 'gpt-5.5' : 'claude-sonnet-4-5-20250929'
+
 // 模型选项（从 API 动态获取）
 const modelOptions = ref([])
 
@@ -276,8 +279,8 @@ async function loadConfig() {
 
     // 根据平台获取配置端点
     let endpoint = ''
-    if (platform === 'claude') {
-      endpoint = `${APP_CONFIG.apiPrefix}/admin/claude-accounts/${props.account.id}/test-config`
+    if (['claude', 'openai'].includes(platform)) {
+      endpoint = `${APP_CONFIG.apiPrefix}/admin/${platform}-accounts/${props.account.id}/test-config`
     } else {
       // 其他平台暂不支持
       loading.value = false
@@ -297,7 +300,7 @@ async function loadConfig() {
         config.value = {
           enabled: data.data.config.enabled || false,
           cronExpression: data.data.config.cronExpression || '0 8 * * *',
-          model: data.data.config.model || 'claude-sonnet-4-5-20250929'
+          model: data.data.config.model || defaultModel()
         }
       }
     }
@@ -333,8 +336,8 @@ async function saveConfig() {
     const platform = props.account.platform
 
     let endpoint = ''
-    if (platform === 'claude') {
-      endpoint = `${APP_CONFIG.apiPrefix}/admin/claude-accounts/${props.account.id}/test-config`
+    if (['claude', 'openai'].includes(platform)) {
+      endpoint = `${APP_CONFIG.apiPrefix}/admin/${platform}-accounts/${props.account.id}/test-config`
     } else {
       saving.value = false
       return
@@ -382,9 +385,10 @@ watch(
       config.value = {
         enabled: false,
         cronExpression: '0 8 * * *',
-        model: 'claude-sonnet-4-5-20250929'
+        model: defaultModel()
       }
       testHistory.value = []
+      loadModels()
       loadConfig()
     }
   }

--- a/web/admin-spa/src/components/common/ModelSelector.vue
+++ b/web/admin-spa/src/components/common/ModelSelector.vue
@@ -8,7 +8,7 @@
       :value="modelValue"
       @change="handleSelectChange"
     >
-      <option v-for="m in models" :key="m.value" :value="m.value">
+      <option v-for="m in modelOptions" :key="m.value" :value="m.value">
         {{ m.label }}
       </option>
       <option value="__custom__">自定义模型...</option>
@@ -37,7 +37,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 const props = defineProps({
   modelValue: { type: String, default: '' },
@@ -49,6 +49,12 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue'])
 
 const customMode = ref(false)
+const modelOptions = computed(() => {
+  if (!props.modelValue || props.models.some((model) => model.value === props.modelValue)) {
+    return props.models
+  }
+  return [{ value: props.modelValue, label: props.modelValue }, ...props.models]
+})
 
 const handleSelectChange = (e) => {
   if (e.target.value === '__custom__') {
@@ -61,8 +67,7 @@ const handleSelectChange = (e) => {
 
 const exitCustomMode = () => {
   customMode.value = false
-  // 切回列表时选中第一个预设模型
-  if (props.models.length > 0) {
+  if (!props.modelValue && props.models.length > 0) {
     emit('update:modelValue', props.models[0].value)
   }
 }

--- a/web/admin-spa/src/components/common/UnifiedTestModal.vue
+++ b/web/admin-spa/src/components/common/UnifiedTestModal.vue
@@ -284,6 +284,7 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { APP_CONFIG } from '@/utils/tools'
 import { getModelsApi } from '@/utils/http_apis'
+import request from '@/utils/request'
 import { useTestState } from '@/utils/useTestState'
 import ModelSelector from '@/components/common/ModelSelector.vue'
 
@@ -303,6 +304,7 @@ const state = useTestState()
 
 // ========== 模型相关 ==========
 const selectedModel = ref('')
+const loadingAccountModel = ref(false)
 const modelsFromApi = ref({ claude: [], gemini: [], openai: [], platforms: {} })
 
 const loadModels = async () => {
@@ -330,6 +332,7 @@ const availableModels = computed(() => {
 
 // 各平台回退默认模型（模型列表未加载时使用）
 const platformFallbackModels = {
+  openai: 'gpt-5.5',
   claude: 'claude-sonnet-4-5-20250929',
   'claude-console': 'claude-sonnet-4-5-20250929',
   gemini: 'gemini-2.5-pro',
@@ -342,6 +345,7 @@ const platformFallbackModels = {
 const defaultModel = computed(() => {
   if (props.mode === 'account') {
     const platform = props.account?.platform
+    if (platform === 'openai') return platformFallbackModels.openai
     if (platform === 'azure-openai') return props.account?.deploymentName
     // bedrock 优先用列表，列表为空时按凭证类型回退
     if (platform === 'bedrock') {
@@ -404,10 +408,17 @@ const maskedApiKey = computed(() => {
   return key.substring(0, 6) + '****' + key.substring(key.length - 4)
 })
 
-const disableTest = computed(() => props.mode === 'apikey' && !props.apiKeyValue)
+const disableTest = computed(
+  () => loadingAccountModel.value || (props.mode === 'apikey' && !props.apiKeyValue)
+)
 
 // ========== account 模式 - 平台信息 ==========
 const platformConfigs = {
+  openai: {
+    label: 'OpenAI OAuth',
+    icon: 'fas fa-code',
+    badge: 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-300'
+  },
   claude: {
     label: 'Claude OAuth',
     icon: 'fas fa-brain',
@@ -522,6 +533,7 @@ const getAccountEndpoint = () => {
   if (!props.account) return ''
   const platform = props.account.platform
   const endpoints = {
+    openai: `${APP_CONFIG.apiPrefix}/admin/openai-accounts/${props.account.id}/test`,
     claude: `${APP_CONFIG.apiPrefix}/admin/claude-accounts/${props.account.id}/test`,
     'claude-console': `${APP_CONFIG.apiPrefix}/admin/claude-console-accounts/${props.account.id}/test`,
     bedrock: `${APP_CONFIG.apiPrefix}/admin/bedrock-accounts/${props.account.id}/test`,
@@ -575,24 +587,40 @@ const handleClose = () => {
 
 // ========== 监听 ==========
 watch(
-  () => props.show,
-  (newVal) => {
-    if (newVal) {
+  () => [props.show, props.account?.id, props.serviceType],
+  async ([show], _, onCleanup) => {
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
+    loadingAccountModel.value = false
+    if (show) {
       state.resetState()
       selectedModel.value = defaultModel.value
+      if (props.mode === 'account' && props.account?.platform === 'openai') {
+        loadingAccountModel.value = true
+        try {
+          const result = await request({
+            url: `/admin/openai-accounts/${props.account.id}/test-config`,
+            method: 'GET'
+          })
+          if (!result.success) throw new Error('CONFIG_READ_FAILED')
+          if (!cancelled) selectedModel.value = result.data?.config?.model || defaultModel.value
+        } catch {
+          if (!cancelled) {
+            state.testStatus.value = 'error'
+            state.errorMessage.value = '读取测试模型失败，请关闭后重试'
+          }
+          return
+        } finally {
+          if (!cancelled && state.testStatus.value !== 'error') loadingAccountModel.value = false
+        }
+      }
       if (props.mode === 'apikey') {
         testPrompt.value = 'hi'
         maxTokens.value = 1000
       }
     }
   }
-)
-
-watch(
-  () => [props.account, props.serviceType],
-  () => {
-    selectedModel.value = defaultModel.value
-  },
-  { deep: true }
 )
 </script>

--- a/web/admin-spa/src/components/common/UnifiedTestModal.vue
+++ b/web/admin-spa/src/components/common/UnifiedTestModal.vue
@@ -332,7 +332,7 @@ const availableModels = computed(() => {
 
 // 各平台回退默认模型（模型列表未加载时使用）
 const platformFallbackModels = {
-  openai: 'gpt-5.5',
+  openai: 'gpt-6-astra',
   claude: 'claude-sonnet-4-5-20250929',
   'claude-console': 'claude-sonnet-4-5-20250929',
   gemini: 'gemini-2.5-pro',

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -2745,6 +2745,7 @@ const closeAccountUsageModal = () => {
 
 // 测试账户连通性相关函数
 const supportedTestPlatforms = [
+  'openai',
   'claude',
   'claude-console',
   'bedrock',

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -1147,12 +1147,15 @@
                   </div>
                   <div v-else-if="account.platform === 'openai'" class="space-y-2">
                     <div v-if="account.codexUsage" class="space-y-2">
-                      <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                      <div
+                        v-if="account.codexUsage.primary.windowMinutes !== 0"
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300"
                           >
-                            {{ getCodexWindowLabel('primary') }}
+                            {{ getCodexWindowLabel(account.codexUsage.primary) }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -1179,12 +1182,15 @@
                           重置剩余 {{ formatCodexRemaining(account.codexUsage.primary) }}
                         </div>
                       </div>
-                      <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                      <div
+                        v-if="account.codexUsage.secondary.windowMinutes !== 0"
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:bg-blue-500/20 dark:text-blue-300"
                           >
-                            {{ getCodexWindowLabel('secondary') }}
+                            {{ getCodexWindowLabel(account.codexUsage.secondary) }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -1747,12 +1753,15 @@
             </div>
             <div v-else-if="account.platform === 'openai'" class="space-y-2">
               <div v-if="account.codexUsage" class="space-y-2">
-                <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700">
+                <div
+                  v-if="account.codexUsage.primary.windowMinutes !== 0"
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700"
+                >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300"
                     >
-                      {{ getCodexWindowLabel('primary') }}
+                      {{ getCodexWindowLabel(account.codexUsage.primary) }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -1779,12 +1788,15 @@
                     重置剩余 {{ formatCodexRemaining(account.codexUsage.primary) }}
                   </div>
                 </div>
-                <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700">
+                <div
+                  v-if="account.codexUsage.secondary.windowMinutes !== 0"
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700"
+                >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:bg-blue-500/20 dark:text-blue-300"
                     >
-                      {{ getCodexWindowLabel('secondary') }}
+                      {{ getCodexWindowLabel(account.codexUsage.secondary) }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -2771,8 +2783,10 @@ const openAccountTestModal = (account) => {
 }
 
 const closeAccountTestModal = () => {
+  const refreshQuota = testingAccount.value?.platform === 'openai'
   showAccountTestModal.value = false
   testingAccount.value = null
+  if (refreshQuota) loadAccounts()
 }
 
 // 定时测试配置相关函数
@@ -4950,12 +4964,13 @@ const getCodexUsageWidth = (usageItem) => {
   return `${percent}%`
 }
 
-// 时间窗口标签
-const getCodexWindowLabel = (type) => {
-  if (type === 'secondary') {
-    return '周限'
-  }
-  return '5h'
+// 时间窗口由上游指定，primary 不固定代表五小时。
+const getCodexWindowLabel = (usageItem) => {
+  const minutes = usageItem?.windowMinutes
+  if (!Number.isFinite(minutes) || minutes <= 0) return '未提供窗口'
+  if (minutes % 1440 === 0) return `${minutes / 1440}天`
+  if (minutes % 60 === 0) return `${minutes / 60}小时`
+  return `${minutes}分钟`
 }
 
 // 格式化剩余时间


### PR DESCRIPTION
OpenAI OAuth 账号此前没有手动测试入口，定时测试执行器也只返回“未实现”。本次接入现有测试弹窗、cron 调度和历史记录，让管理员可以按账号选择模型并检查实际生成能力。

- 手动和定时测试共用执行器，使用指定账号的 OAuth 凭证及代理；处理令牌刷新、60 秒超时、限流和流内错误。只有收到非空文本及正常完成事件才判定成功。
- 测试同步保存上游额度响应头，复用正常转发路径的解析逻辑；保存失败单独记录。关闭测试弹窗后刷新账号列表。
- 手动测试默认使用该账号保存的模型；读取配置失败时禁止发起测试，避免不同账号的模型权限差异造成误报。
- 已合并最新 main，额度窗口标签沿用上游 #1262 的实现。本 PR 不包含文档、部署配置、账号数据或测试产物。

验证：
- 独立代码审查；新增执行器、路由、调度器及额度响应头回归测试。
- 真实 Vue 模板和请求封装的浏览器验证覆盖模型恢复、配置读取失败及测试后额度刷新。
- 三个 OAuth 账号通过真实手动请求和 cron 测试；验证额度写回、重置时间计算及重启恢复。合并 main 后完整测试为 30 套通过、342 项通过、8 项跳过；lint 和前端构建均通过。

现有边界：定时调度的防重复机制仍为单进程；测试历史写入沿用现有 Redis helper 的错误处理。


补充修复：模型选择器显示不在预设列表中的已保存模型，自定义输入返回列表时保留当前值；OpenAI 测试复用现有默认问候输入。真实浏览器的四项模型选择回归通过。
