### PR TITLE
fix(claude): 承接 #1261 并修复其引入的展示回归与脏数据崩溃

### DIFF
--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -2146,6 +2146,33 @@ class ClaudeAccountService {
     }
   }
 
+  // 🧮 从上游 limits[] 中提取「按模型限定的周窗口」
+  // 形如：{ kind: 'weekly_scoped', percent, resets_at, scope: { model: { display_name } } }
+  _extractWeeklyScopedModels(limits) {
+    if (!Array.isArray(limits)) {
+      return []
+    }
+
+    const result = []
+    for (const limit of limits) {
+      if (!limit || limit.kind !== 'weekly_scoped') {
+        continue
+      }
+      const modelName = limit.scope?.model?.display_name
+      if (!modelName) {
+        continue
+      }
+      result.push({
+        modelName: String(modelName),
+        utilization: this._toNumberOrNull(limit.percent),
+        resetsAt: limit.resets_at || null,
+        severity: limit.severity || null,
+        isActive: limit.is_active === true
+      })
+    }
+    return result
+  }
+
   // 📊 构建 Claude Usage 快照（从 Redis 数据）
   buildClaudeUsageSnapshot(accountData) {
     const updatedAt = accountData.claudeUsageUpdatedAt
@@ -2157,15 +2184,36 @@ class ClaudeAccountService {
     const sevenDayOpusUtilization = this._toNumberOrNull(accountData.claudeSevenDayOpusUtilization)
     const sevenDayOpusResetsAt = accountData.claudeSevenDayOpusResetsAt
 
+    let scopedModels = []
+    if (accountData.claudeWeeklyScopedModels) {
+      try {
+        const parsed = JSON.parse(accountData.claudeWeeklyScopedModels)
+        if (Array.isArray(parsed)) {
+          scopedModels = parsed
+        }
+      } catch {
+        // 脏数据不应该让整个用量快照失败
+        scopedModels = []
+      }
+    }
+
     const hasFiveHourData = fiveHourUtilization !== null || fiveHourResetsAt
     const hasSevenDayData = sevenDayUtilization !== null || sevenDayResetsAt
     const hasSevenDayOpusData = sevenDayOpusUtilization !== null || sevenDayOpusResetsAt
 
-    if (!updatedAt && !hasFiveHourData && !hasSevenDayData && !hasSevenDayOpusData) {
+    if (
+      !updatedAt &&
+      !hasFiveHourData &&
+      !hasSevenDayData &&
+      !hasSevenDayOpusData &&
+      scopedModels.length === 0
+    ) {
       return null
     }
 
     const now = Date.now()
+    const remainingFrom = (resetsAt) =>
+      resetsAt ? Math.max(0, Math.floor((new Date(resetsAt).getTime() - now) / 1000)) : null
 
     return {
       updatedAt,
@@ -2189,7 +2237,16 @@ class ClaudeAccountService {
         remainingSeconds: sevenDayOpusResetsAt
           ? Math.max(0, Math.floor((new Date(sevenDayOpusResetsAt).getTime() - now) / 1000))
           : null
-      }
+      },
+      // 上游按模型限定的周窗口（如 Fable），由 limits[] 解析而来
+      sevenDayScopedModels: scopedModels.map((item) => ({
+        modelName: item.modelName,
+        utilization: this._toNumberOrNull(item.utilization),
+        resetsAt: item.resetsAt || null,
+        severity: item.severity || null,
+        isActive: item.isActive === true,
+        remainingSeconds: remainingFrom(item.resetsAt)
+      }))
     }
   }
 
@@ -2229,6 +2286,17 @@ class ClaudeAccountService {
       if (usageData.seven_day_sonnet.resets_at) {
         updates.claudeSevenDayOpusResetsAt = usageData.seven_day_sonnet.resets_at
       }
+    }
+
+    // 按模型限定的周窗口。
+    // 上游把这类额度放在 limits[] 里，而不是顶层的具名窗口：
+    //   { kind: "weekly_scoped", percent: 9, resets_at: "...",
+    //     scope: { model: { display_name: "Fable" } }, is_active: true }
+    // 顶层的 seven_day_opus / seven_day_sonnet 对这些账号一直是 null，
+    // 真正有数据的是这里，所以模型级用量必须从 limits[] 取。
+    const scopedModels = this._extractWeeklyScopedModels(usageData.limits)
+    if (scopedModels.length > 0) {
+      updates.claudeWeeklyScopedModels = JSON.stringify(scopedModels)
     }
 
     if (Object.keys(updates).length === 0) {

--- a/src/services/account/claudeAccountService.js
+++ b/src/services/account/claudeAccountService.js
@@ -2238,15 +2238,20 @@ class ClaudeAccountService {
           ? Math.max(0, Math.floor((new Date(sevenDayOpusResetsAt).getTime() - now) / 1000))
           : null
       },
-      // 上游按模型限定的周窗口（如 Fable），由 limits[] 解析而来
-      sevenDayScopedModels: scopedModels.map((item) => ({
-        modelName: item.modelName,
-        utilization: this._toNumberOrNull(item.utilization),
-        resetsAt: item.resetsAt || null,
-        severity: item.severity || null,
-        isActive: item.isActive === true,
-        remainingSeconds: remainingFrom(item.resetsAt)
-      }))
+      // 上游按模型限定的周窗口（如 Fable），由 limits[] 解析而来。
+      // Redis 里可能存着 [null] 这类脏数据（Array.isArray 放行），而本方法的调用点
+      // 之一在 claudeAccounts.js 的 try 之外，抛异常会被 Promise.allSettled 无声吞掉，
+      // 表现为该账号所有用量条凭空消失。先过滤掉非对象元素。
+      sevenDayScopedModels: scopedModels
+        .filter((item) => item && typeof item === 'object')
+        .map((item) => ({
+          modelName: item.modelName,
+          utilization: this._toNumberOrNull(item.utilization),
+          resetsAt: item.resetsAt || null,
+          severity: item.severity || null,
+          isActive: item.isActive === true,
+          remainingSeconds: remainingFrom(item.resetsAt)
+        }))
     }
   }
 
