### PR TITLE
fix: 过滤 Codex 后端不支持的 prompt_cache_options 参数

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -397,6 +397,9 @@ const handleResponses = async (req, res) => {
       return await openaiResponsesRelayService.handleRequest(req, res, account, apiKeyData)
     }
 
+    // The ChatGPT Codex backend rejects this Responses API parameter, regardless of client type.
+    delete req.body.prompt_cache_options
+
     if (schedulerModel !== requestedModel) {
       logger.info(
         `📝 Standard Responses request normalized model ${requestedModel} -> ${schedulerModel} for OpenAI Codex backend`

--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -397,7 +397,9 @@ const handleResponses = async (req, res) => {
       return await openaiResponsesRelayService.handleRequest(req, res, account, apiKeyData)
     }
 
-    // The ChatGPT Codex backend rejects this Responses API parameter, regardless of client type.
+    // ChatGPT Codex 后端不支持此 body 参数；放在账号分流后，保留标准 Responses 后端的支持。
+    // 这是后端兼容限制，不受 CLI 适配开关控制；放进 applyCodexCliAdaptation 会被
+    // 原生 Codex 客户端或关闭适配的请求绕过。删除后使用后端默认缓存行为。
     delete req.body.prompt_cache_options
 
     if (schedulerModel !== requestedModel) {

--- a/tests/openaiResponsesPayloadToggles.test.js
+++ b/tests/openaiResponsesPayloadToggles.test.js
@@ -209,6 +209,74 @@ describe('openai responses payload toggles', () => {
     )
   })
 
+  test.each([false, true])(
+    'preserves prompt_cache_options for Responses accounts with Codex adaptation=%s',
+    async (enableOpenAIResponsesCodexAdaptation) => {
+      const req = createReq({
+        body: {
+          model: 'gpt-5.6',
+          prompt_cache_options: { mode: 'explicit' },
+          prompt_cache_key: 'cache-key'
+        },
+        apiKeyOverrides: { enableOpenAIResponsesCodexAdaptation }
+      })
+
+      await openaiRoutes.handleResponses(req, createRes())
+
+      expect(openaiResponsesRelayService.handleRequest).toHaveBeenCalled()
+      expect(openaiResponsesRelayService.handleRequest.mock.calls[0][0].body).toMatchObject({
+        prompt_cache_options: { mode: 'explicit' },
+        prompt_cache_key: 'cache-key'
+      })
+      expect(axios.post).not.toHaveBeenCalled()
+    }
+  )
+
+  test.each([
+    ['my-client/1.0', false],
+    ['my-client/1.0', true],
+    ['codex_cli_rs/0.100.0', false],
+    ['codex_cli_rs/0.100.0', true]
+  ])(
+    'strips unsupported prompt_cache_options for Codex backend (%s, adaptation=%s)',
+    async (userAgent, enableOpenAIResponsesCodexAdaptation) => {
+      unifiedOpenAIScheduler.selectAccountForApiKey.mockResolvedValue({
+        accountId: 'openai-1',
+        accountType: 'openai'
+      })
+      openaiAccountService.getAccount.mockResolvedValue({
+        id: 'openai-1',
+        name: 'OpenAI Account',
+        accessToken: 'encrypted-token',
+        accountId: 'chatgpt-account-1'
+      })
+      axios.post.mockResolvedValue({ status: 200, data: {}, headers: {} })
+
+      const req = createReq({
+        userAgent,
+        body: {
+          model: 'gpt-5.6',
+          prompt_cache_options: { mode: 'explicit' },
+          prompt_cache_key: 'cache-key',
+          stream: false
+        },
+        apiKeyOverrides: { enableOpenAIResponsesCodexAdaptation }
+      })
+      const res = createRes()
+
+      await openaiRoutes.handleResponses(req, res)
+
+      expect(res.statusCode).toBe(200)
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://chatgpt.com/backend-api/codex/responses',
+        expect.objectContaining({ model: 'gpt-5.6', prompt_cache_key: 'cache-key' }),
+        expect.any(Object)
+      )
+      expect(axios.post.mock.calls[0][1]).not.toHaveProperty('prompt_cache_options')
+      expect(openaiResponsesRelayService.handleRequest).not.toHaveBeenCalled()
+    }
+  )
+
   test('applies Codex adaptation only when adaptation toggle is on', async () => {
     const req = createReq({
       body: {


### PR DESCRIPTION
请求包含 `prompt_cache_options` 时，ChatGPT Codex 后端返回 HTTP 400：`Unsupported parameter: prompt_cache_options`。例如，Pi 的上下文摘要请求使用 `cacheRetention: "none"` 时会生成 `{ "mode": "explicit" }`。实际 A/B 验证中，同一请求仅移除此字段，上游响应便从 400 变为 200。

本次在账号选择、标准 OpenAI-Responses 账号分流之后，仅对 Codex 后端移除该 body 参数。标准 Responses 账号保留此字段；现有 `prompt_cache_key` 行为不变。删除不支持的选项后，Codex 使用后端默认缓存行为。

这是后端兼容限制，不受 CLI 适配开关控制。原生 Codex 客户端和关闭适配的请求会绕过 `applyCodexCliAdaptation`，因此不能只将字段加入该函数的过滤列表。代码注释说明了过滤位置及这一边界。

验证：

- 覆盖普通/Codex 客户端与适配开关组合，以及标准 Responses 账号保留字段的行为。
- 原代码下 4 个 Codex 回归用例失败，修复后通过。
- `npm test -- --runInBand tests/openaiResponsesPayloadToggles.test.js`：16 项通过。
- 两个修改文件的 Prettier、ESLint 及 `git diff --check` 通过。
- 后续仅补充中文注释，重新执行 Prettier 和 diff 检查，未重复运行行为测试。