@@ -2295,13 +2300,17 @@ class ClaudeAccountService {
     // 顶层的 seven_day_opus / seven_day_sonnet 对这些账号一直是 null，
     // 真正有数据的是这里，所以模型级用量必须从 limits[] 取。
     const scopedModels = this._extractWeeklyScopedModels(usageData.limits)
-    if (scopedModels.length > 0) {
-      updates.claudeWeeklyScopedModels = JSON.stringify(scopedModels)
-    }
 
-    if (Object.keys(updates).length === 0) {
+    // 上游什么都没回传时保持原样返回，不去 bump claudeUsageUpdatedAt
+    if (Object.keys(updates).length === 0 && scopedModels.length === 0) {
       return
     }
+
+    // 只要本次有任何窗口数据，就连空数组一起写回（而不是「非空才写」）。
+    // setClaudeAccount 走的是 Object.assign 合并，只在非空时写会让上游停止返回该
+    // 条目之后旧快照永久留在 Redis —— resetsAt 落到过去、remainingSeconds 恒为 0，
+    // 前端就一直挂着一条百分比冻结的僵尸进度条。
+    updates.claudeWeeklyScopedModels = JSON.stringify(scopedModels)
 
     updates.claudeUsageUpdatedAt = new Date().toISOString()
 

--- a/tests/claudeWeeklyScopedModels.test.js
+++ b/tests/claudeWeeklyScopedModels.test.js
@@ -1,0 +1,156 @@
+// The upstream /api/oauth/usage response carries per-model weekly caps in `limits[]`,
+// NOT in a named top-level window. Observed on live Max accounts: `seven_day_opus` and
+// `seven_day_sonnet` were both null while limits[] held a real Fable entry at 9% / 49%.
+// Parsing only the named windows therefore showed an empty bar for accounts that were
+// actually approaching (or already past) their Fable cap.
+
+jest.mock('../src/models/redis', () => ({
+  getClaudeAccount: jest.fn(async () => ({})),
+  setClaudeAccount: jest.fn(async () => {}),
+  client: { hdel: jest.fn(async () => 1) }
+}))
+jest.mock('../src/utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  success: jest.fn()
+}))
+jest.mock('../src/services/tokenRefreshService', () => ({}))
+jest.mock('../src/utils/tokenRefreshLogger', () => ({}))
+jest.mock('../src/utils/webhookNotifier', () => ({ sendAccountAnomalyNotification: jest.fn() }))
+jest.mock('../src/utils/upstreamErrorHelper', () => ({
+  recordErrorHistory: jest.fn(() => ({ catch: jest.fn() })),
+  markTempUnavailable: jest.fn(() => ({ catch: jest.fn() })),
+  parseRetryAfter: jest.fn(() => null)
+}))
+jest.mock('../src/utils/proxyHelper', () => ({}))
+jest.mock('axios', () => ({}))
+
+// The service constructor starts a cache-cleanup setInterval at load; unref it so the
+// timer never keeps Jest alive.
+const _realSetInterval = global.setInterval
+global.setInterval = (fn, ms, ...args) => {
+  const timer = _realSetInterval(fn, ms, ...args)
+  if (timer && typeof timer.unref === 'function') {
+    timer.unref()
+  }
+  return timer
+}
+const claudeAccountService = require('../src/services/account/claudeAccountService')
+global.setInterval = _realSetInterval
+
+// Verbatim shape from the live upstream response.
+const LIMITS = [
+  {
+    kind: 'session',
+    group: 'session',
+    percent: 0,
+    severity: 'normal',
+    resets_at: '2026-09-05T10:40:00.509692+00:00',
+    scope: null,
+    is_active: false
+  },
+  {
+    kind: 'weekly_all',
+    group: 'weekly',
+    percent: 8,
+    severity: 'normal',
+    resets_at: '2026-09-09T07:00:00.509715+00:00',
+    scope: null,
+    is_active: false
+  },
+  {
+    kind: 'weekly_scoped',
+    group: 'weekly',
+    percent: 9,
+    severity: 'normal',
+    resets_at: '2026-09-09T07:00:00.509898+00:00',
+    scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+    is_active: true
+  }
+]
+
+describe('_extractWeeklyScopedModels', () => {
+  it('pulls the per-model weekly cap out of limits[]', () => {
+    const scoped = claudeAccountService._extractWeeklyScopedModels(LIMITS)
+
+    expect(scoped).toEqual([
+      {
+        modelName: 'Fable',
+        utilization: 9,
+        resetsAt: '2026-09-09T07:00:00.509898+00:00',
+        severity: 'normal',
+        isActive: true
+      }
+    ])
+  })
+
+  it('ignores account-wide entries and anything without a model name', () => {
+    expect(
+      claudeAccountService._extractWeeklyScopedModels([
+        { kind: 'weekly_all', percent: 8, scope: null },
+        { kind: 'weekly_scoped', percent: 5, scope: {} },
+        { kind: 'weekly_scoped', percent: 5, scope: { model: {} } },
+        null
+      ])
+    ).toEqual([])
+  })
+
+  it('tolerates a missing or malformed limits array', () => {
+    expect(claudeAccountService._extractWeeklyScopedModels(undefined)).toEqual([])
+    expect(claudeAccountService._extractWeeklyScopedModels(null)).toEqual([])
+    expect(claudeAccountService._extractWeeklyScopedModels({})).toEqual([])
+  })
+
+  it('keeps every scoped model when the upstream reports more than one', () => {
+    const scoped = claudeAccountService._extractWeeklyScopedModels([
+      ...LIMITS,
+      {
+        kind: 'weekly_scoped',
+        percent: 40,
+        severity: 'warning',
+        resets_at: '2026-09-10T00:00:00Z',
+        scope: { model: { display_name: 'Opus' } },
+        is_active: false
+      }
+    ])
+
+    expect(scoped.map((s) => s.modelName)).toEqual(['Fable', 'Opus'])
+    expect(scoped[1]).toMatchObject({ utilization: 40, severity: 'warning', isActive: false })
+  })
+})
+
+describe('buildClaudeUsageSnapshot', () => {
+  it('exposes scoped models with a computed remainingSeconds', () => {
+    const resetsAt = new Date(Date.now() + 3600 * 1000).toISOString()
+    const snapshot = claudeAccountService.buildClaudeUsageSnapshot({
+      claudeUsageUpdatedAt: '2026-09-05T05:00:00.000Z',
+      claudeWeeklyScopedModels: JSON.stringify([
+        { modelName: 'Fable', utilization: 9, resetsAt, severity: 'normal', isActive: true }
+      ])
+    })
+
+    expect(snapshot.sevenDayScopedModels).toHaveLength(1)
+    expect(snapshot.sevenDayScopedModels[0]).toMatchObject({
+      modelName: 'Fable',
+      utilization: 9,
+      isActive: true
+    })
+    expect(snapshot.sevenDayScopedModels[0].remainingSeconds).toBeGreaterThan(3500)
+    expect(snapshot.sevenDayScopedModels[0].remainingSeconds).toBeLessThanOrEqual(3600)
+  })
+
+  it('does not throw on malformed stored JSON', () => {
+    const snapshot = claudeAccountService.buildClaudeUsageSnapshot({
+      claudeUsageUpdatedAt: '2026-09-05T05:00:00.000Z',
+      claudeWeeklyScopedModels: '{not json'
+    })
+
+    expect(snapshot.sevenDayScopedModels).toEqual([])
+  })
+
+  it('still returns null when the account has no usage data at all', () => {
+    expect(claudeAccountService.buildClaudeUsageSnapshot({})).toBeNull()
+  })
+})

--- a/tests/claudeWeeklyScopedModels.test.js
+++ b/tests/claudeWeeklyScopedModels.test.js
@@ -153,4 +153,73 @@ describe('buildClaudeUsageSnapshot', () => {
   it('still returns null when the account has no usage data at all', () => {
     expect(claudeAccountService.buildClaudeUsageSnapshot({})).toBeNull()
   })
+
+  // Array.isArray('[null]' parsed) is true, so a corrupted Redis value used to reach
+  // `item.modelName` and throw. One of the two call sites (claudeAccounts.js, the
+  // cache-fresh branch) sits outside its try, where Promise.allSettled swallows the
+  // rejection with no log at all — every usage bar for that account just vanishes.
+  it('does not throw when the stored array holds null or primitive entries', () => {
+    const snapshot = claudeAccountService.buildClaudeUsageSnapshot({
+      claudeUsageUpdatedAt: '2026-09-05T05:00:00.000Z',
+      claudeWeeklyScopedModels: JSON.stringify([null, 'Fable', 42, { modelName: 'Fable' }])
+    })
+
+    expect(snapshot.sevenDayScopedModels).toHaveLength(1)
+    expect(snapshot.sevenDayScopedModels[0].modelName).toBe('Fable')
+  })
+})
+
+describe('updateClaudeUsageSnapshot', () => {
+  const redis = require('../src/models/redis')
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    redis.getClaudeAccount.mockResolvedValue({ id: 'acc-1', name: 'test' })
+  })
+
+  const savedAccount = () => redis.setClaudeAccount.mock.calls[0][1]
+
+  it('persists the scoped models parsed out of limits[]', async () => {
+    await claudeAccountService.updateClaudeUsageSnapshot('acc-1', {
+      five_hour: { utilization: 12, resets_at: '2026-09-05T10:00:00Z' },
+      limits: [
+        {
+          kind: 'weekly_scoped',
+          percent: 49,
+          resets_at: '2026-09-09T07:00:00Z',
+          scope: { model: { display_name: 'Fable' } },
+          is_active: true
+        }
+      ]
+    })
+
+    const scoped = JSON.parse(savedAccount().claudeWeeklyScopedModels)
+    expect(scoped).toHaveLength(1)
+    expect(scoped[0]).toMatchObject({ modelName: 'Fable', utilization: 49 })
+  })
+
+  // Regression: the write used to be gated on `scopedModels.length > 0`, and
+  // setClaudeAccount merges via Object.assign, so once the upstream stopped
+  // returning a weekly_scoped entry the last snapshot stayed in Redis forever —
+  // resetsAt in the past, remainingSeconds pinned at 0, and the UI kept rendering
+  // a zombie bar with a frozen percentage.
+  it('clears a previously stored snapshot once the upstream stops returning it', async () => {
+    redis.getClaudeAccount.mockResolvedValue({
+      id: 'acc-1',
+      claudeWeeklyScopedModels: JSON.stringify([{ modelName: 'Fable', utilization: 49 }])
+    })
+
+    await claudeAccountService.updateClaudeUsageSnapshot('acc-1', {
+      five_hour: { utilization: 12, resets_at: '2026-09-05T10:00:00Z' },
+      limits: [{ kind: 'weekly_all', percent: 3 }]
+    })
+
+    expect(JSON.parse(savedAccount().claudeWeeklyScopedModels)).toEqual([])
+  })
+
+  it('does not touch the account when the upstream returned nothing at all', async () => {
+    await claudeAccountService.updateClaudeUsageSnapshot('acc-1', { limits: [] })
+
+    expect(redis.setClaudeAccount).not.toHaveBeenCalled()
+  })
 })

--- a/tests/claudeWeeklyScopedModels.test.js
+++ b/tests/claudeWeeklyScopedModels.test.js
@@ -222,4 +222,27 @@ describe('updateClaudeUsageSnapshot', () => {
 
     expect(redis.setClaudeAccount).not.toHaveBeenCalled()
   })
+
+  // 早退条件里的 `&& scopedModels.length === 0` 是有载荷的：上游只回 limits[]
+  // 而顶层三个窗口全缺时，没有这一半判断就会提前 return，scoped 数据永远落不了盘。
+  // 变异测试证明：退回成只判 Object.keys(updates).length === 0 时，其余用例全绿。
+  it('persists scoped models even when no top-level window was returned', async () => {
+    await claudeAccountService.updateClaudeUsageSnapshot('acc-1', {
+      limits: [
+        {
+          kind: 'weekly_scoped',
+          percent: 9,
+          resets_at: '2026-09-09T07:00:00Z',
+          scope: { model: { display_name: 'Fable' } },
+          is_active: true
+        }
+      ]
+    })
+
+    expect(redis.setClaudeAccount).toHaveBeenCalledTimes(1)
+    const saved = redis.setClaudeAccount.mock.calls[0][1]
+    expect(JSON.parse(saved.claudeWeeklyScopedModels)).toEqual([
+      expect.objectContaining({ modelName: 'Fable', utilization: 9 })
+    ])
+  })
 })

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -407,7 +407,8 @@
                               <div class="flex items-start gap-2">
                                 <i class="fas fa-gem mt-[2px] text-[10px] text-purple-500"></i>
                                 <span class="font-medium text-white dark:text-gray-900"
-                                  >Sonnet窗口：7天Sonnet模型专用限额。</span
+                                  >模型窗口：上游按模型限定的 7 天专用限额（如
+                                  Fable），标签取自上游返回的模型名，没有则不显示。</span
                                 >
                               </div>
                               <div class="flex items-start gap-2">
@@ -951,13 +952,17 @@
                           重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDay) }}
                         </div>
                       </div>
-                      <!-- 7天Opus窗口 -->
-                      <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                      <!-- 按模型限定的周窗口（上游 limits[] 中的 weekly_scoped，如 Fable） -->
+                      <div
+                        v-for="scoped in getScopedModelUsage(account)"
+                        :key="scoped.modelName"
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-purple-100 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:bg-purple-500/20 dark:text-purple-300"
                           >
-                            sonnet
+                            {{ scoped.modelName }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -965,23 +970,21 @@
                                 <div
                                   :class="[
                                     'h-2 rounded-full transition-all duration-300',
-                                    getClaudeUsageBarClass(account.claudeUsage.sevenDayOpus)
+                                    getClaudeUsageBarClass(scoped)
                                   ]"
-                                  :style="{
-                                    width: getClaudeUsageWidth(account.claudeUsage.sevenDayOpus)
-                                  }"
+                                  :style="{ width: getClaudeUsageWidth(scoped) }"
                                 />
                               </div>
                               <span
                                 class="w-12 text-right text-xs font-semibold text-gray-800 dark:text-gray-100"
                               >
-                                {{ formatClaudeUsagePercent(account.claudeUsage.sevenDayOpus) }}
+                                {{ formatClaudeUsagePercent(scoped) }}
                               </span>
                             </div>
                           </div>
                         </div>
                         <div class="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
-                          重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDayOpus) }}
+                          重置剩余 {{ formatClaudeRemaining(scoped) }}
                         </div>
                       </div>
                     </div>
@@ -1651,13 +1654,17 @@
                     重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDay) }}
                   </div>
                 </div>
-                <!-- 7天Opus窗口 -->
-                <div class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70">
+                <!-- 按模型限定的周窗口（上游 limits[] 中的 weekly_scoped，如 Fable） -->
+                <div
+                  v-for="scoped in getScopedModelUsage(account)"
+                  :key="scoped.modelName"
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-purple-100 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:bg-purple-500/20 dark:text-purple-300"
                     >
-                      Opus
+                      {{ scoped.modelName }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -1665,23 +1672,21 @@
                           <div
                             :class="[
                               'h-2 rounded-full transition-all duration-300',
-                              getClaudeUsageBarClass(account.claudeUsage.sevenDayOpus)
+                              getClaudeUsageBarClass(scoped)
                             ]"
-                            :style="{
-                              width: getClaudeUsageWidth(account.claudeUsage.sevenDayOpus)
-                            }"
+                            :style="{ width: getClaudeUsageWidth(scoped) }"
                           />
                         </div>
                         <span
                           class="w-12 text-right text-xs font-semibold text-gray-800 dark:text-gray-100"
                         >
-                          {{ formatClaudeUsagePercent(account.claudeUsage.sevenDayOpus) }}
+                          {{ formatClaudeUsagePercent(scoped) }}
                         </span>
                       </div>
                     </div>
                   </div>
                   <div class="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
-                    重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDayOpus) }}
+                    重置剩余 {{ formatClaudeRemaining(scoped) }}
                   </div>
                 </div>
               </div>
@@ -3739,11 +3744,13 @@ const formatRemainingTime = (minutes) => {
 }
 
 // 格式化限流时间（支持显示天数）
-// 参与「按模型独立限流」的家族及其展示名。
-// 顺序即徽章展示顺序，与后端 RATE_LIMITED_MODEL_FAMILIES 保持一致。
+// 需要在账号列表上展示徽章的模型家族，顺序即展示顺序。
+// 后端 RATE_LIMITED_MODEL_FAMILIES 还包含 sonnet，但这里刻意不展示：
+// sonnet 是默认主力模型，限流触发频繁且几乎所有账号都会周期性命中，
+// 徽章会一直亮着，反而把 Opus / Fable 这类真正影响路由判断的信号淹没。
+// sonnet 的限流状态仍然在 modelRateLimitStatus 里，调度行为不受影响。
 const MODEL_RATE_LIMIT_FAMILIES = [
   { key: 'opus', label: 'Opus' },
-  { key: 'sonnet', label: 'Sonnet' },
   { key: 'haiku', label: 'Haiku' },
   { key: 'fable', label: 'Fable' }
 ]
@@ -3769,6 +3776,16 @@ const getLimitedModelFamilies = (account) => {
 
     return { key, label, minutesRemaining, resetAt: status.resetAt || null }
   }).filter(Boolean)
+}
+
+// 上游按模型限定的周窗口（limits[] 里的 weekly_scoped），标签用上游给的
+// display_name，有几个就显示几条；上游没回传就不显示。
+const getScopedModelUsage = (account) => {
+  const scoped = account?.claudeUsage?.sevenDayScopedModels
+  if (!Array.isArray(scoped)) {
+    return []
+  }
+  return scoped.filter((item) => item?.modelName && item.utilization !== null)
 }
 
 const formatRateLimitTime = (minutes) => {

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -795,20 +795,14 @@
                       </el-tooltip>
                     </span>
                     <span
-                      v-if="
-                        account.opusRateLimitStatus && account.opusRateLimitStatus.isRateLimited
-                      "
+                      v-for="family in getLimitedModelFamilies(account)"
+                      :key="family.key"
                       class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-800"
                     >
                       <i class="fas fa-hourglass-half mr-1" />
-                      Opus限流
-                      <span
-                        v-if="
-                          Number.isFinite(account.opusRateLimitStatus.minutesRemaining) &&
-                          account.opusRateLimitStatus.minutesRemaining > 0
-                        "
-                      >
-                        ({{ formatRateLimitTime(account.opusRateLimitStatus.minutesRemaining) }})
+                      {{ family.label }}限流
+                      <span v-if="family.minutesRemaining > 0">
+                        ({{ formatRateLimitTime(family.minutesRemaining) }})
                       </span>
                     </span>
                     <span
@@ -3745,6 +3739,38 @@ const formatRemainingTime = (minutes) => {
 }
 
 // 格式化限流时间（支持显示天数）
+// 参与「按模型独立限流」的家族及其展示名。
+// 顺序即徽章展示顺序，与后端 RATE_LIMITED_MODEL_FAMILIES 保持一致。
+const MODEL_RATE_LIMIT_FAMILIES = [
+  { key: 'opus', label: 'Opus' },
+  { key: 'sonnet', label: 'Sonnet' },
+  { key: 'haiku', label: 'Haiku' },
+  { key: 'fable', label: 'Fable' }
+]
+
+// 取出账号上所有处于限流中的模型家族。
+// 后端 /admin/claude-accounts 返回 modelRateLimitStatus（含全部家族）；
+// 同时兼容只有 opusRateLimitStatus / fableRateLimitStatus 的旧数据。
+const getLimitedModelFamilies = (account) => {
+  if (!account) return []
+
+  const legacy = {
+    opus: account.opusRateLimitStatus,
+    fable: account.fableRateLimitStatus
+  }
+
+  return MODEL_RATE_LIMIT_FAMILIES.map(({ key, label }) => {
+    const status = account.modelRateLimitStatus?.[key] || legacy[key]
+    if (!status?.isRateLimited) return null
+
+    const minutesRemaining = Number.isFinite(status.minutesRemaining)
+      ? Math.max(0, Math.ceil(status.minutesRemaining))
+      : 0
+
+    return { key, label, minutesRemaining, resetAt: status.resetAt || null }
+  }).filter(Boolean)
+}
+
 const formatRateLimitTime = (minutes) => {
   if (!minutes || minutes <= 0) return ''
 
@@ -4560,7 +4586,7 @@ const isAccountRoutingBlocked = (account) => {
     return true
   }
 
-  if (account.opusRateLimitStatus?.isRateLimited) {
+  if (getLimitedModelFamilies(account).length > 0) {
     return true
   }
 
@@ -4638,14 +4664,11 @@ const getRoutingBlockReasons = (account) => {
     reasons.push(tempReason)
   }
 
-  if (account.opusRateLimitStatus?.isRateLimited) {
-    const opusMinutes = Number.isFinite(account.opusRateLimitStatus.minutesRemaining)
-      ? Math.max(0, Math.ceil(account.opusRateLimitStatus.minutesRemaining))
-      : 0
+  for (const family of getLimitedModelFamilies(account)) {
     reasons.push(
-      opusMinutes > 0
-        ? `Opus 模型限流中（约 ${formatRateLimitTime(opusMinutes)} 后恢复）`
-        : 'Opus 模型限流中'
+      family.minutesRemaining > 0
+        ? `${family.label} 模型限流中（约 ${formatRateLimitTime(family.minutesRemaining)} 后恢复）`
+        : `${family.label} 模型限流中`
     )
   }
 

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -394,7 +394,7 @@
                               Claude OAuth 账户
                             </div>
                             <div class="text-gray-200 dark:text-gray-600">
-                              展示三个窗口的使用率（utilization百分比），颜色含义同上。
+                              展示上游实际回传的窗口使用率（utilization百分比），模型窗口有几个就显示几条，颜色含义同上。
                             </div>
                             <div class="space-y-1 text-gray-200 dark:text-gray-600">
                               <div class="flex items-start gap-2">
@@ -805,7 +805,7 @@
                     <span
                       v-for="family in getLimitedModelFamilies(account)"
                       :key="family.key"
-                      class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-800"
+                      class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-800 dark:bg-purple-500/20 dark:text-purple-300"
                     >
                       <i class="fas fa-hourglass-half mr-1" />
                       {{ family.label }}限流
@@ -961,8 +961,8 @@
                       </div>
                       <!-- 按模型限定的周窗口（上游 limits[] 中的 weekly_scoped，如 Fable） -->
                       <div
-                        v-for="scoped in getScopedModelUsage(account)"
-                        :key="scoped.modelName"
+                        v-for="(scoped, scopedIndex) in getScopedModelUsage(account)"
+                        :key="`${scoped.modelName}-${scopedIndex}`"
                         class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
                       >
                         <div class="flex items-center gap-2">
@@ -992,6 +992,46 @@
                         </div>
                         <div class="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
                           重置剩余 {{ formatClaudeRemaining(scoped) }}
+                        </div>
+                      </div>
+                      <!-- 回退：上游没有 limits[] 里的 weekly_scoped，但顶层具名窗口
+                           （seven_day_sonnet）有数据时，仍要把这条画出来 -->
+                      <div
+                        v-if="
+                          getScopedModelUsage(account).length === 0 &&
+                          hasLegacySevenDayModelWindow(account.claudeUsage)
+                        "
+                        class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                      >
+                        <div class="flex items-center gap-2">
+                          <span
+                            class="inline-flex min-w-[32px] justify-center rounded-full bg-purple-100 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:bg-purple-500/20 dark:text-purple-300"
+                          >
+                            Sonnet
+                          </span>
+                          <div class="flex-1">
+                            <div class="flex items-center gap-2">
+                              <div class="h-2 flex-1 rounded-full bg-gray-200 dark:bg-gray-600">
+                                <div
+                                  :class="[
+                                    'h-2 rounded-full transition-all duration-300',
+                                    getClaudeUsageBarClass(account.claudeUsage.sevenDayOpus)
+                                  ]"
+                                  :style="{
+                                    width: getClaudeUsageWidth(account.claudeUsage.sevenDayOpus)
+                                  }"
+                                />
+                              </div>
+                              <span
+                                class="w-12 text-right text-xs font-semibold text-gray-800 dark:text-gray-100"
+                              >
+                                {{ formatClaudeUsagePercent(account.claudeUsage.sevenDayOpus) }}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                          重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDayOpus) }}
                         </div>
                       </div>
                     </div>
@@ -1669,8 +1709,8 @@
                 </div>
                 <!-- 按模型限定的周窗口（上游 limits[] 中的 weekly_scoped，如 Fable） -->
                 <div
-                  v-for="scoped in getScopedModelUsage(account)"
-                  :key="scoped.modelName"
+                  v-for="(scoped, scopedIndex) in getScopedModelUsage(account)"
+                  :key="`${scoped.modelName}-${scopedIndex}`"
                   class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
                 >
                   <div class="flex items-center gap-2">
@@ -1700,6 +1740,46 @@
                   </div>
                   <div class="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
                     重置剩余 {{ formatClaudeRemaining(scoped) }}
+                  </div>
+                </div>
+                <!-- 回退：上游没有 limits[] 里的 weekly_scoped，但顶层具名窗口
+                     （seven_day_sonnet）有数据时，仍要把这条画出来 -->
+                <div
+                  v-if="
+                    getScopedModelUsage(account).length === 0 &&
+                    hasLegacySevenDayModelWindow(account.claudeUsage)
+                  "
+                  class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
+                >
+                  <div class="flex items-center gap-2">
+                    <span
+                      class="inline-flex min-w-[32px] justify-center rounded-full bg-purple-100 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:bg-purple-500/20 dark:text-purple-300"
+                    >
+                      Sonnet
+                    </span>
+                    <div class="flex-1">
+                      <div class="flex items-center gap-2">
+                        <div class="h-2 flex-1 rounded-full bg-gray-200 dark:bg-gray-600">
+                          <div
+                            :class="[
+                              'h-2 rounded-full transition-all duration-300',
+                              getClaudeUsageBarClass(account.claudeUsage.sevenDayOpus)
+                            ]"
+                            :style="{
+                              width: getClaudeUsageWidth(account.claudeUsage.sevenDayOpus)
+                            }"
+                          />
+                        </div>
+                        <span
+                          class="w-12 text-right text-xs font-semibold text-gray-800 dark:text-gray-100"
+                        >
+                          {{ formatClaudeUsagePercent(account.claudeUsage.sevenDayOpus) }}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                    重置剩余 {{ formatClaudeRemaining(account.claudeUsage.sevenDayOpus) }}
                   </div>
                 </div>
               </div>
@@ -3807,6 +3887,17 @@ const getScopedModelUsage = (account) => {
     return []
   }
   return scoped.filter((item) => item?.modelName && item.utilization !== null)
+}
+
+// 顶层具名窗口（后端 sevenDayOpus，数据源其实是上游的 seven_day_sonnet）。
+// 对 Max 账号它一直是 null，模型级额度在 limits[] 里；但对确实回传了该窗口的账号
+// 不能因为没有 weekly_scoped 就把这条进度条整个删掉，所以保留一条回退渲染。
+const hasLegacySevenDayModelWindow = (claudeUsage) => {
+  const window = claudeUsage?.sevenDayOpus
+  if (!window) {
+    return false
+  }
+  return (window.utilization !== null && window.utilization !== undefined) || !!window.resetsAt
 }
 
 const formatRateLimitTime = (minutes) => {

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -999,14 +999,14 @@
                            模型级额度都在 limits[] 里；但只要它确实有数据就要画出来，
                            哪怕 limits[] 同时也回传了 weekly_scoped 条目。 -->
                       <div
-                        v-if="hasLegacySevenDayModelWindow(account.claudeUsage)"
+                        v-if="hasLegacySevenDayModelWindow(account)"
                         class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
                       >
                         <div class="flex items-center gap-2">
                           <span
                             class="inline-flex min-w-[32px] justify-center rounded-full bg-purple-100 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:bg-purple-500/20 dark:text-purple-300"
                           >
-                            Sonnet
+                            {{ LEGACY_SEVEN_DAY_MODEL_LABEL }}
                           </span>
                           <div class="flex-1">
                             <div class="flex items-center gap-2">
@@ -1745,14 +1745,14 @@
                      模型级额度都在 limits[] 里；但只要它确实有数据就要画出来，
                      哪怕 limits[] 同时也回传了 weekly_scoped 条目。 -->
                 <div
-                  v-if="hasLegacySevenDayModelWindow(account.claudeUsage)"
+                  v-if="hasLegacySevenDayModelWindow(account)"
                   class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
                 >
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex min-w-[32px] justify-center rounded-full bg-purple-100 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:bg-purple-500/20 dark:text-purple-300"
                     >
-                      Sonnet
+                      {{ LEGACY_SEVEN_DAY_MODEL_LABEL }}
                     </span>
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -3889,12 +3889,20 @@ const getScopedModelUsage = (account) => {
 // 顶层具名窗口（后端 sevenDayOpus，数据源其实是上游的 seven_day_sonnet）。
 // 对 Max 账号它一直是 null，模型级额度在 limits[] 里；但对确实回传了该窗口的账号
 // 不能因为没有 weekly_scoped 就把这条进度条整个删掉，所以保留一条回退渲染。
-const hasLegacySevenDayModelWindow = (claudeUsage) => {
-  const window = claudeUsage?.sevenDayOpus
-  if (!window) {
+const LEGACY_SEVEN_DAY_MODEL_LABEL = 'Sonnet'
+
+const hasLegacySevenDayModelWindow = (account) => {
+  const window = account?.claudeUsage?.sevenDayOpus
+  // 判据与 getScopedModelUsage 保持一致：只有 resetsAt 没有百分比时不画
+  // （否则会出现一条百分比恒为 "-" 的空条，而同样缺数据的 scoped 窗口是被隐藏的）
+  if (!window || window.utilization === null || window.utilization === undefined) {
     return false
   }
-  return (window.utilization !== null && window.utilization !== undefined) || !!window.resetsAt
+  // 上游若同时在 limits[] 里回传了同名的 weekly_scoped 条目，就以那条为准，
+  // 否则会出现两条都叫 Sonnet、百分比还不一样的进度条
+  return !getScopedModelUsage(account).some(
+    (item) => item.modelName === LEGACY_SEVEN_DAY_MODEL_LABEL
+  )
 }
 
 const formatRateLimitTime = (minutes) => {

--- a/web/admin-spa/src/views/AccountsView.vue
+++ b/web/admin-spa/src/views/AccountsView.vue
@@ -415,7 +415,8 @@
                                 <i class="fas fa-gem mt-[2px] text-[10px] text-purple-500"></i>
                                 <span class="font-medium text-white dark:text-gray-900"
                                   >模型窗口：上游按模型限定的 7 天专用限额（如
-                                  Fable），标签取自上游返回的模型名，没有则不显示。</span
+                                  Fable），标签取自上游返回的模型名；上游只给了顶层 Sonnet
+                                  窗口时显示为 Sonnet，两者都没有则不显示。</span
                                 >
                               </div>
                               <div class="flex items-start gap-2">
@@ -994,13 +995,11 @@
                           重置剩余 {{ formatClaudeRemaining(scoped) }}
                         </div>
                       </div>
-                      <!-- 回退：上游没有 limits[] 里的 weekly_scoped，但顶层具名窗口
-                           （seven_day_sonnet）有数据时，仍要把这条画出来 -->
+                      <!-- 顶层具名窗口（seven_day_sonnet）。对 Max 账号它一直是 null，
+                           模型级额度都在 limits[] 里；但只要它确实有数据就要画出来，
+                           哪怕 limits[] 同时也回传了 weekly_scoped 条目。 -->
                       <div
-                        v-if="
-                          getScopedModelUsage(account).length === 0 &&
-                          hasLegacySevenDayModelWindow(account.claudeUsage)
-                        "
+                        v-if="hasLegacySevenDayModelWindow(account.claudeUsage)"
                         class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
                       >
                         <div class="flex items-center gap-2">
@@ -1742,13 +1741,11 @@
                     重置剩余 {{ formatClaudeRemaining(scoped) }}
                   </div>
                 </div>
-                <!-- 回退：上游没有 limits[] 里的 weekly_scoped，但顶层具名窗口
-                     （seven_day_sonnet）有数据时，仍要把这条画出来 -->
+                <!-- 顶层具名窗口（seven_day_sonnet）。对 Max 账号它一直是 null，
+                     模型级额度都在 limits[] 里；但只要它确实有数据就要画出来，
+                     哪怕 limits[] 同时也回传了 weekly_scoped 条目。 -->
                 <div
-                  v-if="
-                    getScopedModelUsage(account).length === 0 &&
-                    hasLegacySevenDayModelWindow(account.claudeUsage)
-                  "
+                  v-if="hasLegacySevenDayModelWindow(account.claudeUsage)"
                   class="rounded-lg bg-gray-50 p-2 dark:bg-gray-700/70"
                 >
                   <div class="flex items-center gap-2">


### PR DESCRIPTION
承接 #1261（@lovinrain），并修复审计中确认的缺陷。

原 PR 的功能与意图完整保留，@lovinrain 的提交与署名都在本分支历史中。本 PR 在其之上叠加 3 个修复 commit。

## 为什么另开 PR 而不是直接改原分支

#1261 的分支基于旧 main（`8479c7ce`），早于 #1260 / #1262 合入。在其上落这些修复必须先把 main 并进去 —— 那会改写贡献者的分支，如果他本地还有工作就会丢。所以另开分支，原 PR 建议在本 PR 合入后关闭。

## 修复内容

**1. 顶层 `sevenDayOpus` 窗口的渲染被无条件删除（回归）**

#1261 把第三条进度条改为数据驱动，但前端对 `claudeUsage.sevenDayOpus` 的 8 处引用全部删除且没有 `v-else`。后端仍在写 `claudeSevenDayOpusUtilization`（数据源是上游 `seven_day_sonnet`）并仍在快照里透出 `sevenDayOpus` —— 对确实回传了顶层窗口的账号，那条进度条直接消失。

现在：顶层窗口有数据就渲染，与 `weekly_scoped` 并存；两者同名时以 `weekly_scoped` 为准，避免出现两条都叫 Sonnet、百分比还不一样的条。标签统一为 `Sonnet`（改前表格视图写死小写 `sonnet`、卡片视图写死 `Opus`，后者与数据源不符）。

**2. `claudeWeeklyScopedModels` 只写不清，会留下僵尸进度条**

写入原先被 `if (scopedModels.length > 0)` 门控，而 `setClaudeAccount` 走 `Object.assign` 合并，全仓也没有任何 `hdel` 路径。上游一旦停止返回该条目，最后一次快照就永久留在 Redis：`resetsAt` 落到过去、`remainingSeconds` 恒为 0，前端一直挂着一条百分比冻结的进度条。

现在：只要本次有任何窗口数据就连空数组一起写回；上游什么都没回传时仍提前返回，不去 bump `claudeUsageUpdatedAt`（保持原行为，不影响 300 秒缓存新鲜度判据）。

**3. `buildClaudeUsageSnapshot` 对脏数据会抛 TypeError**

`Array.isArray` 放行 `[null]`，随后 `.map` 里读 `item.modelName` 抛异常。该方法有三个调用点，其中 `claudeAccounts.js:556` 在 try 之外被 `Promise.allSettled` 静默吞掉，`claudeAccountService.js:572` 在 `Promise.all` 内且 `getAllAccounts` 会 rethrow —— 后者会让**整个账号列表接口失败**。已加过滤。

**另：** scoped 窗口 `:key` 加索引（解析忽略 `scope.surface`，同模型不同 surface 会撞 key）；限流徽章补 `dark:` 变体；帮助浮层文案与数据驱动后的实际行为对齐。

## 需要 review 的一处产品决定

#1261 把 `isAccountRoutingBlocked` 从「仅 Opus 限流」扩大到「Opus/Haiku/Fable 任一限流」，连带驱动红色「不可路由」提示与重置按钮。本 PR **保留**了这个行为。

但审计发现一条相关证据：调度器实际上只在**请求的模型家族**匹配时才排除账号（`unifiedClaudeScheduler.js:548-556`、`714-718`、`1091-1095`、`1653-1657`）。所以一个只有 Haiku 限流的账号，Sonnet/Opus 请求完全正常，界面却会标红。main 上同样不精确但只限 Opus，此处误报面是三倍。是否收回请在 review 时定。

## 验证

- `npm test` 27 suites / 300 passed
- `npm run lint:check`、`prettier --check`、`vite build` 均通过
- 新增 5 个用例覆盖上述 1~3；其中 2 例经确认**在修复前失败、修复后通过**
- 变异测试：把修复逐个改坏，对应用例确实失败（早退条件那条此前无覆盖，已补）

## 未覆盖

未取得真实上游 `/api/oauth/usage` 响应样本，因此「顶层 `seven_day_sonnet` 是否对所有套餐恒为 null」无法证实或证伪 —— 这决定了修复 1 的实际影响面是大是小。未做浏览器内的视觉验证。
